### PR TITLE
Fix duplicate dream content

### DIFF
--- a/src/lib/jobs/dream.ts
+++ b/src/lib/jobs/dream.ts
@@ -102,7 +102,7 @@ async function handleTopic(
   );
   const score = await scoreDream(userId, systemPrompt, dream);
   if (score < 0.7) return;
-  await persistDream(db, userId, dayId, dream);
+  await persistDream(db, userId, dayId, topic, dream);
 }
 
 // 1. Structured analysis: propose search queries
@@ -215,6 +215,7 @@ async function persistDream(
   db: DrizzleDB,
   userId: string,
   dayId: TypeId<"node">,
+  label: string,
   dreamContent: string,
 ) {
   const inserted = await db
@@ -229,7 +230,7 @@ async function persistDream(
   const newNode = inserted[0]!;
   await db.insert(nodeMetadata).values({
     nodeId: newNode.id,
-    label: dreamContent,
+    label,
     description: dreamContent,
   });
   const emb = await generateEmbeddings({


### PR DESCRIPTION
## Summary
- fix dream node labels to avoid repeating dream text in graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d435caf9c832fa7a3e7a058c833ac