### PR TITLE
Add query endpoint for knowledge graph

### DIFF
--- a/src/lib/query/graph.ts
+++ b/src/lib/query/graph.ts
@@ -1,0 +1,152 @@
+import { and, aliasedTable, eq, inArray, isNotNull } from "drizzle-orm";
+import { generateEmbeddings } from "../embeddings";
+import { findOneHopNodes, findSimilarNodes } from "../graph";
+import {
+  QueryGraphRequest,
+  QueryGraphResponse,
+} from "../schemas/query-graph";
+import { nodes, nodeMetadata, edges } from "~/db/schema";
+import type { EdgeType, NodeType } from "~/types/graph";
+import type { TypeId } from "~/types/typeid";
+import { useDatabase } from "~/utils/db";
+
+interface GraphNodeResult {
+  id: TypeId<"node">;
+  nodeType: NodeType;
+  label: string;
+  description: string | null;
+}
+
+interface GraphEdgeResult {
+  source: TypeId<"node">;
+  target: TypeId<"node">;
+  edgeType: EdgeType;
+  description: string | null;
+}
+
+export async function queryKnowledgeGraph(
+  params: QueryGraphRequest,
+): Promise<QueryGraphResponse> {
+  const { userId, query, maxNodes } = params;
+  const db = await useDatabase();
+
+  // If no query -> return full labeled graph
+  if (!query) {
+    const nodeRows = await db
+      .select({
+        id: nodes.id,
+        nodeType: nodes.nodeType,
+        label: nodeMetadata.label,
+        description: nodeMetadata.description,
+      })
+      .from(nodes)
+      .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .where(and(eq(nodes.userId, userId), isNotNull(nodeMetadata.label)));
+
+    const nodeIds = nodeRows.map((n) => n.id);
+
+    if (nodeIds.length === 0) {
+      return { nodes: [], edges: [] };
+    }
+
+    const src = aliasedTable(nodeMetadata, "src");
+    const tgt = aliasedTable(nodeMetadata, "tgt");
+    const edgeRows = await db
+      .select({
+        source: edges.sourceNodeId,
+        target: edges.targetNodeId,
+        edgeType: edges.edgeType,
+        description: edges.description,
+      })
+      .from(edges)
+      .innerJoin(src, eq(src.nodeId, edges.sourceNodeId))
+      .innerJoin(tgt, eq(tgt.nodeId, edges.targetNodeId))
+      .where(
+        and(
+          eq(edges.userId, userId),
+          inArray(edges.sourceNodeId, nodeIds),
+          inArray(edges.targetNodeId, nodeIds),
+          isNotNull(src.label),
+          isNotNull(tgt.label),
+        ),
+      );
+
+    return { nodes: nodeRows, edges: edgeRows };
+  }
+
+  // Query-based subgraph
+  const emb = await generateEmbeddings({
+    model: "jina-embeddings-v3",
+    task: "retrieval.query",
+    input: [query],
+    truncate: true,
+  });
+  const embedding = emb.data[0]?.embedding;
+  if (!embedding) throw new Error("Failed to generate embedding");
+
+  const seeds = (
+    await findSimilarNodes({
+      userId,
+      embedding,
+      limit: Math.min(maxNodes, 5),
+      minimumSimilarity: 0.4,
+    })
+  ).filter((n) => n.label);
+
+  const nodeMap = new Map<TypeId<"node">, GraphNodeResult>();
+  seeds.forEach((s) => {
+    nodeMap.set(s.id, {
+      id: s.id,
+      nodeType: s.type,
+      label: s.label ?? "",
+      description: s.description,
+    });
+  });
+
+  let currentIds = seeds.map((s) => s.id);
+  while (nodeMap.size < maxNodes && currentIds.length) {
+    const conns = await findOneHopNodes(db, userId, currentIds);
+    const nextIds: TypeId<"node">[] = [];
+    for (const c of conns) {
+      if (!nodeMap.has(c.id) && nodeMap.size < maxNodes) {
+        nodeMap.set(c.id, {
+          id: c.id,
+          nodeType: c.type,
+          label: c.label ?? "",
+          description: c.description,
+        });
+        nextIds.push(c.id);
+      }
+    }
+    currentIds = nextIds;
+  }
+
+  const nodeIds = Array.from(nodeMap.keys());
+  if (nodeIds.length === 0) {
+    return { nodes: [], edges: [] };
+  }
+
+  const src = aliasedTable(nodeMetadata, "srcMeta");
+  const tgt = aliasedTable(nodeMetadata, "tgtMeta");
+  const edgeRows = await db
+    .select({
+      source: edges.sourceNodeId,
+      target: edges.targetNodeId,
+      edgeType: edges.edgeType,
+      description: edges.description,
+    })
+    .from(edges)
+    .innerJoin(src, eq(src.nodeId, edges.sourceNodeId))
+    .innerJoin(tgt, eq(tgt.nodeId, edges.targetNodeId))
+    .where(
+      and(
+        eq(edges.userId, userId),
+        inArray(edges.sourceNodeId, nodeIds),
+        inArray(edges.targetNodeId, nodeIds),
+        isNotNull(src.label),
+        isNotNull(tgt.label),
+      ),
+    );
+
+  return { nodes: Array.from(nodeMap.values()), edges: edgeRows };
+}

--- a/src/lib/schemas/query-graph.ts
+++ b/src/lib/schemas/query-graph.ts
@@ -1,0 +1,31 @@
+import { EdgeTypeEnum, NodeTypeEnum } from "../../types/graph.js";
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+export const queryGraphRequestSchema = z.object({
+  userId: z.string(),
+  query: z.string().optional(),
+  maxNodes: z.number().int().positive().default(100),
+});
+
+export const queryGraphNodeSchema = z.object({
+  id: typeIdSchema("node"),
+  nodeType: NodeTypeEnum,
+  label: z.string(),
+  description: z.string().nullable().optional(),
+});
+
+export const queryGraphEdgeSchema = z.object({
+  source: typeIdSchema("node"),
+  target: typeIdSchema("node"),
+  edgeType: EdgeTypeEnum,
+  description: z.string().nullable().optional(),
+});
+
+export const queryGraphResponseSchema = z.object({
+  nodes: z.array(queryGraphNodeSchema),
+  edges: z.array(queryGraphEdgeSchema),
+});
+
+export type QueryGraphRequest = z.infer<typeof queryGraphRequestSchema>;
+export type QueryGraphResponse = z.infer<typeof queryGraphResponseSchema>;

--- a/src/routes/query/graph.ts
+++ b/src/routes/query/graph.ts
@@ -1,0 +1,12 @@
+import { defineEventHandler } from "h3";
+import { queryKnowledgeGraph } from "~/lib/query/graph";
+import {
+  queryGraphRequestSchema,
+  queryGraphResponseSchema,
+} from "~/lib/schemas/query-graph";
+
+export default defineEventHandler(async (event) => {
+  const params = queryGraphRequestSchema.parse(await readBody(event));
+  const result = await queryKnowledgeGraph(params);
+  return queryGraphResponseSchema.parse(result);
+});


### PR DESCRIPTION
## Summary
- implement queryKnowledgeGraph to return user graph data
- add request/response schemas for querying the graph
- expose new `query/graph` API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683992378328832fb19729ff60fe3690