### PR TITLE
Fix enum typo and remove unused formatter

### DIFF
--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -91,52 +91,6 @@ ${xmlItems}
 </items>`;
 }
 
-/**
- * Formats search results as a readable markdown string
- */
-export function formatAsMarkdown(
-  query: string,
-  allNodes: NodeWithConnections[],
-  directMatches: NodeWithConnections[],
-): string {
-  let result = `Results for query: "${query}"\n\n`;
-
-  // Direct matches section
-  result += `Found ${directMatches.length} direct matches:\n`;
-  directMatches.forEach((node, index) => {
-    const similarityPercentage = Math.round((node.similarity ?? 0) * 100);
-    result += `${index + 1}. ${node.label} (${node.type}, ${node.timestamp.toISOString()}, ${similarityPercentage}% match)\n`;
-    if (node.description) {
-      result += `   ${node.description}\n`;
-    }
-    if (node.connectedTo && node.connectedTo.length > 0) {
-      result += `   Connected to ${node.connectedTo.length} other nodes\n`;
-    }
-    result += "\n";
-  });
-
-  // One-hop related nodes
-  const connectedNodes = allNodes.filter((node) => !node.isDirectMatch);
-  if (connectedNodes.length > 0) {
-    result += `\nRelated nodes (one hop away):\n`;
-    connectedNodes.forEach((node, index) => {
-      result += `${index + 1}. ${node.label} (${node.type}, ${node.timestamp.toISOString()})\n`;
-      if (node.description) {
-        result += `   ${node.description}\n`;
-      }
-      if (node.connectedTo && node.connectedTo.length > 0) {
-        const labels = node.connectedTo
-          .map((id) => directMatches.find((n) => n.id === id)?.label)
-          .filter(Boolean);
-        if (labels.length > 0) {
-          result += `   Connected to: ${labels.join(", ")}\n`;
-        }
-      }
-      result += "\n";
-    });
-  }
-  return result;
-}
 
 // Group definitions for reranked search results
 type SearchGroups = {

--- a/src/lib/ingestion/ensure-source-node.ts
+++ b/src/lib/ingestion/ensure-source-node.ts
@@ -83,7 +83,7 @@ export async function ensureSourceNode({
       .insert(edges)
       .values({
         userId,
-        edgeType: EdgeTypeEnum.Enum.OCCURRED_ON,
+        edgeType: EdgeTypeEnum.enum.OCCURRED_ON,
         sourceNodeId: newNode.id,
         targetNodeId: dayNodeId,
       })


### PR DESCRIPTION
## Summary
- fix incorrect EdgeTypeEnum reference in `ensure-source-node`
- remove unused `formatAsMarkdown` function from formatting utilities

## Testing
- `npx vitest run src/lib/temporary-id-mapper.test.ts`