### PR TITLE
Refine deep research job

### DIFF
--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = array.slice();
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}


### PR DESCRIPTION
## Summary
- adjust deep research query prompt to produce tangential searches
- drop reranker usage in deep research and build results directly
- randomize deep research results before truncating the list

## Testing
- `pnpm test` *(fails: uncaughtException ZodError; missing env vars)*