### PR TITLE
Add structured error handling for missing nodes in claims

### DIFF
--- a/src/lib/claim.ts
+++ b/src/lib/claim.ts
@@ -45,6 +45,26 @@ export class InvalidObjectValueError extends Error {
   }
 }
 
+/**
+ * Thrown when a claim references node ids that either don't exist or aren't
+ * owned by the asserting `userId`. Carries the exact set of missing ids so
+ * route handlers can surface a structured response instead of a string-match
+ * over the message, and callers (including the assistant) can see which
+ * subject/object they got wrong rather than retrying blindly.
+ */
+export class NodesNotFoundError extends Error {
+  readonly userId: string;
+  readonly missingNodeIds: ReadonlyArray<TypeId<"node">>;
+  constructor(userId: string, missingNodeIds: ReadonlyArray<TypeId<"node">>) {
+    super(
+      `Nodes not found or not owned by user ${userId}: ${missingNodeIds.join(", ")}`,
+    );
+    this.name = "NodesNotFoundError";
+    this.userId = userId;
+    this.missingNodeIds = missingNodeIds;
+  }
+}
+
 export type CreatedClaim = ClaimSelect & {
   subjectLabel: string | null;
   objectLabel: string | null;
@@ -108,7 +128,9 @@ async function fetchOwnedNodeLabels(
     .where(and(eq(nodes.userId, userId), inArray(nodes.id, uniqueNodeIds)));
 
   if (found.length !== uniqueNodeIds.length) {
-    throw new Error("One or more nodes not found");
+    const foundIds = new Set(found.map((node) => node.id));
+    const missing = uniqueNodeIds.filter((id) => !foundIds.has(id));
+    throw new NodesNotFoundError(userId, missing);
   }
 
   return new Map(found.map((node) => [node.id, node.label ?? null]));

--- a/src/routes/claim/create.post.ts
+++ b/src/routes/claim/create.post.ts
@@ -1,5 +1,9 @@
 import { defineEventHandler, createError } from "h3";
-import { createClaim, InvalidObjectValueError } from "~/lib/claim";
+import {
+  createClaim,
+  InvalidObjectValueError,
+  NodesNotFoundError,
+} from "~/lib/claim";
 import {
   createClaimRequestSchema,
   createClaimResponseSchema,
@@ -23,8 +27,16 @@ export default defineEventHandler(async (event) => {
         },
       });
     }
-    if (e instanceof Error && e.message.includes("not found")) {
-      throw createError({ statusCode: 404, statusMessage: e.message });
+    if (e instanceof NodesNotFoundError) {
+      throw createError({
+        statusCode: 422,
+        statusMessage: e.message,
+        data: {
+          name: e.name,
+          userId: e.userId,
+          missingNodeIds: e.missingNodeIds,
+        },
+      });
     }
     throw e;
   }

--- a/src/routes/node/create.post.ts
+++ b/src/routes/node/create.post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, createError } from "h3";
-import { InvalidObjectValueError } from "~/lib/claim";
+import { InvalidObjectValueError, NodesNotFoundError } from "~/lib/claim";
 import { createNode } from "~/lib/node";
 import {
   createNodeRequestSchema,
@@ -28,6 +28,17 @@ export default defineEventHandler(async (event) => {
           predicate: e.predicate,
           objectValue: e.objectValue,
           allowedValues: e.allowedValues,
+        },
+      });
+    }
+    if (e instanceof NodesNotFoundError) {
+      throw createError({
+        statusCode: 422,
+        statusMessage: e.message,
+        data: {
+          name: e.name,
+          userId: e.userId,
+          missingNodeIds: e.missingNodeIds,
         },
       });
     }


### PR DESCRIPTION
## Summary
Introduces a new `NodesNotFoundError` exception class to provide structured error information when claims reference non-existent or unowned nodes, replacing generic error messages with detailed, machine-readable responses.

## Key Changes
- **New Error Class**: Added `NodesNotFoundError` in `src/lib/claim.ts` that carries:
  - `userId`: The user attempting the operation
  - `missingNodeIds`: Array of node IDs that were not found or not owned by the user
  - Descriptive error message for logging/debugging

- **Enhanced Node Validation**: Updated `fetchOwnedNodeLabels()` to:
  - Calculate which specific node IDs are missing
  - Throw `NodesNotFoundError` with the missing IDs instead of a generic error message

- **Structured API Responses**: Updated error handlers in both route handlers to:
  - Catch `NodesNotFoundError` specifically (replacing generic message matching)
  - Return HTTP 422 (Unprocessable Entity) with structured error data
  - Include error name, userId, and missingNodeIds in response body
  - Applied to both `src/routes/claim/create.post.ts` and `src/routes/node/create.post.ts`

## Implementation Details
- The error class follows the existing pattern of `InvalidObjectValueError`
- Route handlers can now provide precise feedback to clients about which nodes failed validation
- Enables assistants and callers to identify exactly which subject/object references were incorrect, improving UX over blind retries

https://claude.ai/code/session_013kYTTwz5aEbxfpY4szYHoj