### PR TITLE
Add getMetricSummaries: batch metric summaries for digest/dashboard movers

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Read paths:
 - `POST /metrics/list` returns definitions with units, review state, and lightweight stats.
 - `POST /metrics/series` returns raw or bucketed points for one or more metric definitions.
 - `POST /metrics/summary` returns latest value, 7d/30d/90d stats, and a coarse trend.
+- `POST /metrics/summaries` returns that same per-metric shape for many metrics in one round-trip (omit `metricIds` for all, optionally filtered) — for "metric movers" digests/dashboards without an N+1 fan-out.
 
 New definitions are deduplicated by exact slug first, then definition embedding similarity. Near-duplicate definitions are created with `needsReview: true` and surfaced as normal open Task commitments.
 

--- a/src/lib/metrics/summaries.test.ts
+++ b/src/lib/metrics/summaries.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+import { getMetricSummariesRequestSchema } from "~/lib/schemas/metric-read";
+import { newTypeId } from "~/types/typeid";
+
+type QueryResult = ReadonlyArray<unknown>;
+
+class FakeQuery {
+  constructor(private readonly result: QueryResult) {}
+
+  from(): FakeQuery {
+    return this;
+  }
+
+  where(): FakeQuery {
+    return this;
+  }
+
+  orderBy(): FakeQuery {
+    return this;
+  }
+
+  groupBy(): FakeQuery {
+    return this;
+  }
+
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.result).then(onfulfilled, onrejected);
+  }
+}
+
+// The vectorized reader issues queries in a fixed order regardless of the
+// metric count: definitions, latest (DISTINCT ON), then 7d / 30d / 90d windows.
+function fakeDatabase(results: QueryResult[]) {
+  let index = 0;
+  const next = () => {
+    const result = results[index] ?? [];
+    index += 1;
+    return new FakeQuery(result);
+  };
+  return {
+    select: next,
+    selectDistinctOn: next,
+  };
+}
+
+describe("getMetricSummariesRequestSchema", () => {
+  it("rejects an empty metricIds array", () => {
+    expect(() =>
+      getMetricSummariesRequestSchema.parse({
+        userId: "user_metrics",
+        metricIds: [],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts an omitted metricIds with a filter", () => {
+    expect(() =>
+      getMetricSummariesRequestSchema.parse({
+        userId: "user_metrics",
+        filter: { active: true },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("getMetricSummaries", () => {
+  it("vectorizes explicit metricIds, keeps order, and nulls unknown ids", async () => {
+    const idA = newTypeId("metric_definition");
+    const unknownId = newTypeId("metric_definition");
+    const idB = newTypeId("metric_definition");
+    const latestA = new Date("2026-05-03T07:30:00.000Z");
+    const latestB = new Date("2026-05-02T07:30:00.000Z");
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({
+      useDatabase: async () =>
+        fakeDatabase([
+          // definitions (unknownId is absent — not owned by the user)
+          [
+            { id: idA, aggregationHint: "avg" },
+            { id: idB, aggregationHint: "sum" },
+          ],
+          // latest (DISTINCT ON) — one row per metric with data
+          [
+            { metricDefinitionId: idA, value: "78.4", occurredAt: latestA },
+            { metricDefinitionId: idB, value: "1200", occurredAt: latestB },
+          ],
+          // 7d windows
+          [
+            {
+              metricDefinitionId: idA,
+              count: 2,
+              avg: "78.2",
+              min: "78.0",
+              max: "78.4",
+              sum: "156.4",
+            },
+            {
+              metricDefinitionId: idB,
+              count: 1,
+              avg: "1200",
+              min: "1200",
+              max: "1200",
+              sum: "1200",
+            },
+          ],
+          // 30d windows
+          [
+            {
+              metricDefinitionId: idA,
+              count: 3,
+              avg: "78.1",
+              min: "77.9",
+              max: "78.4",
+              sum: "234.3",
+            },
+            {
+              metricDefinitionId: idB,
+              count: 5,
+              avg: "1000",
+              min: "800",
+              max: "1200",
+              sum: "5000",
+            },
+          ],
+          // 90d windows
+          [
+            {
+              metricDefinitionId: idA,
+              count: 4,
+              avg: "78.0",
+              min: "77.6",
+              max: "78.4",
+              sum: "312.0",
+            },
+            {
+              metricDefinitionId: idB,
+              count: 10,
+              avg: "900",
+              min: "700",
+              max: "1200",
+              sum: "9000",
+            },
+          ],
+        ]),
+    }));
+
+    const { getMetricSummaries } = await import("./summary");
+    const result = await getMetricSummaries({
+      userId: "user_metrics",
+      // Deliberately out of label order, with an unknown id in the middle.
+      metricIds: [idB, unknownId, idA],
+    });
+
+    expect(result.summaries).toEqual([
+      {
+        metricId: idB,
+        latest: { value: 1200, occurredAt: latestB },
+        windows: {
+          "7d": { count: 1, avg: 1200, min: 1200, max: 1200 },
+          "30d": { count: 5, avg: 1000, min: 800, max: 1200 },
+          "90d": { count: 10, avg: 900, min: 700, max: 1200 },
+        },
+        // sum-hinted: 30d sum 5000 vs 90d sum 9000 → down
+        trend: "down",
+      },
+      {
+        metricId: unknownId,
+        latest: null,
+        windows: { "7d": null, "30d": null, "90d": null },
+        trend: null,
+      },
+      {
+        metricId: idA,
+        latest: { value: 78.4, occurredAt: latestA },
+        windows: {
+          "7d": { count: 2, avg: 78.2, min: 78, max: 78.4 },
+          "30d": { count: 3, avg: 78.1, min: 77.9, max: 78.4 },
+          "90d": { count: 4, avg: 78, min: 77.6, max: 78.4 },
+        },
+        // avg-hinted: 30d avg 78.1 vs 90d avg 78.0 → within 1% → flat
+        trend: "flat",
+      },
+    ]);
+  });
+
+  it("drops dataless metrics when filtering to active and no ids are given", async () => {
+    const activeId = newTypeId("metric_definition");
+    const dormantId = newTypeId("metric_definition");
+    const latestAt = new Date("2026-05-03T07:30:00.000Z");
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({
+      useDatabase: async () =>
+        fakeDatabase([
+          // definitions, already ordered by (label, slug)
+          [
+            { id: activeId, aggregationHint: "avg" },
+            { id: dormantId, aggregationHint: "avg" },
+          ],
+          // latest — only the active metric has an observation
+          [
+            {
+              metricDefinitionId: activeId,
+              value: "78.4",
+              occurredAt: latestAt,
+            },
+          ],
+          // 7d / 30d / 90d windows — only the active metric appears
+          [
+            {
+              metricDefinitionId: activeId,
+              count: 1,
+              avg: "78.4",
+              min: "78.4",
+              max: "78.4",
+              sum: "78.4",
+            },
+          ],
+          [
+            {
+              metricDefinitionId: activeId,
+              count: 1,
+              avg: "78.4",
+              min: "78.4",
+              max: "78.4",
+              sum: "78.4",
+            },
+          ],
+          [
+            {
+              metricDefinitionId: activeId,
+              count: 1,
+              avg: "78.4",
+              min: "78.4",
+              max: "78.4",
+              sum: "78.4",
+            },
+          ],
+        ]),
+    }));
+
+    const { getMetricSummaries } = await import("./summary");
+    const result = await getMetricSummaries({
+      userId: "user_metrics",
+      filter: { active: true },
+    });
+
+    expect(result.summaries.map((summary) => summary.metricId)).toEqual([
+      activeId,
+    ]);
+  });
+
+  it("returns null-filled summaries when none of the requested ids exist", async () => {
+    const missingId = newTypeId("metric_definition");
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({
+      useDatabase: async () => fakeDatabase([[]]),
+    }));
+
+    const { getMetricSummaries } = await import("./summary");
+    await expect(
+      getMetricSummaries({
+        userId: "user_metrics",
+        metricIds: [missingId],
+      }),
+    ).resolves.toEqual({
+      summaries: [
+        {
+          metricId: missingId,
+          latest: null,
+          windows: { "7d": null, "30d": null, "90d": null },
+          trend: null,
+        },
+      ],
+    });
+  });
+});

--- a/src/lib/metrics/summary.ts
+++ b/src/lib/metrics/summary.ts
@@ -238,6 +238,16 @@ export async function getMetricSummaries({
     };
   }
 
+  // When summarizing every metric (no explicit ids and no needsReview filter)
+  // the candidate set IS all of the user's definitions, so `userId` alone
+  // already scopes the observation reads — pass the (potentially large) id
+  // array to `inArray` only when it actually narrows, to avoid the planner
+  // overhead and bind-parameter limit of a redundant IN list.
+  const definitionScope =
+    metricIds !== undefined || filter?.needsReview !== undefined
+      ? inArray(metricObservations.metricDefinitionId, definitionIds)
+      : undefined;
+
   // DISTINCT ON pulls the freshest observation per metric in one pass, using
   // the (user_id, metric_definition_id, occurred_at DESC) index.
   const latestRows = await db
@@ -247,12 +257,7 @@ export async function getMetricSummaries({
       occurredAt: metricObservations.occurredAt,
     })
     .from(metricObservations)
-    .where(
-      and(
-        eq(metricObservations.userId, userId),
-        inArray(metricObservations.metricDefinitionId, definitionIds),
-      ),
-    )
+    .where(and(eq(metricObservations.userId, userId), definitionScope))
     .orderBy(
       metricObservations.metricDefinitionId,
       desc(metricObservations.occurredAt),
@@ -274,7 +279,7 @@ export async function getMetricSummaries({
       .where(
         and(
           eq(metricObservations.userId, userId),
-          inArray(metricObservations.metricDefinitionId, definitionIds),
+          definitionScope,
           sql`${metricObservations.occurredAt} >= ${since}`,
         ),
       )

--- a/src/lib/metrics/summary.ts
+++ b/src/lib/metrics/summary.ts
@@ -1,11 +1,14 @@
-/** Single-metric summary reads. Common aliases: metric latest, metric rollup. */
-import { and, eq, sql } from "drizzle-orm";
+/** Metric summary reads. Common aliases: metric latest, metric rollup, movers. */
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { metricDefinitions, metricObservations } from "~/db/schema";
 import {
+  type GetMetricSummariesRequest,
+  type GetMetricSummariesResponse,
   type GetMetricSummaryRequest,
   type GetMetricSummaryResponse,
 } from "~/lib/schemas/metric-read";
 import type { MetricAggregationHint } from "~/lib/schemas/metric-write";
+import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
 interface SummaryWindow {
@@ -65,6 +68,28 @@ function compareTrend(
   return delta > 0 ? "up" : "down";
 }
 
+/** Summary for a metric with no resolvable definition or no observations. */
+function emptySummary(
+  metricId: TypeId<"metric_definition">,
+): GetMetricSummaryResponse {
+  return {
+    metricId,
+    latest: null,
+    windows: { "7d": null, "30d": null, "90d": null },
+    trend: null,
+  };
+}
+
+/** Start of each rollup window, relative to `now`. */
+function windowStarts(now: Date) {
+  const day = 24 * 60 * 60 * 1000;
+  return {
+    "7d": new Date(now.getTime() - 7 * day),
+    "30d": new Date(now.getTime() - 30 * day),
+    "90d": new Date(now.getTime() - 90 * day),
+  };
+}
+
 /** Return latest reading, 7d/30d/90d stats, and coarse trend for one metric. */
 export async function getMetricSummary({
   userId,
@@ -86,16 +111,7 @@ export async function getMetricSummary({
     .limit(1);
 
   if (definition === undefined) {
-    return {
-      metricId,
-      latest: null,
-      windows: {
-        "7d": null,
-        "30d": null,
-        "90d": null,
-      },
-      trend: null,
-    };
+    return emptySummary(metricId);
   }
 
   const [latestRow] = await db
@@ -113,10 +129,7 @@ export async function getMetricSummary({
     .orderBy(sql`${metricObservations.occurredAt} DESC`)
     .limit(1);
 
-  const now = new Date();
-  const last7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-  const last30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const last90d = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+  const starts = windowStarts(new Date());
 
   const readWindow = async (since: Date): Promise<SummaryWindow | null> => {
     const [row] = await db
@@ -147,9 +160,9 @@ export async function getMetricSummary({
   };
 
   const [last7dWindow, last30dWindow, last90dWindow] = await Promise.all([
-    readWindow(last7d),
-    readWindow(last30d),
-    readWindow(last90d),
+    readWindow(starts["7d"]),
+    readWindow(starts["30d"]),
+    readWindow(starts["90d"]),
   ]);
 
   return {
@@ -167,6 +180,161 @@ export async function getMetricSummary({
       last30dWindow,
       last90dWindow,
       definition.aggregationHint,
+    ),
+  };
+}
+
+type MetricId = TypeId<"metric_definition">;
+
+/**
+ * Vectorized {@link getMetricSummary}: latest reading, 7d/30d/90d stats, and a
+ * coarse trend for many metrics in a fixed number of queries (no per-metric
+ * fan-out). Powers "metric movers" dashboards/digests.
+ *
+ * - `metricIds` omitted → every metric the user owns, ordered by label then
+ *   slug, narrowed by `filter` (`active` = has any observation, `needsReview`).
+ * - `metricIds` provided → exactly those metrics, in request order, with a
+ *   null-filled summary for any id the user doesn't own (mirrors
+ *   `getMetricSeries`). `filter` is ignored in this case — the explicit list
+ *   is the selection.
+ */
+export async function getMetricSummaries({
+  userId,
+  metricIds,
+  filter,
+}: GetMetricSummariesRequest): Promise<GetMetricSummariesResponse> {
+  const db = await useDatabase();
+
+  const definitions = await db
+    .select({
+      id: metricDefinitions.id,
+      aggregationHint: metricDefinitions.aggregationHint,
+    })
+    .from(metricDefinitions)
+    .where(
+      and(
+        eq(metricDefinitions.userId, userId),
+        metricIds === undefined
+          ? undefined
+          : inArray(metricDefinitions.id, metricIds),
+        // Definition-level filters only apply to the "summarize all" mode.
+        metricIds === undefined && filter?.needsReview !== undefined
+          ? eq(metricDefinitions.needsReview, filter.needsReview)
+          : undefined,
+      ),
+    )
+    .orderBy(asc(metricDefinitions.label), asc(metricDefinitions.slug));
+
+  const hintById = new Map<MetricId, MetricAggregationHint>(
+    definitions.map((definition) => [
+      definition.id,
+      definition.aggregationHint,
+    ]),
+  );
+  const definitionIds = definitions.map((definition) => definition.id);
+  if (definitionIds.length === 0) {
+    return {
+      summaries: (metricIds ?? []).map((metricId) => emptySummary(metricId)),
+    };
+  }
+
+  // DISTINCT ON pulls the freshest observation per metric in one pass, using
+  // the (user_id, metric_definition_id, occurred_at DESC) index.
+  const latestRows = await db
+    .selectDistinctOn([metricObservations.metricDefinitionId], {
+      metricDefinitionId: metricObservations.metricDefinitionId,
+      value: metricObservations.value,
+      occurredAt: metricObservations.occurredAt,
+    })
+    .from(metricObservations)
+    .where(
+      and(
+        eq(metricObservations.userId, userId),
+        inArray(metricObservations.metricDefinitionId, definitionIds),
+      ),
+    )
+    .orderBy(
+      metricObservations.metricDefinitionId,
+      desc(metricObservations.occurredAt),
+    );
+
+  const readWindow = async (
+    since: Date,
+  ): Promise<Map<MetricId, SummaryWindow>> => {
+    const rows = await db
+      .select({
+        metricDefinitionId: metricObservations.metricDefinitionId,
+        count: sql<number>`count(${metricObservations.id})`,
+        avg: sql<string | null>`avg(${metricObservations.value}::numeric)`,
+        min: sql<string | null>`min(${metricObservations.value}::numeric)`,
+        max: sql<string | null>`max(${metricObservations.value}::numeric)`,
+        sum: sql<string | null>`sum(${metricObservations.value}::numeric)`,
+      })
+      .from(metricObservations)
+      .where(
+        and(
+          eq(metricObservations.userId, userId),
+          inArray(metricObservations.metricDefinitionId, definitionIds),
+          sql`${metricObservations.occurredAt} >= ${since}`,
+        ),
+      )
+      .groupBy(metricObservations.metricDefinitionId);
+
+    return new Map(
+      rows.map((row) => [
+        row.metricDefinitionId,
+        {
+          count: Number(row.count),
+          avg: numberOrNull(row.avg) ?? 0,
+          min: numberOrNull(row.min) ?? 0,
+          max: numberOrNull(row.max) ?? 0,
+          sum: numberOrNull(row.sum) ?? 0,
+        },
+      ]),
+    );
+  };
+
+  const latestById = new Map(
+    latestRows.map((row) => [row.metricDefinitionId, row]),
+  );
+  const starts = windowStarts(new Date());
+  const [win7, win30, win90] = await Promise.all([
+    readWindow(starts["7d"]),
+    readWindow(starts["30d"]),
+    readWindow(starts["90d"]),
+  ]);
+
+  const buildSummary = (metricId: MetricId): GetMetricSummaryResponse => {
+    const aggregationHint = hintById.get(metricId);
+    if (aggregationHint === undefined) return emptySummary(metricId);
+    const latest = latestById.get(metricId);
+    const w7 = win7.get(metricId) ?? null;
+    const w30 = win30.get(metricId) ?? null;
+    const w90 = win90.get(metricId) ?? null;
+    return {
+      metricId,
+      latest:
+        latest === undefined
+          ? null
+          : { value: Number(latest.value), occurredAt: latest.occurredAt },
+      windows: {
+        "7d": toPublicWindow(w7),
+        "30d": toPublicWindow(w30),
+        "90d": toPublicWindow(w90),
+      },
+      trend: compareTrend(w30, w90, aggregationHint),
+    };
+  };
+
+  if (metricIds !== undefined) {
+    return { summaries: metricIds.map(buildSummary) };
+  }
+
+  const summaries = definitionIds.map(buildSummary);
+  if (filter?.active === undefined) return { summaries };
+  return {
+    summaries: summaries.filter(
+      (summary) => filter.active === (summary.latest !== null),
     ),
   };
 }

--- a/src/lib/schemas/metric-read.ts
+++ b/src/lib/schemas/metric-read.ts
@@ -104,6 +104,27 @@ export const getMetricSummaryResponseSchema = z.object({
   trend: z.enum(["up", "down", "flat"]).nullable(),
 });
 
+export const getMetricSummariesRequestSchema = z.object({
+  userId: z.string().min(1),
+  // Explicit selection. Omit to summarize every (optionally filtered) metric.
+  metricIds: z
+    .array(typeIdSchema("metric_definition"))
+    .min(1)
+    .max(200)
+    .optional(),
+  // Consulted only when `metricIds` is omitted; see `getMetricSummaries`.
+  filter: z
+    .object({
+      active: z.boolean().optional(),
+      needsReview: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export const getMetricSummariesResponseSchema = z.object({
+  summaries: z.array(getMetricSummaryResponseSchema),
+});
+
 export type MetricDefinition = z.infer<typeof metricDefinitionSchema>;
 export type MetricDefinitionWithStats = z.infer<
   typeof metricDefinitionWithStatsSchema
@@ -125,4 +146,10 @@ export type GetMetricSummaryRequest = z.infer<
 >;
 export type GetMetricSummaryResponse = z.infer<
   typeof getMetricSummaryResponseSchema
+>;
+export type GetMetricSummariesRequest = z.infer<
+  typeof getMetricSummariesRequestSchema
+>;
+export type GetMetricSummariesResponse = z.infer<
+  typeof getMetricSummariesResponseSchema
 >;

--- a/src/routes/metrics/summaries.post.ts
+++ b/src/routes/metrics/summaries.post.ts
@@ -1,0 +1,12 @@
+import { getMetricSummaries } from "~/lib/metrics/summary";
+import {
+  getMetricSummariesRequestSchema,
+  getMetricSummariesResponseSchema,
+} from "~/lib/schemas/metric-read";
+
+export default defineEventHandler(async (event) => {
+  const params = getMetricSummariesRequestSchema.parse(await readBody(event));
+  return getMetricSummariesResponseSchema.parse(
+    await getMetricSummaries(params),
+  );
+});

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -68,11 +68,14 @@ import {
 import {
   GetMetricSeriesRequest,
   GetMetricSeriesResponse,
+  GetMetricSummariesRequest,
+  GetMetricSummariesResponse,
   GetMetricSummaryRequest,
   GetMetricSummaryResponse,
   ListMetricsRequest,
   ListMetricsResponse,
   getMetricSeriesResponseSchema,
+  getMetricSummariesResponseSchema,
   getMetricSummaryResponseSchema,
   listMetricsResponseSchema,
 } from "../lib/schemas/metric-read.js";
@@ -504,6 +507,27 @@ export class MemoryClient {
       "POST",
       "/metrics/summary",
       getMetricSummaryResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Batch `getMetricSummary`: latest value + 7d/30d/90d windows + coarse trend
+   * for many metrics in one round-trip, for "metric movers" digests and
+   * dashboards (no per-metric fan-out). Omit `metricIds` to summarize every
+   * metric (optionally narrowed by `filter.active`/`filter.needsReview`); pass
+   * `metricIds` to summarize exactly those, in request order, with a
+   * null-filled summary for any id the user doesn't own. When `metricIds` is
+   * provided, `filter` is ignored. The consumer derives direction from
+   * `latest` vs `windows["7d"].avg` (or the returned `trend`).
+   */
+  async getMetricSummaries(
+    payload: GetMetricSummariesRequest,
+  ): Promise<GetMetricSummariesResponse> {
+    return this._fetch(
+      "POST",
+      "/metrics/summaries",
+      getMetricSummariesResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## Summary

Adds a batch metric summary endpoint (proposal **A** from #40) so consumers can build a "metric movers" digest/dashboard in **one round-trip** instead of `1 × listMetrics + N × getMetricSummary`.

`getMetricSummaries` returns the same per-metric shape as `getMetricSummary` (`latest`, `windows.{7d,30d,90d}.{avg,min,max,count}`, `trend`), just vectorized.

## Surface

- `POST /metrics/summaries` → `{ summaries: GetMetricSummaryResponse[] }`
- `MemoryClient.getMetricSummaries(...)` SDK method
- `getMetricSummariesRequestSchema` / `getMetricSummariesResponseSchema` in `metric-read.ts` (auto-exported from the SDK index)

## Contract

- **Omit `metricIds`** → every metric the user owns, ordered by label then slug, narrowable via `filter.active` (has any observation) / `filter.needsReview`.
- **Pass `metricIds`** → exactly those, in request order, with a null-filled summary for any id the user doesn't own (mirrors `getMetricSeries`). `filter` is ignored in this mode since the explicit list is the selection.

Consumers derive direction from `latest` vs `windows["7d"].avg`, or use the returned `trend`.

## Efficiency

Fixed query count regardless of metric count: one definitions query, one `DISTINCT ON` latest query (reusing the existing `(user_id, metric_definition_id, occurred_at DESC)` index, same approach as `listMetrics`), and three grouped window aggregates. A 5–30 metric dashboard is ~5 DB queries, not 5N+1.

## Notes

- Refactored `getMetricSummary` to share the empty-summary and window-bound helpers; behavior unchanged (existing test still passes).
- Scoped to the SDK/HTTP/lib surface the issue targets. The MCP server doesn't get a parallel `get_metric_summaries` tool — that's a separate consumer surface and wasn't in the acceptance criteria. Easy to add later if wanted.

## Testing

- `tsc --noEmit`, ESLint, Prettier: clean
- New `summaries.test.ts` (schema validation, vectorized ordering + unknown-id nulling, `active` filtering, all-missing ids) + full metrics & SDK suites: 24 passed

Closes #40

https://claude.ai/code/session_01S2ZBbxqaDQdsgK7Ec4qWns

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2ZBbxqaDQdsgK7Ec4qWns)_