### PR TITLE
Handle malformed OpenAI API responses in conversation summarization

### DIFF
--- a/src/lib/ai.test.ts
+++ b/src/lib/ai.test.ts
@@ -1,0 +1,91 @@
+import {
+  MalformedUpstreamCompletionError,
+  parseStructuredCompletion,
+} from "./ai";
+import type OpenAI from "openai";
+import { describe, expect, it } from "vitest";
+
+function buildClient(parseImpl: () => Promise<unknown>): OpenAI {
+  return {
+    beta: {
+      chat: {
+        completions: {
+          parse: parseImpl,
+        },
+      },
+    },
+  } as unknown as OpenAI;
+}
+
+describe("parseStructuredCompletion", () => {
+  it("returns the SDK's parsed completion on success", async () => {
+    const expected = { choices: [{ message: { parsed: { ok: true } } }] };
+    const client = buildClient(async () => expected);
+
+    const result = await parseStructuredCompletion(client, {
+      messages: [{ role: "user", content: "hi" }],
+      model: "test",
+    });
+
+    expect(result).toBe(expected);
+  });
+
+  it("normalizes the SDK's missing-choices TypeError into MalformedUpstreamCompletionError", async () => {
+    // Replicate the exact error the SDK throws when `completion.choices`
+    // is undefined (e.g. provider returned an error envelope without the
+    // OpenAI shape). The detector inspects message + stack, so both must
+    // match production conditions.
+    const err = new TypeError(
+      "Cannot read properties of undefined (reading 'map')",
+    );
+    err.stack =
+      "TypeError: Cannot read properties of undefined (reading 'map')\n" +
+      "    at parseChatCompletion (file:///app/node_modules/openai/lib/parser.mjs:75:40)\n" +
+      "    at Completions.parse (file:///app/node_modules/openai/resources/beta/chat/completions.mjs:22:42)";
+    const client = buildClient(async () => {
+      throw err;
+    });
+
+    await expect(
+      parseStructuredCompletion(client, {
+        messages: [{ role: "user", content: "hi" }],
+        model: "test",
+      }),
+    ).rejects.toBeInstanceOf(MalformedUpstreamCompletionError);
+  });
+
+  it("passes unrelated errors through unchanged", async () => {
+    const sentinel = new Error("rate limited");
+    const client = buildClient(async () => {
+      throw sentinel;
+    });
+
+    await expect(
+      parseStructuredCompletion(client, {
+        messages: [{ role: "user", content: "hi" }],
+        model: "test",
+      }),
+    ).rejects.toBe(sentinel);
+  });
+
+  it("passes through TypeErrors that did not originate in parseChatCompletion", async () => {
+    // A different `.map` TypeError from elsewhere in the code path should
+    // not be misclassified as a malformed upstream response.
+    const err = new TypeError(
+      "Cannot read properties of undefined (reading 'map')",
+    );
+    err.stack =
+      "TypeError: Cannot read properties of undefined (reading 'map')\n" +
+      "    at someOtherFunction (file:///app/foo.mjs:1:1)";
+    const client = buildClient(async () => {
+      throw err;
+    });
+
+    await expect(
+      parseStructuredCompletion(client, {
+        messages: [{ role: "user", content: "hi" }],
+        model: "test",
+      }),
+    ).rejects.toBe(err);
+  });
+});

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,11 +1,58 @@
 import type OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod.mjs";
-import {
+import type {
+  ChatCompletionCreateParamsNonStreaming,
   ChatCompletionSystemMessageParam,
   ChatCompletionUserMessageParam,
 } from "openai/resources.mjs";
 import { z } from "zod";
 import { getExtractionClientOverride } from "~/utils/test-overrides";
+
+/**
+ * Thrown when the upstream completion response is missing the standard
+ * OpenAI envelope (no `choices` field). The OpenAI SDK's parser blows up
+ * on this with a cryptic `TypeError: Cannot read properties of undefined
+ * (reading 'map')`; we normalize it here so callers can decide whether to
+ * retry, surface, or drop. Most commonly seen with custom-baseURL providers
+ * returning error envelopes, empty bodies, or rate-limit JSON wrapped as 200.
+ */
+export class MalformedUpstreamCompletionError extends Error {
+  override readonly name = "MalformedUpstreamCompletionError";
+  constructor(options?: { cause?: unknown }) {
+    super(
+      "Upstream completion response was missing the `choices` field — likely a transient upstream issue.",
+      options,
+    );
+  }
+}
+
+function isMalformedUpstreamCompletion(err: unknown): boolean {
+  return (
+    err instanceof TypeError &&
+    err.message.includes("reading 'map'") &&
+    typeof err.stack === "string" &&
+    err.stack.includes("parseChatCompletion")
+  );
+}
+
+/**
+ * Wrapper around `client.beta.chat.completions.parse` that normalizes the
+ * SDK's malformed-response `TypeError` into {@link MalformedUpstreamCompletionError}.
+ * Signature mirrors the SDK so call sites preserve full type inference on
+ * the parsed payload.
+ */
+export async function parseStructuredCompletion<
+  Body extends ChatCompletionCreateParamsNonStreaming,
+>(client: OpenAI, body: Body) {
+  try {
+    return await client.beta.chat.completions.parse(body);
+  } catch (err) {
+    if (isMalformedUpstreamCompletion(err)) {
+      throw new MalformedUpstreamCompletionError({ cause: err });
+    }
+    throw err;
+  }
+}
 
 export async function createCompletionClient(userId: string): Promise<OpenAI> {
   const override = getExtractionClientOverride();
@@ -72,7 +119,7 @@ export async function performStructuredAnalysis({
   if (!schema.description) throw new Error("Schema must have a description");
 
   const client = await createCompletionClient(userId);
-  const completion = await client.beta.chat.completions.parse({
+  const completion = await parseStructuredCompletion(client, {
     messages: [
       ...(systemPrompt
         ? [

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -1,3 +1,4 @@
+import { parseStructuredCompletion } from "./ai";
 import { createAlias, normalizeAliasText } from "./alias";
 import { applyClaimLifecycle, fetchClaimsByIds } from "./claims/lifecycle";
 import { debugGraph } from "./debug-utils";
@@ -385,7 +386,7 @@ ${
     : `Focus on extracting the most significant and meaningful information that the USER provided. Quality and accuracy are more important than quantity.`
 }`;
 
-  const completion = await client.beta.chat.completions.parse({
+  const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
     model: env.MODEL_ID_GRAPH_EXTRACTION,
     response_format: zodResponseFormat(llmExtractionSchema, "subgraph"),

--- a/src/lib/ingestion/extract-document-spine.ts
+++ b/src/lib/ingestion/extract-document-spine.ts
@@ -32,7 +32,9 @@ export async function extractDocumentSpine(params: {
   const { userId, content } = params;
   const condensed = condenseForSpine(content);
 
-  const { createCompletionClient } = await import("~/lib/ai");
+  const { createCompletionClient, parseStructuredCompletion } = await import(
+    "~/lib/ai"
+  );
   const client = await createCompletionClient(userId);
 
   const prompt = `You are reading a document to summarize its high-level shape for a graph extractor.
@@ -52,7 +54,7 @@ Guidance:
 ${condensed}
 </document>`;
 
-  const completion = await client.beta.chat.completions.parse({
+  const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
     model: env.MODEL_ID_GRAPH_EXTRACTION,
     response_format: zodResponseFormat(documentSpineSchema, "document_spine"),

--- a/src/lib/jobs/cleanup-graph.ts
+++ b/src/lib/jobs/cleanup-graph.ts
@@ -10,7 +10,7 @@
  * Common aliases: cleanup-graph, proposeGraphCleanup, buildCleanupPrompt,
  * cleanup pipeline, cleanup prompt builder.
  */
-import { createCompletionClient } from "../ai";
+import { createCompletionClient, parseStructuredCompletion } from "../ai";
 import { getConversationBootstrapContext } from "../context/assemble-bootstrap-context";
 import type { ContextBundle } from "../context/types";
 import { generateAndInsertNodeEmbeddings } from "../embeddings-util";
@@ -641,7 +641,7 @@ export async function proposeGraphCleanup(
 
   const prompt = buildCleanupPrompt(temp, bundle);
 
-  const completion = await client.beta.chat.completions.parse({
+  const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
     model: modelId,
     response_format: zodResponseFormat(

--- a/src/lib/jobs/summarize-conversation.ts
+++ b/src/lib/jobs/summarize-conversation.ts
@@ -167,6 +167,24 @@ ${formatConversationAsXml(turns)}
 
       summarizedCount++;
     } catch (error) {
+      // The OpenAI SDK's parseChatCompletion crashes with
+      // `TypeError: Cannot read properties of undefined (reading 'map')`
+      // when the upstream API returns a response without a `choices` field
+      // (e.g. an error envelope from a custom baseURL provider, an empty
+      // body, or a rate-limit response wrapped as 200). Treat this as a
+      // transient upstream issue: leave the source untouched so the next
+      // batch retries it instead of permanently marking it failed.
+      if (
+        error instanceof TypeError &&
+        error.message.includes("reading 'map'") &&
+        typeof error.stack === "string" &&
+        error.stack.includes("parseChatCompletion")
+      ) {
+        console.warn(
+          `Summarize - upstream returned malformed completion for source ${sourceId}; leaving for retry on next batch`,
+        );
+        continue;
+      }
       console.error(`Error summarizing source ${sourceId}:`, error);
       await db
         .update(sources)

--- a/src/lib/jobs/summarize-conversation.ts
+++ b/src/lib/jobs/summarize-conversation.ts
@@ -54,7 +54,11 @@ export async function summarizeUserConversations(
   }
 
   let summarizedCount = 0;
-  const { createCompletionClient } = await import("../ai");
+  const {
+    createCompletionClient,
+    MalformedUpstreamCompletionError,
+    parseStructuredCompletion,
+  } = await import("../ai");
   const client = await createCompletionClient(userId);
 
   for (const { sourceId, conversationNodeId } of convsToSummarize) {
@@ -112,7 +116,7 @@ ${formatConversationAsXml(turns)}
 
     debug(`Summarize - prompt for source ${sourceId}:`, prompt);
     try {
-      const completion = await client.beta.chat.completions.parse({
+      const completion = await parseStructuredCompletion(client, {
         messages: [{ role: "user", content: prompt }],
         model: env.MODEL_ID_GRAPH_EXTRACTION,
         response_format: zodResponseFormat(
@@ -167,19 +171,10 @@ ${formatConversationAsXml(turns)}
 
       summarizedCount++;
     } catch (error) {
-      // The OpenAI SDK's parseChatCompletion crashes with
-      // `TypeError: Cannot read properties of undefined (reading 'map')`
-      // when the upstream API returns a response without a `choices` field
-      // (e.g. an error envelope from a custom baseURL provider, an empty
-      // body, or a rate-limit response wrapped as 200). Treat this as a
-      // transient upstream issue: leave the source untouched so the next
-      // batch retries it instead of permanently marking it failed.
-      if (
-        error instanceof TypeError &&
-        error.message.includes("reading 'map'") &&
-        typeof error.stack === "string" &&
-        error.stack.includes("parseChatCompletion")
-      ) {
+      // Transient upstream issue (provider returned a non-OpenAI envelope):
+      // leave the source untouched so the next batch retries it instead of
+      // permanently marking it failed.
+      if (error instanceof MalformedUpstreamCompletionError) {
         console.warn(
           `Summarize - upstream returned malformed completion for source ${sourceId}; leaving for retry on next batch`,
         );

--- a/src/lib/transcript/segment-transcript.ts
+++ b/src/lib/transcript/segment-transcript.ts
@@ -11,7 +11,7 @@
  */
 import { zodResponseFormat } from "openai/helpers/zod.mjs";
 import { z } from "zod";
-import { createCompletionClient } from "~/lib/ai";
+import { createCompletionClient, parseStructuredCompletion } from "~/lib/ai";
 import { env } from "~/utils/env";
 
 export const segmentedUtteranceSchema = z.object({
@@ -80,7 +80,7 @@ The transcript was recorded around ${occurredAt.toISOString()}. If individual ut
 ${rawContent}
 </transcript>`;
 
-    const completion = await client.beta.chat.completions.parse({
+    const completion = await parseStructuredCompletion(client, {
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: prompt },


### PR DESCRIPTION
## Summary
Added error handling for malformed API responses from OpenAI's chat completion endpoint that cause the SDK's `parseChatCompletion` function to crash with a `TypeError`.

## Key Changes
- Added specific error detection for `TypeError` exceptions from `parseChatCompletion` that occur when the upstream API returns responses without a `choices` field
- When this error is detected, the source is left untouched instead of being marked as failed, allowing it to be retried in the next batch
- Added a warning log message to indicate when this transient upstream issue occurs

## Implementation Details
The fix targets a specific failure mode where custom baseURL providers, empty response bodies, or rate-limit responses wrapped as HTTP 200 cause the OpenAI SDK to crash. Rather than permanently failing the source, the code now:
1. Checks if the error is a `TypeError` with "reading 'map'" in the message
2. Verifies the error originated from `parseChatCompletion` via stack trace inspection
3. Logs a warning and continues to the next source, leaving the current source for retry
4. Falls through to the existing error handling for other error types

https://claude.ai/code/session_01HD2CNfp2RtkMVrUeWb6qhn