### PR TITLE
Add stdio MCP server CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ This can be used, for example, in the first message with an assistant so it know
 ## MCP Server
 
 An MCP server is also exposed so the assistant can explicitly query for data as well.
+
+## Command line usage
+
+You can run the MCP server over stdio using `npx`:
+
+```bash
+npx @marcelsamyn/memory memory-stdio
+```
+
+This starts the MCP server and communicates via stdin/stdout.

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
       "types": "./dist/sdk/*.d.ts"
     }
   },
+  "bin": {
+    "memory-stdio": "dist/cli.js"
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "nitro build",
+    "build": "nitro build && tsc --outDir dist --module NodeNext src/cli.ts",
     "build-sdk": "tsc --project tsconfig.sdk.json",
     "dev": "nitro dev",
     "prepare": "nitro prepare",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { server } from "./lib/mcp/mcp-server.js";
+
+async function main() {
+  const transport = new StdioServerTransport();
+  try {
+    await server.connect(transport);
+    console.log("MCP server running on stdio");
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- expose a new CLI script for running the MCP server over stdio
- wire the script in package.json as an executable
- document how to run it with `npx`

## Testing
- `pnpm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*