### PR TITLE
Add CLI build tsconfig and esbuild setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "nitro build",
     "build-sdk": "tsc --project tsconfig.sdk.json",
-    "build-cli": "tsc --outDir dist --module NodeNext src/cli.ts && mv dist/cli.js dist/cli.mjs",
+    "build-cli": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=es2022 --outfile=dist/cli.mjs --tsconfig=tsconfig.cli.json",
     "dev": "nitro dev",
     "prepare": "nitro prepare",
     "preview": "node .output/server/index.mjs",

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "NodeNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "allowJs": false,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "noEmit": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["src/cli.ts"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add separate tsconfig for CLI build
- compile CLI using esbuild

## Testing
- `pnpm run build`
- `pnpm run build-cli`
- `pnpm test` *(fails: missing env vars)*