### PR TITLE
Expose core memory tools via MCP

### DIFF
--- a/src/lib/ingestion/save-document.ts
+++ b/src/lib/ingestion/save-document.ts
@@ -1,0 +1,24 @@
+import { batchQueue } from "../queues";
+import {
+  IngestDocumentRequest,
+  IngestDocumentResponse,
+} from "../schemas/ingest-document-request";
+
+/**
+ * Queue a document ingestion job.
+ */
+export async function saveMemory(
+  req: IngestDocumentRequest,
+): Promise<IngestDocumentResponse> {
+  await batchQueue.add("ingest-document", {
+    userId: req.userId,
+    documentId: req.document.id,
+    content: req.document.content,
+    timestamp: req.document.timestamp ?? new Date(),
+  });
+
+  return {
+    message: "Document ingestion job accepted",
+    jobId: req.document.id,
+  };
+}

--- a/src/lib/query/day.ts
+++ b/src/lib/query/day.ts
@@ -1,0 +1,96 @@
+import { and, eq, ne, or } from "drizzle-orm";
+import { edges, nodeMetadata, nodes } from "~/db/schema";
+import { findDayNode } from "../graph";
+import { EdgeType } from "~/types/graph";
+import { useDatabase } from "~/utils/db";
+import {
+  QueryDayRequest,
+  QueryDayResponse,
+} from "../schemas/query-day";
+
+/**
+ * Retrieve memories linked to a given day.
+ */
+export async function queryDayMemories(
+  params: QueryDayRequest,
+): Promise<QueryDayResponse> {
+  const { userId, date, includeFormattedResult } = params;
+  const db = await useDatabase();
+
+  const dayNodeId = await findDayNode(db, userId, date);
+  if (!dayNodeId) {
+    return {
+      date,
+      nodes: [],
+      error: `No day node found for ${date}`,
+    };
+  }
+
+  const connectedNodes = await db
+    .select({
+      id: nodes.id,
+      nodeType: nodes.nodeType,
+      metadata: {
+        label: nodeMetadata.label,
+        description: nodeMetadata.description,
+      },
+      edgeType: edges.edgeType,
+    })
+    .from(nodes)
+    .innerJoin(
+      edges,
+      or(
+        and(eq(edges.sourceNodeId, dayNodeId), eq(edges.targetNodeId, nodes.id)),
+        and(eq(edges.targetNodeId, dayNodeId), eq(edges.sourceNodeId, nodes.id)),
+      ),
+    )
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(edges.userId, userId),
+        eq(nodes.userId, userId),
+        ne(nodes.id, dayNodeId),
+      ),
+    );
+
+  const uniqueNodesMap = new Map<string, (typeof connectedNodes)[number]>();
+  connectedNodes.forEach((node) => {
+    if (!uniqueNodesMap.has(node.id)) uniqueNodesMap.set(node.id, node);
+  });
+  const uniqueConnectedNodes = Array.from(uniqueNodesMap.values());
+
+  let formattedResult: string | undefined;
+  if (includeFormattedResult && connectedNodes.length > 0) {
+    const nodesByEdge = connectedNodes.reduce<Record<EdgeType, (typeof connectedNodes)[number][]>>(
+      (acc, node) => {
+        const type = (node.edgeType ?? "Unknown") as EdgeType;
+        (acc[type] ??= []).push(node);
+        return acc;
+      },
+      {} as Record<EdgeType, (typeof connectedNodes)[number][]>,
+    );
+
+    let formatted = `# Memories from ${date}\n\n`;
+    for (const [edgeType, nodes] of Object.entries(nodesByEdge)) {
+      formatted += `## ${edgeType}\n\n`;
+      const map = new Map<string, (typeof connectedNodes)[number]>();
+      nodes.forEach((n) => {
+        if (!map.has(n.id)) map.set(n.id, n);
+      });
+      Array.from(map.values()).forEach((node) => {
+        const label = node.metadata?.label ?? "Unnamed";
+        const description = node.metadata?.description ?? "";
+        formatted += `- **${label}**: ${description}\n`;
+      });
+      formatted += "\n";
+    }
+    formattedResult = formatted;
+  }
+
+  return {
+    date,
+    nodeCount: uniqueConnectedNodes.length,
+    formattedResult,
+    nodes: uniqueConnectedNodes,
+  };
+}

--- a/src/lib/query/day.ts
+++ b/src/lib/query/day.ts
@@ -61,13 +61,13 @@ export async function queryDayMemories(
 
   let formattedResult: string | undefined;
   if (includeFormattedResult && connectedNodes.length > 0) {
-    const nodesByEdge = connectedNodes.reduce<Record<EdgeType, (typeof connectedNodes)[number][]>>(
+    const nodesByEdge = connectedNodes.reduce<Record<string, (typeof connectedNodes)[number][]>>(
       (acc, node) => {
-        const type = (node.edgeType ?? "Unknown") as EdgeType;
-        (acc[type] ??= []).push(node);
+        const key: string = node.edgeType ?? "Unknown"; // 'key' is now explicitly a string
+        (acc[key] ??= []).push(node);
         return acc;
       },
-      {} as Record<EdgeType, (typeof connectedNodes)[number][]>,
+      {} as Record<string, (typeof connectedNodes)[number][]>, // Ensure accumulator type uses string key
     );
 
     let formatted = `# Memories from ${date}\n\n`;

--- a/src/lib/query/search.ts
+++ b/src/lib/query/search.ts
@@ -1,0 +1,81 @@
+import { generateEmbeddings } from "../embeddings";
+import { formatSearchResultsAsXml } from "../formatting";
+import {
+  findOneHopNodes,
+  findSimilarEdges,
+  findSimilarNodes,
+} from "../graph";
+import { rerankMultiple } from "../rerank";
+import {
+  QuerySearchRequest,
+  QuerySearchResponse,
+} from "../schemas/query-search";
+import { useDatabase } from "~/utils/db";
+
+/**
+ * Search stored memories based on a query string.
+ */
+export async function searchMemory(
+  params: QuerySearchRequest,
+): Promise<QuerySearchResponse> {
+  const { userId, query, limit, excludeNodeTypes } = params;
+  const db = await useDatabase();
+
+  const embeddingsResponse = await generateEmbeddings({
+    model: "jina-embeddings-v3",
+    task: "retrieval.query",
+    input: [query],
+    truncate: true,
+  });
+  const embedding = embeddingsResponse.data[0]?.embedding;
+  if (!embedding) throw new Error("Failed to generate embedding");
+
+  const [similarNodes, similarEdges] = await Promise.all([
+    findSimilarNodes({
+      userId,
+      embedding,
+      limit,
+      excludeNodeTypes,
+      minimumSimilarity: 0.4,
+    }),
+    findSimilarEdges({
+      userId,
+      embedding,
+      limit,
+      minimumSimilarity: 0.4,
+    }),
+  ]);
+
+  const nodeIds = new Set([
+    ...similarNodes.map((node) => node.id),
+    ...similarEdges.flatMap((edge) => [edge.sourceNodeId, edge.targetNodeId]),
+  ]);
+
+  const connections = await findOneHopNodes(db, userId, Array.from(nodeIds));
+
+  const rerankedResults = await rerankMultiple(
+    query,
+    {
+      similarNodes: {
+        items: similarNodes,
+        toDocument: (n) => `${n.label}: ${n.description}`,
+      },
+      similarEdges: {
+        items: similarEdges,
+        toDocument: (e) =>
+          `${e.sourceLabel ?? ""} -> ${e.targetLabel ?? ""}: ${e.edgeType}` +
+          (e.description ? `: ${e.description}` : ""),
+      },
+      connections: {
+        items: connections,
+        toDocument: (c) => `${c.label}: ${c.description}`,
+      },
+    },
+    limit,
+  );
+
+  return {
+    query,
+    formattedResult: formatSearchResultsAsXml(rerankedResults),
+  };
+}

--- a/src/routes/ingest/document.post.ts
+++ b/src/routes/ingest/document.post.ts
@@ -1,5 +1,4 @@
-import { IngestDocumentJobInput } from "~/lib/jobs/ingest-document";
-import { batchQueue } from "~/lib/queues";
+import { saveMemory } from "~/lib/ingestion/save-document";
 import {
   ingestDocumentRequestSchema,
   ingestDocumentResponseSchema,
@@ -9,19 +8,7 @@ export default defineEventHandler(async (event) => {
   const { userId, document } = ingestDocumentRequestSchema.parse(
     await readBody(event),
   );
-
-  const jobInput: IngestDocumentJobInput = {
-    userId,
-    documentId: document.id,
-    content: document.content,
-    // Use provided timestamp or current time if not provided
-    timestamp: document.timestamp ?? new Date(),
-  };
-
-  await batchQueue.add("ingest-document", jobInput);
-
-  return ingestDocumentResponseSchema.parse({
-    message: "Document ingestion job accepted",
-    jobId: jobInput.documentId,
-  });
+  return ingestDocumentResponseSchema.parse(
+    await saveMemory({ userId, document }),
+  );
 });

--- a/src/routes/query/day.ts
+++ b/src/routes/query/day.ts
@@ -1,9 +1,5 @@
-import { and, eq, ne, or } from "drizzle-orm";
 import { defineEventHandler } from "h3";
-import { edges, nodeMetadata, nodes } from "~/db/schema";
-import { findDayNode } from "~/lib/graph";
-import { EdgeType } from "~/types/graph";
-import { useDatabase } from "~/utils/db";
+import { queryDayMemories } from "~/lib/query/day";
 import {
   queryDayRequestSchema,
   queryDayResponseSchema,
@@ -17,109 +13,7 @@ export default defineEventHandler(async (event) => {
   const { userId, date, includeFormattedResult } = queryDayRequestSchema.parse(
     await readBody(event),
   );
-  const db = await useDatabase();
-
-  // Fetch the day node id for the specified date
-  const dayNodeId = await findDayNode(db, userId, date);
-  if (!dayNodeId) {
-    return queryDayResponseSchema.parse({
-      date,
-      error: `No day node found for ${date}`,
-      nodes: [],
-    });
-  }
-
-  // Single optimized query to get connected nodes with their metadata
-  const connectedNodes = await db
-    .select({
-      id: nodes.id,
-      nodeType: nodes.nodeType,
-      metadata: {
-        label: nodeMetadata.label,
-        description: nodeMetadata.description,
-      },
-      edgeType: edges.edgeType,
-    })
-    .from(nodes)
-    .innerJoin(
-      edges,
-      or(
-        and(
-          eq(edges.sourceNodeId, dayNodeId),
-          eq(edges.targetNodeId, nodes.id),
-        ),
-        and(
-          eq(edges.targetNodeId, dayNodeId),
-          eq(edges.sourceNodeId, nodes.id),
-        ),
-      ),
-    )
-    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
-    .where(
-      and(
-        eq(edges.userId, userId),
-        eq(nodes.userId, userId),
-        ne(nodes.id, dayNodeId), // Exclude the day node itself
-      ),
-    );
-
-  // --- Deduplicate nodes based on ID for the final response ---
-  const uniqueNodesMap = new Map<string, ConnectedNode>();
-  connectedNodes.forEach((node) => {
-    if (!uniqueNodesMap.has(node.id)) {
-      uniqueNodesMap.set(node.id, node);
-    }
-    // If node already exists, we keep the first encountered version.
-    // Modify this logic if a different version (e.g., based on edge type) is preferred.
-  });
-  const uniqueConnectedNodes = Array.from(uniqueNodesMap.values());
-
-  type ConnectedNode = (typeof connectedNodes)[number];
-
-  // Format the results as a nice string if requested
-  let formattedResult: string | null = null;
-  if (includeFormattedResult && connectedNodes.length > 0) {
-    formattedResult = `# Memories from ${date}\n\n`;
-
-    // Group nodes by edge type (using the original list with potential duplicates)
-    const nodesByEdgeType = connectedNodes.reduce(
-      (acc, node) => {
-        const type = node.edgeType || "Unknown";
-        if (!acc[type]) acc[type] = [];
-        acc[type].push(node);
-        return acc;
-      },
-      {} as Record<EdgeType, ConnectedNode[]>,
-    );
-
-    // Format each group
-    for (const [edgeType, nodes] of Object.entries(nodesByEdgeType)) {
-      formattedResult += `## ${edgeType}\n\n`;
-      // Deduplicate nodes *within this specific edge type group* for formatting
-      const uniqueNodesInGroup = Array.from(
-        nodes
-          .reduce((map, node) => {
-            if (!map.has(node.id)) {
-              map.set(node.id, node);
-            }
-            return map;
-          }, new Map<string, ConnectedNode>())
-          .values(),
-      );
-
-      uniqueNodesInGroup.forEach((node) => {
-        const label = node.metadata?.label || "Unnamed";
-        const description = node.metadata?.description || "";
-        formattedResult += `- **${label}**: ${description}\n`;
-      });
-      formattedResult += "\n";
-    }
-  }
-
-  return queryDayResponseSchema.parse({
-    date,
-    nodeCount: uniqueConnectedNodes.length, // Use count of unique nodes
-    ...(includeFormattedResult && formattedResult ? { formattedResult } : {}),
-    nodes: uniqueConnectedNodes, // Return the unique list
-  });
+  return queryDayResponseSchema.parse(
+    await queryDayMemories({ userId, date, includeFormattedResult }),
+  );
 });

--- a/src/routes/query/search.ts
+++ b/src/routes/query/search.ts
@@ -1,80 +1,15 @@
-import { generateEmbeddings } from "~/lib/embeddings";
-import { formatSearchResultsAsXml } from "~/lib/formatting";
-import {
-  findOneHopNodes,
-  findSimilarEdges,
-  findSimilarNodes,
-} from "~/lib/graph";
-import { rerankMultiple } from "~/lib/rerank";
+import { searchMemory } from "~/lib/query/search";
 import {
   querySearchRequestSchema,
   QuerySearchResponse,
   querySearchResponseSchema,
 } from "~/lib/schemas/query-search";
-import { useDatabase } from "~/utils/db";
 
 export default defineEventHandler(async (event) => {
   // Parse the request
   const { userId, query, limit, excludeNodeTypes } =
     querySearchRequestSchema.parse(await readBody(event));
-  const db = await useDatabase();
-
-  const embeddingsResponse = await generateEmbeddings({
-    model: "jina-embeddings-v3",
-    task: "retrieval.query",
-    input: [query],
-    truncate: true,
-  });
-  const embedding = embeddingsResponse.data[0]?.embedding;
-  if (!embedding) throw new Error("Failed to generate embedding");
-
-  const [similarNodes, similarEdges] = await Promise.all([
-    findSimilarNodes({
-      userId,
-      embedding,
-      limit,
-      excludeNodeTypes,
-      minimumSimilarity: 0.4,
-    }),
-    findSimilarEdges({
-      userId,
-      embedding,
-      limit,
-      minimumSimilarity: 0.4,
-    }),
-  ]);
-
-  const nodeIds = new Set([
-    ...similarNodes.map((node) => node.id),
-    ...similarEdges.flatMap((edge) => [edge.sourceNodeId, edge.targetNodeId]),
-  ]);
-
-  const connections = await findOneHopNodes(db, userId, Array.from(nodeIds));
-
-  // Run reranker so we know the top from the similar nodes, similar edges and connected nodes
-  const rerankedResults = await rerankMultiple(
-    query,
-    {
-      similarNodes: {
-        items: similarNodes,
-        toDocument: (n) => `${n.label}: ${n.description}`,
-      },
-      similarEdges: {
-        items: similarEdges,
-        toDocument: (e) =>
-          `${e.sourceLabel ?? ""} -> ${e.targetLabel ?? ""}: ${e.edgeType}` +
-          (e.description ? `: ${e.description}` : ""),
-      },
-      connections: {
-        items: connections,
-        toDocument: (c) => `${c.label}: ${c.description}`,
-      },
-    },
-    limit,
+  return querySearchResponseSchema.parse(
+    await searchMemory({ userId, query, limit, excludeNodeTypes }),
   );
-
-  return querySearchResponseSchema.parse({
-    query,
-    formattedResult: formatSearchResultsAsXml(rerankedResults),
-  } satisfies QuerySearchResponse);
 });


### PR DESCRIPTION
## Summary
- add helper functions to share memory ingestion and query logic
- update API routes to use shared helpers
- simplify MCP server to delegate to new helpers

## Testing
- `pnpm test --run`
