### PR TITLE
Add metric definition update and delete operations

### DIFF
--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -1060,14 +1060,22 @@ async function _processAndRecordLlmMetrics({
   });
 
   if (observations.length === 0 && events.length === 0) return;
-  await recordMetricObservations({
+  const result = await recordMetricObservations({
     userId,
     source: { sourceId },
-    createDefinitions: true,
+    createDefinitions: false,
     replaceSourceObservations: true,
     events,
     observations,
   });
+  const skippedUnknownDefinition = result.errors.filter(
+    (error) => error.code === "DEFINITION_NOT_FOUND",
+  );
+  if (skippedUnknownDefinition.length > 0) {
+    console.warn(
+      `Skipped ${skippedUnknownDefinition.length} metric observation(s) referencing unknown metric definitions during ingestion of source ${sourceId}`,
+    );
+  }
 }
 
 function _defaultAssertedByKind(sourceType: SourceType): AssertedByKind {

--- a/src/lib/ingestion/save-document.ts
+++ b/src/lib/ingestion/save-document.ts
@@ -10,13 +10,13 @@
  * cascaded away here too, so the worker only ever sees a freshly-inserted
  * row to extract from.
  */
-import { ensureUser } from "./ensure-user";
 import { batchQueue } from "../queues";
 import {
   IngestDocumentRequest,
   IngestDocumentResponse,
 } from "../schemas/ingest-document-request";
 import { sourceService } from "../sources";
+import { ensureUser } from "./ensure-user";
 import { and, eq, inArray } from "drizzle-orm";
 import { createError } from "h3";
 import db from "~/db";

--- a/src/lib/jobs/ingest-file.ts
+++ b/src/lib/jobs/ingest-file.ts
@@ -17,8 +17,8 @@ import { z } from "zod";
 import { DrizzleDB } from "~/db";
 import { sources } from "~/db/schema";
 import { convertToMarkdown } from "~/lib/converters/markitdown";
-import { extractDocumentGraph } from "~/lib/ingestion/extract-document-graph";
 import { ensureUser } from "~/lib/ingestion/ensure-user";
+import { extractDocumentGraph } from "~/lib/ingestion/extract-document-graph";
 import { sourceMetadataSchema, sourceService } from "~/lib/sources";
 import { typeIdSchema, type TypeId } from "~/types/typeid";
 

--- a/src/lib/metrics/definitions.test.ts
+++ b/src/lib/metrics/definitions.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 import { HIGH_SIMILARITY, MID_SIMILARITY } from "~/lib/metrics/constants";
 import { metricDefinitionEmbeddingText } from "~/lib/metrics/definitions";
 import { proposedMetricDefinitionSchema } from "~/lib/schemas/metric-definition";
+import {
+  deleteMetricDefinitionRequestSchema,
+  updateMetricDefinitionRequestSchema,
+} from "~/lib/schemas/metric-write";
+import { newTypeId } from "~/types/typeid";
+
+vi.mock("~/utils/db", () => ({
+  useDatabase: async () => {
+    throw new Error("useDatabase should not be called in this test");
+  },
+}));
 
 vi.mock("~/lib/embeddings", () => ({
   generateEmbeddings: async () => ({
@@ -61,5 +72,33 @@ describe("metric definitions", () => {
         description: "Morning bathroom scale weight",
       }),
     ).toBe("Body weight\nMorning bathroom scale weight");
+  });
+
+  it("requires at least one editable field on update", () => {
+    expect(() =>
+      updateMetricDefinitionRequestSchema.parse({
+        userId: "user_A",
+        metricDefinitionId: newTypeId("metric_definition"),
+      }),
+    ).toThrow();
+  });
+
+  it("accepts a partial update with one field", () => {
+    expect(() =>
+      updateMetricDefinitionRequestSchema.parse({
+        userId: "user_A",
+        metricDefinitionId: newTypeId("metric_definition"),
+        label: "Body weight",
+      }),
+    ).not.toThrow();
+  });
+
+  it("validates the delete request shape", () => {
+    expect(() =>
+      deleteMetricDefinitionRequestSchema.parse({
+        userId: "user_A",
+        metricDefinitionId: newTypeId("metric_definition"),
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/lib/metrics/definitions.ts
+++ b/src/lib/metrics/definitions.ts
@@ -274,7 +274,19 @@ export class MetricDefinitionSlugConflictError extends Error {
   }
 }
 
-/** Patch a metric definition. Regenerates the embedding when label/description change. */
+export class MetricDefinitionValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MetricDefinitionValidationError";
+  }
+}
+
+/**
+ * Patch a metric definition. When label/description change, regenerates the
+ * embedding too — the new embedding is computed up-front, then the row update
+ * and embedding delete+insert run in a single transaction so we never persist
+ * an updated definition without a matching embedding.
+ */
 export async function updateMetricDefinition(
   userId: string,
   metricDefinitionId: TypeId<"metric_definition">,
@@ -295,23 +307,26 @@ export async function updateMetricDefinition(
 
   if (!existing) throw new MetricDefinitionNotFoundError(metricDefinitionId);
 
-  if (patch.slug !== undefined && patch.slug !== existing.slug) {
-    const [conflict] = await db
-      .select({ id: metricDefinitions.id })
-      .from(metricDefinitions)
-      .where(
-        and(
-          eq(metricDefinitions.userId, userId),
-          eq(metricDefinitions.slug, patch.slug),
-        ),
-      )
-      .limit(1);
-    if (conflict) throw new MetricDefinitionSlugConflictError(patch.slug);
-  }
-
   const nextLabel = patch.label ?? existing.label;
   const nextDescription = patch.description ?? existing.description;
+  const nextUnit = patch.unit ?? existing.unit;
+  const nextAggregationHint = patch.aggregationHint ?? existing.aggregationHint;
+  const nextSlug = patch.slug ?? existing.slug;
   const nextValidRange = validateUpdatedRange(existing, patch);
+
+  const embeddingTextChanged =
+    nextLabel !== existing.label || nextDescription !== existing.description;
+  // Compute the new embedding *before* the transaction so a failure in the
+  // embedding service can't leave the row updated with a stale vector.
+  const newEmbedding = embeddingTextChanged
+    ? await generateMetricDefinitionEmbedding({
+        slug: nextSlug,
+        label: nextLabel,
+        description: nextDescription,
+        unit: nextUnit,
+        aggregationHint: nextAggregationHint,
+      })
+    : null;
 
   const updateValues: Partial<typeof metricDefinitions.$inferInsert> = {
     updatedAt: new Date(),
@@ -330,38 +345,49 @@ export async function updateMetricDefinition(
   if (patch.needsReview !== undefined)
     updateValues.needsReview = patch.needsReview;
 
-  const [updated] = await db
-    .update(metricDefinitions)
-    .set(updateValues)
-    .where(
-      and(
-        eq(metricDefinitions.userId, userId),
-        eq(metricDefinitions.id, metricDefinitionId),
-      ),
-    )
-    .returning();
+  const updated = await db.transaction(async (tx) => {
+    if (patch.slug !== undefined && patch.slug !== existing.slug) {
+      const [conflict] = await tx
+        .select({ id: metricDefinitions.id })
+        .from(metricDefinitions)
+        .where(
+          and(
+            eq(metricDefinitions.userId, userId),
+            eq(metricDefinitions.slug, patch.slug),
+          ),
+        )
+        .limit(1);
+      if (conflict) throw new MetricDefinitionSlugConflictError(patch.slug);
+    }
 
-  if (!updated) throw new MetricDefinitionNotFoundError(metricDefinitionId);
+    const [row] = await tx
+      .update(metricDefinitions)
+      .set(updateValues)
+      .where(
+        and(
+          eq(metricDefinitions.userId, userId),
+          eq(metricDefinitions.id, metricDefinitionId),
+        ),
+      )
+      .returning();
 
-  const embeddingTextChanged =
-    nextLabel !== existing.label || nextDescription !== existing.description;
-  if (embeddingTextChanged) {
-    const embedding = await generateMetricDefinitionEmbedding({
-      slug: updated.slug,
-      label: nextLabel,
-      description: nextDescription,
-      unit: updated.unit,
-      aggregationHint: updated.aggregationHint,
-    });
-    if (embedding) {
-      await db
+    if (!row) throw new MetricDefinitionNotFoundError(metricDefinitionId);
+
+    if (embeddingTextChanged && newEmbedding) {
+      await tx
         .delete(metricDefinitionEmbeddings)
         .where(
           eq(metricDefinitionEmbeddings.metricDefinitionId, metricDefinitionId),
         );
-      await insertMetricDefinitionEmbedding(db, metricDefinitionId, embedding);
+      await insertMetricDefinitionEmbedding(
+        tx,
+        metricDefinitionId,
+        newEmbedding,
+      );
     }
-  }
+
+    return row;
+  });
 
   return parseDefinition(updated);
 }
@@ -383,7 +409,9 @@ function validateUpdatedRange(
         ? null
         : patch.validRangeMax.toString();
   if (min !== null && max !== null && Number(min) > Number(max)) {
-    throw new Error("validRangeMin must be less than or equal to validRangeMax");
+    throw new MetricDefinitionValidationError(
+      "validRangeMin must be less than or equal to validRangeMax",
+    );
   }
   return { min, max };
 }

--- a/src/lib/metrics/definitions.ts
+++ b/src/lib/metrics/definitions.ts
@@ -1,6 +1,10 @@
 import { and, cosineDistance, desc, eq, sql } from "drizzle-orm";
 import type { DrizzleDB } from "~/db";
-import { metricDefinitionEmbeddings, metricDefinitions } from "~/db/schema";
+import {
+  metricDefinitionEmbeddings,
+  metricDefinitions,
+  metricObservations,
+} from "~/db/schema";
 import { generateEmbeddings } from "~/lib/embeddings";
 import { HIGH_SIMILARITY, MID_SIMILARITY } from "~/lib/metrics/constants";
 import { createNode } from "~/lib/node";
@@ -11,6 +15,7 @@ import {
   proposedMetricDefinitionSchema,
 } from "~/lib/schemas/metric-definition";
 import type { TypeId } from "~/types/typeid";
+import { useDatabase } from "~/utils/db";
 import { shouldSkipEmbeddingPersistence } from "~/utils/test-overrides";
 
 type MetricDefinitionRow = typeof metricDefinitions.$inferSelect;
@@ -238,4 +243,182 @@ export async function getMetricDefinitionBySlug(
     .limit(1);
 
   return row ? parseDefinition(row) : null;
+}
+
+export interface UpdateMetricDefinitionPatch {
+  slug?: string | undefined;
+  label?: string | undefined;
+  description?: string | undefined;
+  unit?: string | undefined;
+  aggregationHint?: "avg" | "sum" | "min" | "max" | undefined;
+  validRangeMin?: number | null | undefined;
+  validRangeMax?: number | null | undefined;
+  needsReview?: boolean | undefined;
+}
+
+export class MetricDefinitionNotFoundError extends Error {
+  readonly metricDefinitionId: TypeId<"metric_definition">;
+  constructor(metricDefinitionId: TypeId<"metric_definition">) {
+    super(`Metric definition not found: ${metricDefinitionId}`);
+    this.name = "MetricDefinitionNotFoundError";
+    this.metricDefinitionId = metricDefinitionId;
+  }
+}
+
+export class MetricDefinitionSlugConflictError extends Error {
+  readonly slug: string;
+  constructor(slug: string) {
+    super(`Metric definition slug already in use: ${slug}`);
+    this.name = "MetricDefinitionSlugConflictError";
+    this.slug = slug;
+  }
+}
+
+/** Patch a metric definition. Regenerates the embedding when label/description change. */
+export async function updateMetricDefinition(
+  userId: string,
+  metricDefinitionId: TypeId<"metric_definition">,
+  patch: UpdateMetricDefinitionPatch,
+): Promise<MetricDefinition> {
+  const db = await useDatabase();
+
+  const [existing] = await db
+    .select()
+    .from(metricDefinitions)
+    .where(
+      and(
+        eq(metricDefinitions.userId, userId),
+        eq(metricDefinitions.id, metricDefinitionId),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) throw new MetricDefinitionNotFoundError(metricDefinitionId);
+
+  if (patch.slug !== undefined && patch.slug !== existing.slug) {
+    const [conflict] = await db
+      .select({ id: metricDefinitions.id })
+      .from(metricDefinitions)
+      .where(
+        and(
+          eq(metricDefinitions.userId, userId),
+          eq(metricDefinitions.slug, patch.slug),
+        ),
+      )
+      .limit(1);
+    if (conflict) throw new MetricDefinitionSlugConflictError(patch.slug);
+  }
+
+  const nextLabel = patch.label ?? existing.label;
+  const nextDescription = patch.description ?? existing.description;
+  const nextValidRange = validateUpdatedRange(existing, patch);
+
+  const updateValues: Partial<typeof metricDefinitions.$inferInsert> = {
+    updatedAt: new Date(),
+  };
+  if (patch.slug !== undefined) updateValues.slug = patch.slug;
+  if (patch.label !== undefined) updateValues.label = patch.label;
+  if (patch.description !== undefined)
+    updateValues.description = patch.description;
+  if (patch.unit !== undefined) updateValues.unit = patch.unit;
+  if (patch.aggregationHint !== undefined)
+    updateValues.aggregationHint = patch.aggregationHint;
+  if (patch.validRangeMin !== undefined)
+    updateValues.validRangeMin = nextValidRange.min;
+  if (patch.validRangeMax !== undefined)
+    updateValues.validRangeMax = nextValidRange.max;
+  if (patch.needsReview !== undefined)
+    updateValues.needsReview = patch.needsReview;
+
+  const [updated] = await db
+    .update(metricDefinitions)
+    .set(updateValues)
+    .where(
+      and(
+        eq(metricDefinitions.userId, userId),
+        eq(metricDefinitions.id, metricDefinitionId),
+      ),
+    )
+    .returning();
+
+  if (!updated) throw new MetricDefinitionNotFoundError(metricDefinitionId);
+
+  const embeddingTextChanged =
+    nextLabel !== existing.label || nextDescription !== existing.description;
+  if (embeddingTextChanged) {
+    const embedding = await generateMetricDefinitionEmbedding({
+      slug: updated.slug,
+      label: nextLabel,
+      description: nextDescription,
+      unit: updated.unit,
+      aggregationHint: updated.aggregationHint,
+    });
+    if (embedding) {
+      await db
+        .delete(metricDefinitionEmbeddings)
+        .where(
+          eq(metricDefinitionEmbeddings.metricDefinitionId, metricDefinitionId),
+        );
+      await insertMetricDefinitionEmbedding(db, metricDefinitionId, embedding);
+    }
+  }
+
+  return parseDefinition(updated);
+}
+
+function validateUpdatedRange(
+  existing: MetricDefinitionRow,
+  patch: UpdateMetricDefinitionPatch,
+): { min: string | null; max: string | null } {
+  const min =
+    patch.validRangeMin === undefined
+      ? existing.validRangeMin
+      : patch.validRangeMin === null
+        ? null
+        : patch.validRangeMin.toString();
+  const max =
+    patch.validRangeMax === undefined
+      ? existing.validRangeMax
+      : patch.validRangeMax === null
+        ? null
+        : patch.validRangeMax.toString();
+  if (min !== null && max !== null && Number(min) > Number(max)) {
+    throw new Error("validRangeMin must be less than or equal to validRangeMax");
+  }
+  return { min, max };
+}
+
+/** Delete a metric definition (and its observations + embedding via FK cascade). */
+export async function deleteMetricDefinition(
+  userId: string,
+  metricDefinitionId: TypeId<"metric_definition">,
+): Promise<{ deletedObservationCount: number }> {
+  const db = await useDatabase();
+
+  const [observationCountRow] = await db
+    .select({ value: sql<number>`count(*)::int` })
+    .from(metricObservations)
+    .where(
+      and(
+        eq(metricObservations.userId, userId),
+        eq(metricObservations.metricDefinitionId, metricDefinitionId),
+      ),
+    );
+  const deletedObservationCount = observationCountRow?.value ?? 0;
+
+  const deletedRows = await db
+    .delete(metricDefinitions)
+    .where(
+      and(
+        eq(metricDefinitions.userId, userId),
+        eq(metricDefinitions.id, metricDefinitionId),
+      ),
+    )
+    .returning({ id: metricDefinitions.id });
+
+  if (deletedRows.length === 0) {
+    throw new MetricDefinitionNotFoundError(metricDefinitionId);
+  }
+
+  return { deletedObservationCount };
 }

--- a/src/lib/metrics/list.test.ts
+++ b/src/lib/metrics/list.test.ts
@@ -35,12 +35,14 @@ class FakeQuery {
 
 function fakeDatabase(results: QueryResult[]) {
   let index = 0;
+  const next = () => {
+    const result = results[index] ?? [];
+    index += 1;
+    return new FakeQuery(result);
+  };
   return {
-    select() {
-      const result = results[index] ?? [];
-      index += 1;
-      return new FakeQuery(result);
-    },
+    select: next,
+    selectDistinctOn: next,
   };
 }
 

--- a/src/lib/metrics/list.ts
+++ b/src/lib/metrics/list.ts
@@ -3,20 +3,19 @@ import {
   and,
   asc,
   count,
+  desc,
   eq,
   ilike,
   inArray,
   max,
   min,
   or,
-  sql,
 } from "drizzle-orm";
 import { metricDefinitions, metricObservations } from "~/db/schema";
 import {
   type ListMetricsRequest,
   type MetricDefinitionWithStats,
 } from "~/lib/schemas/metric-read";
-import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
 function numberOrNull(value: string | number | null): number | null {
@@ -69,8 +68,11 @@ export async function listMetrics({
     )
     .groupBy(metricObservations.metricDefinitionId);
 
+  // DISTINCT ON pulls one row per metric — the freshest — using the existing
+  // (user_id, metric_definition_id, occurred_at DESC) index, instead of
+  // scanning every observation and reducing in JS.
   const latestRows = await db
-    .select({
+    .selectDistinctOn([metricObservations.metricDefinitionId], {
       metricDefinitionId: metricObservations.metricDefinitionId,
       value: metricObservations.value,
       occurredAt: metricObservations.occurredAt,
@@ -84,21 +86,14 @@ export async function listMetrics({
     )
     .orderBy(
       metricObservations.metricDefinitionId,
-      sql`${metricObservations.occurredAt} DESC`,
+      desc(metricObservations.occurredAt),
     );
 
   const statsByDefinitionId = new Map(
     statsRows.map((row) => [row.metricDefinitionId, row]),
   );
-  const latestByDefinitionId = latestRows.reduce(
-    (latest, row) =>
-      latest.has(row.metricDefinitionId)
-        ? latest
-        : latest.set(row.metricDefinitionId, row),
-    new Map<
-      TypeId<"metric_definition">,
-      { value: string | number; occurredAt: Date }
-    >(),
+  const latestByDefinitionId = new Map(
+    latestRows.map((row) => [row.metricDefinitionId, row]),
   );
 
   return definitions

--- a/src/lib/metrics/observations.test.ts
+++ b/src/lib/metrics/observations.test.ts
@@ -73,3 +73,123 @@ describe("metric observation range guard", () => {
     ).not.toThrow();
   });
 });
+
+describe("recordMetricObservations with createDefinitions: false", () => {
+  it("attaches LLM-proposed observations to existing metrics via slug lookup", async () => {
+    const existing = definition({ validRangeMin: null, validRangeMax: null });
+    const inserted: unknown[] = [];
+    const fakeDb = {
+      delete: () => ({ where: async () => undefined }),
+      insert: () => ({
+        values: (value: unknown) => ({
+          returning: async () => {
+            inserted.push(value);
+            return [
+              {
+                id: newTypeId("metric_observation"),
+                metricDefinitionId: existing.id,
+              },
+            ];
+          },
+        }),
+      }),
+    };
+
+    vi.resetModules();
+    vi.doMock("~/lib/metrics/definitions", () => ({
+      getMetricDefinitionBySlug: async () => existing,
+      resolveMetricDefinition: async () => {
+        throw new Error("must not be called when createDefinitions is false");
+      },
+    }));
+    vi.doMock("~/lib/metrics/sources", () => ({
+      upsertMetricManualSource: async () => newTypeId("source"),
+      upsertMetricPushSource: async () => newTypeId("source"),
+    }));
+    vi.doMock("~/lib/metrics/event-nodes", () => ({
+      ensureMetricEventNode: async () => newTypeId("node"),
+    }));
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => fakeDb }));
+
+    const { recordMetricObservations } = await import(
+      "~/lib/metrics/observations"
+    );
+    const result = await recordMetricObservations({
+      userId: "user_A",
+      source: { type: "metric_manual" },
+      createDefinitions: false,
+      observations: [
+        {
+          metric: {
+            slug: "resting_hr",
+            label: "Resting HR",
+            description: "Morning resting heart rate",
+            unit: "bpm",
+            aggregationHint: "avg",
+          },
+          value: 58,
+          occurredAt: new Date("2026-05-12T07:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(inserted).toHaveLength(1);
+  });
+
+  it("skips observations whose slug doesn't match any existing metric", async () => {
+    const fakeDb = {
+      delete: () => ({ where: async () => undefined }),
+      insert: () => ({
+        values: () => ({
+          returning: async () => {
+            throw new Error("insert must not be called when slug is unknown");
+          },
+        }),
+      }),
+    };
+
+    vi.resetModules();
+    vi.doMock("~/lib/metrics/definitions", () => ({
+      getMetricDefinitionBySlug: async () => null,
+      resolveMetricDefinition: async () => {
+        throw new Error("must not be called when createDefinitions is false");
+      },
+    }));
+    vi.doMock("~/lib/metrics/sources", () => ({
+      upsertMetricManualSource: async () => newTypeId("source"),
+      upsertMetricPushSource: async () => newTypeId("source"),
+    }));
+    vi.doMock("~/lib/metrics/event-nodes", () => ({
+      ensureMetricEventNode: async () => newTypeId("node"),
+    }));
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => fakeDb }));
+
+    const { recordMetricObservations } = await import(
+      "~/lib/metrics/observations"
+    );
+    const result = await recordMetricObservations({
+      userId: "user_A",
+      source: { type: "metric_manual" },
+      createDefinitions: false,
+      observations: [
+        {
+          metric: {
+            slug: "height_of_sam",
+            label: "Height of Sam",
+            description: "Sam's height mentioned in chat",
+            unit: "cm",
+            aggregationHint: "avg",
+          },
+          value: 182,
+          occurredAt: new Date("2026-05-12T07:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.code).toBe("DEFINITION_NOT_FOUND");
+  });
+});

--- a/src/lib/metrics/observations.ts
+++ b/src/lib/metrics/observations.ts
@@ -164,37 +164,38 @@ async function resolveObservationDefinition(
   observation: MetricObservationInput,
 ): Promise<MetricDefinitionResolution | MetricObservationRowError> {
   if (observation.metric !== undefined) {
-    if (!createDefinitions) {
-      return {
-        index: -1,
-        code: "INVALID_INPUT",
-        message: "Metric definitions cannot be created for this source",
-      };
+    if (createDefinitions) {
+      return resolveMetricDefinition(
+        db,
+        userId,
+        toProposedMetricDefinition(observation.metric),
+      );
     }
-    return resolveMetricDefinition(
-      db,
-      userId,
-      toProposedMetricDefinition(observation.metric),
-    );
+    // Caller may not mint new definitions (e.g. LLM ingestion). Fall through
+    // to slug lookup so observations still attach to user-curated metrics.
+    return resolveDefinitionBySlug(db, userId, observation.metric.slug);
   }
 
   if (observation.metricSlug === undefined) {
     return missingMetricError(-1);
   }
 
-  const definition = await getMetricDefinitionBySlug(
-    db,
-    userId,
-    observation.metricSlug,
-  );
+  return resolveDefinitionBySlug(db, userId, observation.metricSlug);
+}
+
+async function resolveDefinitionBySlug(
+  db: DrizzleDB,
+  userId: string,
+  slug: string,
+): Promise<MetricDefinitionResolution | MetricObservationRowError> {
+  const definition = await getMetricDefinitionBySlug(db, userId, slug);
   if (!definition) {
     return {
       index: -1,
       code: "DEFINITION_NOT_FOUND",
-      message: `Metric definition not found for slug '${observation.metricSlug}'`,
+      message: `Metric definition not found for slug '${slug}'`,
     };
   }
-
   return {
     definition,
     created: false,

--- a/src/lib/schemas/metric-write.ts
+++ b/src/lib/schemas/metric-write.ts
@@ -1,6 +1,7 @@
 import { typeIdSchema } from "../../types/typeid.js";
 import {
   metricAggregationHintSchema,
+  metricDefinitionSchema,
   proposedMetricDefinitionSchema,
 } from "./metric-definition.js";
 import { metricObservationErrorCodeSchema } from "./metric-observation.js";
@@ -72,4 +73,60 @@ export type BulkRecordMetricsRequest = z.infer<
 >;
 export type BulkRecordMetricsResponse = z.infer<
   typeof bulkRecordMetricsResponseSchema
+>;
+
+export const updateMetricDefinitionRequestSchema = z
+  .object({
+    userId: z.string().min(1),
+    metricDefinitionId: typeIdSchema("metric_definition"),
+    slug: z
+      .string()
+      .regex(/^[a-z0-9_]{1,80}$/, "lowercase snake_case slug, max 80 chars")
+      .optional(),
+    label: z.string().min(1).max(200).optional(),
+    description: z.string().min(1).max(2000).optional(),
+    unit: z.string().min(1).max(40).optional(),
+    aggregationHint: metricAggregationHintSchema.optional(),
+    validRangeMin: z.number().nullable().optional(),
+    validRangeMax: z.number().nullable().optional(),
+    needsReview: z.boolean().optional(),
+  })
+  .refine(
+    (value) =>
+      value.slug !== undefined ||
+      value.label !== undefined ||
+      value.description !== undefined ||
+      value.unit !== undefined ||
+      value.aggregationHint !== undefined ||
+      value.validRangeMin !== undefined ||
+      value.validRangeMax !== undefined ||
+      value.needsReview !== undefined,
+    { message: "At least one field must be provided" },
+  );
+
+export const updateMetricDefinitionResponseSchema = z.object({
+  definition: metricDefinitionSchema,
+});
+
+export const deleteMetricDefinitionRequestSchema = z.object({
+  userId: z.string().min(1),
+  metricDefinitionId: typeIdSchema("metric_definition"),
+});
+
+export const deleteMetricDefinitionResponseSchema = z.object({
+  deleted: z.literal(true),
+  deletedObservationCount: z.number().int().min(0),
+});
+
+export type UpdateMetricDefinitionRequest = z.infer<
+  typeof updateMetricDefinitionRequestSchema
+>;
+export type UpdateMetricDefinitionResponse = z.infer<
+  typeof updateMetricDefinitionResponseSchema
+>;
+export type DeleteMetricDefinitionRequest = z.infer<
+  typeof deleteMetricDefinitionRequestSchema
+>;
+export type DeleteMetricDefinitionResponse = z.infer<
+  typeof deleteMetricDefinitionResponseSchema
 >;

--- a/src/routes/metrics/delete.post.ts
+++ b/src/routes/metrics/delete.post.ts
@@ -1,0 +1,28 @@
+import {
+  MetricDefinitionNotFoundError,
+  deleteMetricDefinition,
+} from "~/lib/metrics/definitions";
+import {
+  deleteMetricDefinitionRequestSchema,
+  deleteMetricDefinitionResponseSchema,
+} from "~/lib/schemas/metric-write";
+
+export default defineEventHandler(async (event) => {
+  const { userId, metricDefinitionId } =
+    deleteMetricDefinitionRequestSchema.parse(await readBody(event));
+  try {
+    const { deletedObservationCount } = await deleteMetricDefinition(
+      userId,
+      metricDefinitionId,
+    );
+    return deleteMetricDefinitionResponseSchema.parse({
+      deleted: true,
+      deletedObservationCount,
+    });
+  } catch (error) {
+    if (error instanceof MetricDefinitionNotFoundError) {
+      throw createError({ statusCode: 404, statusMessage: error.message });
+    }
+    throw error;
+  }
+});

--- a/src/routes/metrics/update.post.ts
+++ b/src/routes/metrics/update.post.ts
@@ -1,6 +1,7 @@
 import {
   MetricDefinitionNotFoundError,
   MetricDefinitionSlugConflictError,
+  MetricDefinitionValidationError,
   updateMetricDefinition,
 } from "~/lib/metrics/definitions";
 import {
@@ -24,6 +25,9 @@ export default defineEventHandler(async (event) => {
     }
     if (error instanceof MetricDefinitionSlugConflictError) {
       throw createError({ statusCode: 409, statusMessage: error.message });
+    }
+    if (error instanceof MetricDefinitionValidationError) {
+      throw createError({ statusCode: 400, statusMessage: error.message });
     }
     throw error;
   }

--- a/src/routes/metrics/update.post.ts
+++ b/src/routes/metrics/update.post.ts
@@ -1,0 +1,30 @@
+import {
+  MetricDefinitionNotFoundError,
+  MetricDefinitionSlugConflictError,
+  updateMetricDefinition,
+} from "~/lib/metrics/definitions";
+import {
+  updateMetricDefinitionRequestSchema,
+  updateMetricDefinitionResponseSchema,
+} from "~/lib/schemas/metric-write";
+
+export default defineEventHandler(async (event) => {
+  const body = updateMetricDefinitionRequestSchema.parse(await readBody(event));
+  const { userId, metricDefinitionId, ...patch } = body;
+  try {
+    const definition = await updateMetricDefinition(
+      userId,
+      metricDefinitionId,
+      patch,
+    );
+    return updateMetricDefinitionResponseSchema.parse({ definition });
+  } catch (error) {
+    if (error instanceof MetricDefinitionNotFoundError) {
+      throw createError({ statusCode: 404, statusMessage: error.message });
+    }
+    if (error instanceof MetricDefinitionSlugConflictError) {
+      throw createError({ statusCode: 409, statusMessage: error.message });
+    }
+    throw error;
+  }
+});

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -79,10 +79,16 @@ import {
 import {
   BulkRecordMetricsRequest,
   BulkRecordMetricsResponse,
+  DeleteMetricDefinitionRequest,
+  DeleteMetricDefinitionResponse,
   RecordMetricRequest,
   RecordMetricResponse,
+  UpdateMetricDefinitionRequest,
+  UpdateMetricDefinitionResponse,
   bulkRecordMetricsResponseSchema,
+  deleteMetricDefinitionResponseSchema,
   recordMetricResponseSchema,
+  updateMetricDefinitionResponseSchema,
 } from "../lib/schemas/metric-write.js";
 import {
   BatchDeleteNodesRequest,
@@ -498,6 +504,28 @@ export class MemoryClient {
       "POST",
       "/metrics/summary",
       getMetricSummaryResponseSchema,
+      payload,
+    );
+  }
+
+  async updateMetricDefinition(
+    payload: UpdateMetricDefinitionRequest,
+  ): Promise<UpdateMetricDefinitionResponse> {
+    return this._fetch(
+      "POST",
+      "/metrics/update",
+      updateMetricDefinitionResponseSchema,
+      payload,
+    );
+  }
+
+  async deleteMetricDefinition(
+    payload: DeleteMetricDefinitionRequest,
+  ): Promise<DeleteMetricDefinitionResponse> {
+    return this._fetch(
+      "POST",
+      "/metrics/delete",
+      deleteMetricDefinitionResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## Summary
This PR adds the ability to update and delete metric definitions, along with supporting infrastructure for these operations. It also improves the metric observation recording flow to support attaching observations to existing metrics without creating new definitions.

## Key Changes

### Metric Definition Management
- **New `updateMetricDefinition()` function**: Allows patching metric definition fields (slug, label, description, unit, aggregationHint, validRange, needsReview). Automatically regenerates embeddings when label or description changes.
- **New `deleteMetricDefinition()` function**: Deletes a metric definition and cascades to observations via foreign key. Returns count of deleted observations.
- **Custom error classes**: `MetricDefinitionNotFoundError` and `MetricDefinitionSlugConflictError` for better error handling with specific HTTP status codes (404, 409).

### API Endpoints
- **POST `/metrics/update`**: Updates a metric definition with validation that at least one field is provided
- **POST `/metrics/delete`**: Deletes a metric definition and returns deletion count
- Both endpoints include proper error handling and response schemas

### Observation Recording Improvements
- **`createDefinitions: false` support**: When `createDefinitions` is false, observations now fall back to slug-based lookup of existing metrics instead of failing. This allows LLM-proposed metrics to attach to user-curated definitions.
- **New `resolveDefinitionBySlug()` helper**: Extracted common slug lookup logic for reuse in both observation paths
- **LLM ingestion behavior change**: Changed from `createDefinitions: true` to `false` with warning logging for skipped observations referencing unknown metrics

### Schema & Client Updates
- **New request/response schemas**: `UpdateMetricDefinitionRequest/Response` and `DeleteMetricDefinitionRequest/Response` with proper validation
- **SDK methods**: Added `updateMetricDefinition()` and `deleteMetricDefinition()` to `MemoryClient`

### Query Optimization
- **`listMetrics()` refactoring**: Uses `selectDistinctOn()` with database-level ordering instead of in-memory deduplication, leveraging the existing index for better performance

### Testing
- Added comprehensive tests for `createDefinitions: false` behavior with slug matching
- Added schema validation tests for update/delete requests
- Updated test mocks to support new database query patterns

https://claude.ai/code/session_013jPCp9xTD4Bd8ogS8xxXi4