### PR TITLE
Add subject and object labels to claim queries

### DIFF
--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -327,8 +327,12 @@ async function findSimilarNodesViaSubstring(
   opts: FindSimilarNodesOptions,
   query: string,
 ): Promise<NodeSearchResult[]> {
-  const { userId, limit = 10, excludeNodeTypes, includeReference = false } =
-    opts;
+  const {
+    userId,
+    limit = 10,
+    excludeNodeTypes,
+    includeReference = false,
+  } = opts;
   const db = await useDatabase();
 
   let where = and(

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -600,6 +600,8 @@ export async function fetchClaimsBetweenNodeIds(
       id: claims.id,
       subject: claims.subjectNodeId,
       object: sql<TypeId<"node">>`${claims.objectNodeId}`.as("object"),
+      subjectLabel: src.label,
+      objectLabel: tgt.label,
       predicate: claims.predicate,
       statement: claims.statement,
       description: claims.description,

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -715,6 +715,8 @@ export async function getNodeNeighborhood(
     id: TypeId<"claim">;
     subject: TypeId<"node">;
     object: TypeId<"node"> | null;
+    subjectLabel: string | null;
+    objectLabel: string | null;
     predicate: string;
     statement: string;
     description: string | null;

--- a/src/lib/schemas/query-graph.ts
+++ b/src/lib/schemas/query-graph.ts
@@ -27,6 +27,8 @@ export const queryGraphClaimSchema = z.object({
   id: typeIdSchema("claim"),
   subject: typeIdSchema("node"),
   object: typeIdSchema("node"),
+  subjectLabel: z.string().nullable(),
+  objectLabel: z.string().nullable(),
   predicate: PredicateEnum,
   statement: z.string(),
   description: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
This change enhances claim data returned from graph queries by including the labels of both the subject and object nodes alongside their IDs.

## Key Changes
- **graph.ts**: Updated `fetchClaimsBetweenNodeIds()` to select `subjectLabel` from the source node and `objectLabel` from the target node in the query results
- **node.ts**: Extended the `getNodeNeighborhood()` return type to include `subjectLabel` and `objectLabel` as nullable string fields
- **query-graph.ts**: Updated the `queryGraphClaimSchema` validation schema to include the new `subjectLabel` and `objectLabel` fields as nullable strings

## Implementation Details
The labels are sourced from the existing node joins (`src` and `tgt`) that are already part of the query, so this change adds minimal overhead by simply projecting additional columns from the existing data.

https://claude.ai/code/session_01FpuCryJNPaRk8T4cu9FzZv