### PR TITLE
Add queryRecentChanges API for time-range memory feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The integration only works if these are true:
 - `POST /query/search` – vector search to retrieve relevant nodes.
 - `POST /commitments/open` – lifecycle-aware list of pending and in-progress tasks.
 - `POST /query/day` – get a quick summary of a particular day.
+- `POST /query/recent-changes` – "what's new in memory" feed over a time range: active claims and nodes added/updated since a `since` cursor, with labels and per-source provenance.
 - `GET /sse` and `POST /messages` – MCP over HTTP using Server‑Sent Events.
 
 ## Metrics

--- a/src/lib/query/recent-changes.test.ts
+++ b/src/lib/query/recent-changes.test.ts
@@ -1,0 +1,425 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+import { queryRecentChangesResponseSchema } from "~/lib/schemas/query-recent-changes";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+process.env["DATABASE_URL"] ??= adminDsn();
+process.env["JINA_API_KEY"] ??= "test";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("recent changes query", () => {
+  const dbName = `memory_recent_changes_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("returns active personal claims and nodes added/updated in the window with labels and provenance", async () => {
+    const userId = "user_recent_changes";
+
+    // Window under test: [SINCE, UNTIL].
+    const SINCE = "2026-05-20T00:00:00.000Z";
+    const UNTIL = "2026-05-29T00:00:00.000Z";
+
+    const personLena = newTypeId("node"); // added in window
+    const projectBook = newTypeId("node"); // old node, linked in window -> updated
+    const goalNode = newTypeId("node"); // old node, claim updated in window -> updated
+    const dayNode = newTypeId("node"); // Temporal, added in window -> excluded (structural)
+    const oldPerson = newTypeId("node"); // old node, only stale claims -> excluded
+    const refNode = newTypeId("node"); // old node, only a reference claim -> excluded
+
+    const srcConv = newTypeId("source");
+    const srcRef = newTypeId("source");
+
+    const claimAdded = newTypeId("claim");
+    const claimUpdated = newTypeId("claim");
+    const claimSuperseded = newTypeId("claim");
+    const claimReference = newTypeId("claim");
+    const claimOld = newTypeId("claim");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({
+      useDatabase: async () => database,
+    }));
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_metadata" (
+          "id" text PRIMARY KEY NOT NULL,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "label" text,
+          "canonical_label" text,
+          "description" text,
+          "additional_data" jsonb,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+        );
+        CREATE TABLE "sources" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "type" varchar(50) NOT NULL,
+          "external_id" text NOT NULL,
+          "parent_source" text,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "metadata" jsonb,
+          "last_ingested_at" timestamp with time zone,
+          "status" varchar(20) DEFAULT 'pending',
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "deleted_at" timestamp with time zone,
+          "content_type" varchar(100),
+          "content_length" integer
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_value" text,
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "description" text,
+          "metadata" jsonb,
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "asserted_by_kind" varchar(24) NOT NULL,
+          "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+          "superseded_by_claim_id" text,
+          "contradicted_by_claim_id" text,
+          "stated_at" timestamp with time zone NOT NULL,
+          "valid_from" timestamp with time zone,
+          "valid_to" timestamp with time zone,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+      `);
+
+      await database.insert(schema.users).values({ id: userId });
+
+      await database.insert(schema.sources).values([
+        {
+          id: srcConv,
+          userId,
+          type: "conversation",
+          externalId: "conv:1",
+          scope: "personal",
+          metadata: { title: "Coaching call" },
+          lastIngestedAt: new Date("2026-05-28T09:00:00.000Z"),
+          status: "completed",
+          createdAt: new Date("2026-05-28T08:00:00.000Z"),
+        },
+        {
+          id: srcRef,
+          userId,
+          type: "document",
+          externalId: "doc:1",
+          scope: "reference",
+          metadata: { title: "Reference doc" },
+          lastIngestedAt: new Date("2026-05-24T00:00:00.000Z"),
+          status: "completed",
+          createdAt: new Date("2026-05-24T00:00:00.000Z"),
+        },
+      ]);
+
+      await database.insert(schema.nodes).values([
+        {
+          id: personLena,
+          userId,
+          nodeType: "Person",
+          createdAt: new Date("2026-05-28T10:00:00.000Z"),
+        },
+        {
+          id: projectBook,
+          userId,
+          nodeType: "Object",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          id: goalNode,
+          userId,
+          nodeType: "Concept",
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+        {
+          id: dayNode,
+          userId,
+          nodeType: "Temporal",
+          createdAt: new Date("2026-05-28T00:00:00.000Z"),
+        },
+        {
+          id: oldPerson,
+          userId,
+          nodeType: "Person",
+          createdAt: new Date("2026-01-03T00:00:00.000Z"),
+        },
+        {
+          id: refNode,
+          userId,
+          nodeType: "Concept",
+          createdAt: new Date("2026-01-04T00:00:00.000Z"),
+        },
+      ]);
+
+      await database.insert(schema.nodeMetadata).values([
+        { id: newTypeId("node_metadata"), nodeId: personLena, label: "Lena" },
+        { id: newTypeId("node_metadata"), nodeId: projectBook, label: "Book" },
+        {
+          id: newTypeId("node_metadata"),
+          nodeId: goalNode,
+          label: "Draft goal",
+        },
+        {
+          id: newTypeId("node_metadata"),
+          nodeId: dayNode,
+          label: "2026-05-28",
+        },
+        {
+          id: newTypeId("node_metadata"),
+          nodeId: oldPerson,
+          label: "Old Person",
+        },
+        { id: newTypeId("node_metadata"), nodeId: refNode, label: "Ref node" },
+      ]);
+
+      await database.insert(schema.claims).values([
+        {
+          // Added in window; links existing project node.
+          id: claimAdded,
+          userId,
+          subjectNodeId: personLena,
+          objectNodeId: projectBook,
+          predicate: "RELATED_TO",
+          statement: "Lena is linked to the Book project.",
+          sourceId: srcConv,
+          scope: "personal",
+          assertedByKind: "user",
+          statedAt: new Date("2026-05-28T10:01:00.000Z"),
+          status: "active",
+          createdAt: new Date("2026-05-28T10:01:00.000Z"),
+          updatedAt: new Date("2026-05-28T10:01:00.000Z"),
+        },
+        {
+          // Created before the window, updated inside it (value claim).
+          id: claimUpdated,
+          userId,
+          subjectNodeId: goalNode,
+          objectValue: "finish draft by June 30",
+          predicate: "HAS_GOAL",
+          statement: "Goal: finish draft by June 30.",
+          sourceId: srcConv,
+          scope: "personal",
+          assertedByKind: "user",
+          statedAt: new Date("2026-01-05T00:00:00.000Z"),
+          status: "active",
+          createdAt: new Date("2026-01-05T00:00:00.000Z"),
+          updatedAt: new Date("2026-05-27T10:00:00.000Z"),
+        },
+        {
+          // In window but superseded -> excluded; must not "update" oldPerson.
+          id: claimSuperseded,
+          userId,
+          subjectNodeId: oldPerson,
+          objectNodeId: projectBook,
+          predicate: "RELATED_TO",
+          statement: "Old Person was linked to the Book project.",
+          sourceId: srcConv,
+          scope: "personal",
+          assertedByKind: "user",
+          statedAt: new Date("2026-05-26T00:00:00.000Z"),
+          status: "superseded",
+          createdAt: new Date("2026-05-26T00:00:00.000Z"),
+          updatedAt: new Date("2026-05-26T00:00:00.000Z"),
+        },
+        {
+          // In window but reference scope -> excluded; must not "update" refNode.
+          id: claimReference,
+          userId,
+          subjectNodeId: refNode,
+          objectValue: "reference value",
+          predicate: "RELATED_TO",
+          statement: "Reference material note.",
+          sourceId: srcRef,
+          scope: "reference",
+          assertedByKind: "document_author",
+          statedAt: new Date("2026-05-24T00:00:00.000Z"),
+          status: "active",
+          createdAt: new Date("2026-05-24T00:00:00.000Z"),
+          updatedAt: new Date("2026-05-24T00:00:00.000Z"),
+        },
+        {
+          // Entirely before the window -> excluded.
+          id: claimOld,
+          userId,
+          subjectNodeId: oldPerson,
+          objectValue: "old value",
+          predicate: "RELATED_TO",
+          statement: "Old Person had an old note.",
+          sourceId: srcConv,
+          scope: "personal",
+          assertedByKind: "user",
+          statedAt: new Date("2026-01-10T00:00:00.000Z"),
+          status: "active",
+          createdAt: new Date("2026-01-10T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-10T00:00:00.000Z"),
+        },
+      ]);
+
+      const { queryRecentChanges } = await import("./recent-changes");
+
+      // --- Default call over the window -----------------------------------
+      const parsed = queryRecentChangesResponseSchema.parse(
+        await queryRecentChanges({
+          userId,
+          since: SINCE,
+          until: UNTIL,
+          limit: 100,
+        }),
+      );
+
+      // Claims: only the active personal ones changed in the window, newest
+      // change first (added before the older updated claim).
+      expect(parsed.claims.map((c) => c.id)).toEqual([
+        claimAdded,
+        claimUpdated,
+      ]);
+      expect(parsed.claims[0]).toMatchObject({
+        id: claimAdded,
+        changeKind: "added",
+        predicate: "RELATED_TO",
+        subjectLabel: "Lena",
+        objectLabel: "Book",
+        sourceId: srcConv,
+        assertedByKind: "user",
+      });
+      expect(parsed.claims[1]).toMatchObject({
+        id: claimUpdated,
+        changeKind: "updated",
+        predicate: "HAS_GOAL",
+        // Attribute claims surface the literal objectValue as objectLabel.
+        objectLabel: "finish draft by June 30",
+      });
+
+      // Nodes: added (personLena) plus existing nodes touched in the window
+      // (projectBook, goalNode), newest change first. Structural day node and
+      // untouched/stale/reference-only nodes are excluded.
+      expect(
+        parsed.nodes.map((n) => ({ id: n.id, changeKind: n.changeKind })),
+      ).toEqual([
+        { id: projectBook, changeKind: "updated" },
+        { id: personLena, changeKind: "added" },
+        { id: goalNode, changeKind: "updated" },
+      ]);
+      const nodeIds = parsed.nodes.map((n) => n.id);
+      expect(nodeIds).not.toContain(dayNode);
+      expect(nodeIds).not.toContain(oldPerson);
+      expect(nodeIds).not.toContain(refNode);
+
+      // Labels are carried on the node rows — no N+1 getNode required.
+      expect(parsed.nodes.find((n) => n.id === personLena)?.label).toBe("Lena");
+
+      // Sources: distinct provenance behind the returned claims only.
+      expect(parsed.sources).toEqual([
+        expect.objectContaining({
+          sourceId: srcConv,
+          type: "conversation",
+          title: "Coaching call",
+        }),
+      ]);
+      expect(parsed.sources[0]?.timestamp.toISOString()).toBe(
+        "2026-05-28T09:00:00.000Z",
+      );
+
+      // --- nodeTypes filter narrows claims and nodes ----------------------
+      const filtered = queryRecentChangesResponseSchema.parse(
+        await queryRecentChanges({
+          userId,
+          since: SINCE,
+          until: UNTIL,
+          limit: 100,
+          nodeTypes: ["Person"],
+        }),
+      );
+      // Only the claim whose subject/object is a Person survives.
+      expect(filtered.claims.map((c) => c.id)).toEqual([claimAdded]);
+      // Only the Person node added in the window survives.
+      expect(filtered.nodes.map((n) => n.id)).toEqual([personLena]);
+      expect(filtered.nodes[0]).toMatchObject({
+        changeKind: "added",
+        nodeType: "Person",
+      });
+
+      // --- since > until is an empty range --------------------------------
+      await expect(
+        queryRecentChanges({
+          userId,
+          since: UNTIL,
+          until: SINCE,
+          limit: 100,
+        }),
+      ).resolves.toEqual({ claims: [], nodes: [], sources: [] });
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+});

--- a/src/lib/query/recent-changes.ts
+++ b/src/lib/query/recent-changes.ts
@@ -46,15 +46,22 @@ const STRUCTURAL_NODE_TYPES: readonly NodeType[] = [
  */
 const sourceTitleMetadataSchema = z
   .object({
-    title: z.string().min(1).optional(),
-    filename: z.string().min(1).optional(),
+    // Allow any string here and enforce non-empty in `deriveSourceTitle`: an
+    // empty `title` must not fail the whole parse and skip the `filename`
+    // fallback.
+    title: z.string().optional(),
+    filename: z.string().optional(),
   })
   .catchall(z.unknown());
 
 function deriveSourceTitle(metadata: unknown): string | null {
   const parsed = sourceTitleMetadataSchema.safeParse(metadata ?? {});
   if (!parsed.success) return null;
-  return parsed.data.title ?? parsed.data.filename ?? null;
+  const title = parsed.data.title?.trim();
+  if (title) return title;
+  const filename = parsed.data.filename?.trim();
+  if (filename) return filename;
+  return null;
 }
 
 function toTime(value: Date | string): number {
@@ -140,6 +147,10 @@ export async function queryRecentChanges(
       statedAt: claims.statedAt,
       createdAt: claims.createdAt,
       assertedByKind: claims.assertedByKind,
+      // Carried so updated-node candidates can be resolved in-memory below.
+      subjectNodeId: claims.subjectNodeId,
+      objectNodeId: claims.objectNodeId,
+      changedAt: claimChangedAt.as("changed_at"),
     })
     .from(claims)
     .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
@@ -191,37 +202,44 @@ export async function queryRecentChanges(
     .limit(limit);
 
   // --- Existing nodes touched by a claim in the window (updated) ----------
-  const lastClaimChange = sql<Date>`MAX(GREATEST(${claims.createdAt}, ${claims.updatedAt}))`;
+  // The claims above are capped at `limit`, so the set of nodes they touch is
+  // small. Resolve candidate node ids and their most recent change time
+  // in-memory, then look them up by primary key — this avoids a
+  // `subjectNodeId = id OR objectNodeId = id` join, which can't use either
+  // claim index efficiently in Postgres.
+  const nodeChanges = new Map<TypeId<"node">, Date>();
+  for (const row of claimRows) {
+    const changedAt = new Date(row.changedAt);
+    for (const nodeId of [row.subjectNodeId, row.objectNodeId]) {
+      if (!nodeId) continue;
+      const current = nodeChanges.get(nodeId);
+      if (!current || changedAt > current) nodeChanges.set(nodeId, changedAt);
+    }
+  }
+  const candidateNodeIds = Array.from(nodeChanges.keys());
 
-  const updatedNodeRows = await db
-    .select({
-      id: nodes.id,
-      nodeType: nodes.nodeType,
-      label: nodeMetadata.label,
-      firstSeenAt: nodes.createdAt,
-      changedAt: lastClaimChange.as("changed_at"),
-    })
-    .from(nodes)
-    .innerJoin(
-      claims,
-      and(
-        or(
-          eq(claims.subjectNodeId, nodes.id),
-          eq(claims.objectNodeId, nodes.id),
-        ),
-        eq(claims.userId, userId),
-        eq(claims.status, "active"),
-        eq(claims.scope, "personal"),
-        claimChangedInWindow,
-      ),
-    )
-    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
-    .where(
-      and(eq(nodes.userId, userId), lt(nodes.createdAt, since), nodeTypeFilter),
-    )
-    .groupBy(nodes.id, nodes.nodeType, nodes.createdAt, nodeMetadata.label)
-    .orderBy(desc(lastClaimChange))
-    .limit(limit);
+  // Candidates created before the window are "updated"; those created inside it
+  // already surface as "added" above and are excluded here via `createdAt < since`.
+  const updatedNodeRows =
+    candidateNodeIds.length > 0
+      ? await db
+          .select({
+            id: nodes.id,
+            nodeType: nodes.nodeType,
+            label: nodeMetadata.label,
+            firstSeenAt: nodes.createdAt,
+          })
+          .from(nodes)
+          .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+          .where(
+            and(
+              eq(nodes.userId, userId),
+              inArray(nodes.id, candidateNodeIds),
+              lt(nodes.createdAt, since),
+              nodeTypeFilter,
+            ),
+          )
+      : [];
 
   // Merge added + updated nodes, newest change first, capped at `limit`.
   // "Change time" is the createdAt for added nodes and the most recent
@@ -242,7 +260,7 @@ export async function queryRecentChanges(
       label: row.label,
       changeKind: "updated" as ChangeKind,
       firstSeenAt: row.firstSeenAt,
-      changedAt: row.changedAt,
+      changedAt: nodeChanges.get(row.id) ?? row.firstSeenAt,
     })),
   ];
 

--- a/src/lib/query/recent-changes.ts
+++ b/src/lib/query/recent-changes.ts
@@ -1,0 +1,291 @@
+import {
+  aliasedTable,
+  and,
+  desc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  lt,
+  lte,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
+import { z } from "zod";
+import { claims, nodeMetadata, nodes, sources } from "~/db/schema";
+import {
+  type ChangeKind,
+  type QueryRecentChangesRequest,
+  type QueryRecentChangesResponse,
+  type RecentChangeClaim,
+  type RecentChangeNode,
+  type RecentChangeSource,
+} from "~/lib/schemas/query-recent-changes";
+import { type NodeType } from "~/types/graph";
+import type { TypeId } from "~/types/typeid";
+import { useDatabase } from "~/utils/db";
+
+/**
+ * Node types that are pure graph infrastructure rather than user-facing
+ * "memory content". Excluded from the `nodes` feed by default so a digest
+ * isn't flooded with a fresh `Temporal` day node every morning (and the
+ * `Atlas` summary / internal `AssistantDream` artifacts). Callers can still
+ * surface them by passing them explicitly via `nodeTypes`.
+ */
+const STRUCTURAL_NODE_TYPES: readonly NodeType[] = [
+  "Temporal",
+  "Atlas",
+  "AssistantDream",
+];
+
+/**
+ * Minimal view of `sources.metadata` for title rendering. Kept local so this
+ * read path doesn't pull the MinIO-backed `~/lib/sources` module into the
+ * query layer.
+ */
+const sourceTitleMetadataSchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    filename: z.string().min(1).optional(),
+  })
+  .catchall(z.unknown());
+
+function deriveSourceTitle(metadata: unknown): string | null {
+  const parsed = sourceTitleMetadataSchema.safeParse(metadata ?? {});
+  if (!parsed.success) return null;
+  return parsed.data.title ?? parsed.data.filename ?? null;
+}
+
+function toTime(value: Date | string): number {
+  return new Date(value).getTime();
+}
+
+/**
+ * "What's new in memory" feed over a time range. Returns active personal
+ * claims and the nodes added/updated within `[since, until]`, with labels and
+ * provenance so consumers render without an N+1 fan-out. See the schema module
+ * for the full contract.
+ */
+export async function queryRecentChanges(
+  params: QueryRecentChangesRequest,
+): Promise<QueryRecentChangesResponse> {
+  const { userId, nodeTypes, limit } = params;
+  const since = new Date(params.since);
+  const until = params.until ? new Date(params.until) : new Date();
+
+  // Empty range (e.g. a caller passing since > until) → nothing to report.
+  if (since > until) {
+    return { claims: [], nodes: [], sources: [] };
+  }
+
+  const db = await useDatabase();
+
+  // A claim counts as changed when either its insert (createdAt) or its last
+  // mutation (updatedAt) lands inside the window. GREATEST orders by whichever
+  // happened most recently.
+  const claimChangedInWindow = or(
+    and(gte(claims.createdAt, since), lte(claims.createdAt, until)),
+    and(gte(claims.updatedAt, since), lte(claims.updatedAt, until)),
+  );
+  const claimChangedAt = sql<Date>`GREATEST(${claims.createdAt}, ${claims.updatedAt})`;
+
+  // Node-type filter shared by the node queries: an explicit allow-list when
+  // `nodeTypes` is given, otherwise drop the structural infrastructure types.
+  // The truthiness check narrows `nodeTypes` to a defined array for `inArray`.
+  const nodeTypeFilter =
+    nodeTypes && nodeTypes.length > 0
+      ? inArray(nodes.nodeType, nodeTypes)
+      : notInArray(nodes.nodeType, [...STRUCTURAL_NODE_TYPES]);
+
+  // --- Claims changed in the window ---------------------------------------
+  // The subject node joins as the base `nodes` table; the object node's label
+  // comes from an aliased `node_metadata`. The object node itself is only
+  // needed for the `nodeTypes` filter, so it's reached via a correlated
+  // EXISTS rather than a second join on `nodes` — a `nodes` self-join defeats
+  // Drizzle's result-type inference and collapses the row type to `never`.
+  const objectMeta = aliasedTable(nodeMetadata, "object_meta");
+  const objectNode = aliasedTable(nodes, "object_node");
+
+  // Claims are kept when their subject or object node matches `nodeTypes`.
+  const claimTypeFilter =
+    nodeTypes && nodeTypes.length > 0
+      ? or(
+          inArray(nodes.nodeType, nodeTypes),
+          exists(
+            db
+              .select({ one: sql`1` })
+              .from(objectNode)
+              .where(
+                and(
+                  eq(objectNode.id, claims.objectNodeId),
+                  inArray(objectNode.nodeType, nodeTypes),
+                ),
+              ),
+          ),
+        )
+      : undefined;
+
+  const claimRows = await db
+    .select({
+      id: claims.id,
+      predicate: claims.predicate,
+      statement: claims.statement,
+      subjectLabel: nodeMetadata.label,
+      // Relationship claims carry an object node (and thus a label); attribute
+      // claims carry a literal `objectValue`. Coalesced into `objectLabel` below.
+      objectNodeLabel: objectMeta.label,
+      objectValue: claims.objectValue,
+      sourceId: claims.sourceId,
+      statedAt: claims.statedAt,
+      createdAt: claims.createdAt,
+      assertedByKind: claims.assertedByKind,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, claims.subjectNodeId))
+    .leftJoin(objectMeta, eq(objectMeta.nodeId, claims.objectNodeId))
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.status, "active"),
+        eq(claims.scope, "personal"),
+        claimChangedInWindow,
+        claimTypeFilter,
+      ),
+    )
+    .orderBy(desc(claimChangedAt))
+    .limit(limit);
+
+  const claimsOut: RecentChangeClaim[] = claimRows.map((row) => ({
+    id: row.id,
+    predicate: row.predicate,
+    statement: row.statement,
+    subjectLabel: row.subjectLabel,
+    objectLabel: row.objectNodeLabel ?? row.objectValue,
+    sourceId: row.sourceId,
+    statedAt: row.statedAt,
+    changeKind: row.createdAt >= since ? "added" : "updated",
+    assertedByKind: row.assertedByKind,
+  }));
+
+  // --- Nodes added in the window ------------------------------------------
+  const addedNodeRows = await db
+    .select({
+      id: nodes.id,
+      nodeType: nodes.nodeType,
+      label: nodeMetadata.label,
+      firstSeenAt: nodes.createdAt,
+    })
+    .from(nodes)
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(nodes.userId, userId),
+        gte(nodes.createdAt, since),
+        lte(nodes.createdAt, until),
+        nodeTypeFilter,
+      ),
+    )
+    .orderBy(desc(nodes.createdAt))
+    .limit(limit);
+
+  // --- Existing nodes touched by a claim in the window (updated) ----------
+  const lastClaimChange = sql<Date>`MAX(GREATEST(${claims.createdAt}, ${claims.updatedAt}))`;
+
+  const updatedNodeRows = await db
+    .select({
+      id: nodes.id,
+      nodeType: nodes.nodeType,
+      label: nodeMetadata.label,
+      firstSeenAt: nodes.createdAt,
+      changedAt: lastClaimChange.as("changed_at"),
+    })
+    .from(nodes)
+    .innerJoin(
+      claims,
+      and(
+        or(
+          eq(claims.subjectNodeId, nodes.id),
+          eq(claims.objectNodeId, nodes.id),
+        ),
+        eq(claims.userId, userId),
+        eq(claims.status, "active"),
+        eq(claims.scope, "personal"),
+        claimChangedInWindow,
+      ),
+    )
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(eq(nodes.userId, userId), lt(nodes.createdAt, since), nodeTypeFilter),
+    )
+    .groupBy(nodes.id, nodes.nodeType, nodes.createdAt, nodeMetadata.label)
+    .orderBy(desc(lastClaimChange))
+    .limit(limit);
+
+  // Merge added + updated nodes, newest change first, capped at `limit`.
+  // "Change time" is the createdAt for added nodes and the most recent
+  // touching-claim change for updated ones.
+  type SortableNode = RecentChangeNode & { changedAt: Date | string };
+  const mergedNodes: SortableNode[] = [
+    ...addedNodeRows.map((row) => ({
+      id: row.id,
+      nodeType: row.nodeType,
+      label: row.label,
+      changeKind: "added" as ChangeKind,
+      firstSeenAt: row.firstSeenAt,
+      changedAt: row.firstSeenAt,
+    })),
+    ...updatedNodeRows.map((row) => ({
+      id: row.id,
+      nodeType: row.nodeType,
+      label: row.label,
+      changeKind: "updated" as ChangeKind,
+      firstSeenAt: row.firstSeenAt,
+      changedAt: row.changedAt,
+    })),
+  ];
+
+  const nodesOut: RecentChangeNode[] = mergedNodes
+    .sort((a, b) => toTime(b.changedAt) - toTime(a.changedAt))
+    .slice(0, limit)
+    .map((node) => ({
+      id: node.id,
+      nodeType: node.nodeType,
+      label: node.label,
+      changeKind: node.changeKind,
+      firstSeenAt: node.firstSeenAt,
+    }));
+
+  // --- Sources behind the returned claims ---------------------------------
+  const sourceIds = Array.from(new Set(claimsOut.map((c) => c.sourceId)));
+  let sourcesOut: RecentChangeSource[] = [];
+  if (sourceIds.length > 0) {
+    const sourceRows = await db
+      .select({
+        id: sources.id,
+        type: sources.type,
+        metadata: sources.metadata,
+        lastIngestedAt: sources.lastIngestedAt,
+        createdAt: sources.createdAt,
+      })
+      .from(sources)
+      .where(
+        and(
+          eq(sources.userId, userId),
+          inArray(sources.id, sourceIds as TypeId<"source">[]),
+        ),
+      );
+
+    sourcesOut = sourceRows
+      .map((row) => ({
+        sourceId: row.id,
+        type: row.type,
+        title: deriveSourceTitle(row.metadata),
+        timestamp: row.lastIngestedAt ?? row.createdAt,
+      }))
+      .sort((a, b) => toTime(b.timestamp) - toTime(a.timestamp));
+  }
+
+  return { claims: claimsOut, nodes: nodesOut, sources: sourcesOut };
+}

--- a/src/lib/schemas/query-recent-changes.ts
+++ b/src/lib/schemas/query-recent-changes.ts
@@ -1,0 +1,113 @@
+/**
+ * Schemas for the "recent changes" feed (`POST /query/recent-changes`).
+ *
+ * A time-range query that returns the personal, currently-active claims and
+ * the nodes added or updated within `[since, until]`, each carrying labels
+ * and provenance. Built for "what's new in memory since you last looked"
+ * surfaces — the daily digest and a Memory "Today" dashboard — so consumers
+ * can render a feed without an N+1 `getNode`/`getSource` fan-out.
+ *
+ * Unlike `query/day` this takes a `since` cursor (not a single calendar
+ * date), spans multiple days, and includes claims-with-labels plus a
+ * `changeKind` and per-source grouping data.
+ */
+import {
+  AssertedByKindEnum,
+  NodeTypeEnum,
+  PredicateEnum,
+} from "../../types/graph.js";
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+/**
+ * ISO-8601 datetime, e.g. `2026-05-29T08:00:00Z`. Accepts a UTC `Z` suffix
+ * or a numeric offset (`+02:00`); the natural output of `Date#toISOString()`.
+ */
+const isoDateTimeSchema = z
+  .string()
+  .datetime({ offset: true, message: "Must be an ISO-8601 datetime string" });
+
+/**
+ * Whether an item was first created inside the window (`added`) or existed
+ * beforehand and was touched within it (`updated`). For nodes, `updated`
+ * means a node created before `since` that gained a new active claim in the
+ * window (e.g. an existing project newly linked to a person).
+ */
+export const changeKindEnum = z.enum(["added", "updated"]);
+export type ChangeKind = z.infer<typeof changeKindEnum>;
+
+export const queryRecentChangesRequestSchema = z.object({
+  userId: z.string(),
+  /** Inclusive lower bound on change time (a claim/node `createdAt` or `updatedAt`). */
+  since: isoDateTimeSchema,
+  /** Inclusive upper bound; defaults to "now" when omitted. */
+  until: isoDateTimeSchema.optional(),
+  /** Caps the `claims` and `nodes` lists independently (default 100, max 500). */
+  limit: z.number().int().min(1).max(500).default(100),
+  /**
+   * Restrict the feed to these node types. Applies to the `nodes` list and
+   * to `claims` (kept when their subject or object node matches). When
+   * omitted, structural `Temporal`/`Atlas`/`AssistantDream` nodes are
+   * excluded from `nodes` so a digest isn't flooded with day buckets.
+   */
+  nodeTypes: z.array(NodeTypeEnum).optional(),
+});
+
+export const recentChangeClaimSchema = z.object({
+  id: typeIdSchema("claim"),
+  predicate: PredicateEnum,
+  statement: z.string(),
+  /** Label of the claim's subject node (`null` if the node has no metadata). */
+  subjectLabel: z.string().nullable(),
+  /**
+   * Label of the claim's object. For relationship claims this is the object
+   * node's label; for attribute claims (no object node) it is the literal
+   * `objectValue` (e.g. `"finish draft by June 30"`).
+   */
+  objectLabel: z.string().nullable(),
+  sourceId: typeIdSchema("source"),
+  statedAt: z.coerce.date(),
+  changeKind: changeKindEnum,
+  assertedByKind: AssertedByKindEnum,
+});
+export type RecentChangeClaim = z.infer<typeof recentChangeClaimSchema>;
+
+export const recentChangeNodeSchema = z.object({
+  id: typeIdSchema("node"),
+  nodeType: NodeTypeEnum,
+  label: z.string().nullable(),
+  changeKind: changeKindEnum,
+  /** When the node first entered memory (`nodes.createdAt`). */
+  firstSeenAt: z.coerce.date(),
+});
+export type RecentChangeNode = z.infer<typeof recentChangeNodeSchema>;
+
+export const recentChangeSourceSchema = z.object({
+  sourceId: typeIdSchema("source"),
+  /** Raw `sources.type` (e.g. `conversation`, `document`, `meeting_transcript`). */
+  type: z.string(),
+  /**
+   * Best-effort display title from `sources.metadata` (`title`, falling back
+   * to `filename`); `null` when none is available.
+   */
+  title: z.string().nullable(),
+  /** Effective source date: `lastIngestedAt` falling back to `createdAt`. */
+  timestamp: z.coerce.date(),
+});
+export type RecentChangeSource = z.infer<typeof recentChangeSourceSchema>;
+
+export const queryRecentChangesResponseSchema = z.object({
+  /** Active personal claims changed in the window, newest change first. */
+  claims: z.array(recentChangeClaimSchema),
+  /** Nodes added or updated in the window, newest change first. */
+  nodes: z.array(recentChangeNodeSchema),
+  /** Distinct sources behind the returned claims — for "N facts from <source>" grouping. */
+  sources: z.array(recentChangeSourceSchema),
+});
+
+export type QueryRecentChangesRequest = z.infer<
+  typeof queryRecentChangesRequestSchema
+>;
+export type QueryRecentChangesResponse = z.infer<
+  typeof queryRecentChangesResponseSchema
+>;

--- a/src/query-recent-changes-route.test.ts
+++ b/src/query-recent-changes-route.test.ts
@@ -1,0 +1,99 @@
+import handler from "./routes/query/recent-changes";
+import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { newTypeId } from "~/types/typeid";
+
+const recentChangesMocks = vi.hoisted(() => ({
+  queryRecentChanges: vi.fn(),
+}));
+
+vi.mock("~/lib/query/recent-changes", () => recentChangesMocks);
+
+describe("POST /query/recent-changes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("parses the request body (defaulting limit) and returns the schema-validated feed", async () => {
+    const claimId = newTypeId("claim");
+    const nodeId = newTypeId("node");
+    const sourceId = newTypeId("source");
+
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_rc",
+      since: "2026-05-20T00:00:00.000Z",
+      until: "2026-05-29T00:00:00.000Z",
+      nodeTypes: ["Person"],
+    }));
+
+    recentChangesMocks.queryRecentChanges.mockResolvedValue({
+      claims: [
+        {
+          id: claimId,
+          predicate: "RELATED_TO",
+          statement: "Lena is linked to the Book project.",
+          subjectLabel: "Lena",
+          objectLabel: "Book",
+          sourceId,
+          statedAt: new Date("2026-05-28T10:01:00.000Z"),
+          changeKind: "added",
+          assertedByKind: "user",
+        },
+      ],
+      nodes: [
+        {
+          id: nodeId,
+          nodeType: "Person",
+          label: "Lena",
+          changeKind: "added",
+          firstSeenAt: new Date("2026-05-28T10:00:00.000Z"),
+        },
+      ],
+      sources: [
+        {
+          sourceId,
+          type: "conversation",
+          title: "Coaching call",
+          timestamp: new Date("2026-05-28T09:00:00.000Z"),
+        },
+      ],
+    });
+
+    const response = await handler({} as H3Event);
+
+    // The lib receives the parsed request with `limit` defaulted by the schema.
+    expect(recentChangesMocks.queryRecentChanges).toHaveBeenCalledWith({
+      userId: "user_rc",
+      since: "2026-05-20T00:00:00.000Z",
+      until: "2026-05-29T00:00:00.000Z",
+      limit: 100,
+      nodeTypes: ["Person"],
+    });
+
+    expect(response.claims[0]).toMatchObject({
+      id: claimId,
+      changeKind: "added",
+      subjectLabel: "Lena",
+      objectLabel: "Book",
+    });
+    expect(response.nodes[0]).toMatchObject({
+      id: nodeId,
+      changeKind: "added",
+    });
+    expect(response.sources[0]).toMatchObject({
+      sourceId,
+      title: "Coaching call",
+    });
+  });
+
+  it("rejects a malformed `since` before reaching the query layer", async () => {
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_rc",
+      since: "2026-05-20", // date-only, not an ISO datetime
+    }));
+
+    await expect(handler({} as H3Event)).rejects.toThrow();
+    expect(recentChangesMocks.queryRecentChanges).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/query/recent-changes.ts
+++ b/src/routes/query/recent-changes.ts
@@ -1,0 +1,13 @@
+import { defineEventHandler } from "h3";
+import { queryRecentChanges } from "~/lib/query/recent-changes";
+import {
+  queryRecentChangesRequestSchema,
+  queryRecentChangesResponseSchema,
+} from "~/lib/schemas/query-recent-changes";
+
+export default defineEventHandler(async (event) => {
+  const params = queryRecentChangesRequestSchema.parse(await readBody(event));
+  return queryRecentChangesResponseSchema.parse(
+    await queryRecentChanges(params),
+  );
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -17,6 +17,7 @@ export * from "../lib/schemas/query-search.js";
 export * from "../lib/schemas/query-atlas.js";
 export * from "../lib/schemas/query-day.js";
 export * from "../lib/schemas/query-node-type.js";
+export * from "../lib/schemas/query-recent-changes.js";
 export * from "../lib/schemas/query-graph.js";
 export * from "../lib/schemas/messages.js";
 export * from "../lib/schemas/summarize.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -163,6 +163,11 @@ import {
   queryNodeTypeResponseSchema,
 } from "../lib/schemas/query-node-type.js";
 import {
+  QueryRecentChangesRequest,
+  QueryRecentChangesResponse,
+  queryRecentChangesResponseSchema,
+} from "../lib/schemas/query-recent-changes.js";
+import {
   QuerySearchRequest,
   QuerySearchResponse,
   querySearchResponseSchema,
@@ -451,6 +456,30 @@ export class MemoryClient {
       "POST",
       "/query/timeline",
       queryTimelineResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Time-range "what's new in memory" feed for a daily digest or a Memory
+   * "Today" dashboard. Returns the personal, currently-active claims and the
+   * nodes added or updated within `[since, until]` (`until` defaults to now),
+   * each carrying labels and provenance so the consumer can render
+   * "N facts from <source>" without an N+1 `getNode`/`getSource` fan-out.
+   * `changeKind` separates freshly `added` items from existing ones `updated`
+   * in the window. Pass `nodeTypes` to narrow the node feed; otherwise
+   * structural `Temporal`/`Atlas`/`AssistantDream` nodes are omitted. `limit`
+   * caps the `claims` and `nodes` lists independently. Use this instead of
+   * `queryDay` when you have a `since` cursor and need labelled claims, not
+   * just a single day's nodes.
+   */
+  async queryRecentChanges(
+    payload: QueryRecentChangesRequest,
+  ): Promise<QueryRecentChangesResponse> {
+    return this._fetch(
+      "POST",
+      "/query/recent-changes",
+      queryRecentChangesResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## Summary
Adds a new `queryRecentChanges` API endpoint that returns a time-range "what's new in memory" feed for daily digests and dashboards. The feed includes active personal claims and nodes added/updated within a time window, with labels and provenance pre-fetched to avoid N+1 queries.

## Key Changes

- **New query function** (`src/lib/query/recent-changes.ts`): Core logic that queries claims and nodes changed within `[since, until]`, with intelligent filtering:
  - Returns only active personal claims (excludes superseded and reference-scoped claims)
  - Separates nodes into "added" (created in window) and "updated" (touched by a claim in window)
  - Excludes structural node types (`Temporal`, `Atlas`, `AssistantDream`) by default unless explicitly requested
  - Joins labels and source metadata to avoid consumer N+1 fan-out
  - Supports optional `nodeTypes` filter to narrow both claims and nodes

- **Schema definitions** (`src/lib/schemas/query-recent-changes.ts`): Request/response types with validation:
  - `QueryRecentChangesRequest`: userId, since (required), until (optional, defaults to now), limit (1-500, default 100), nodeTypes filter
  - `QueryRecentChangesResponse`: claims, nodes, and sources arrays with change metadata
  - `ChangeKind` enum: "added" vs "updated" to distinguish fresh items from touched existing ones

- **HTTP route** (`src/routes/query/recent-changes.ts`): POST endpoint that parses and validates the request, delegates to the query function, and validates the response

- **SDK integration** (`src/sdk/memory-client.ts`, `src/sdk/index.ts`): Exposes `queryRecentChanges()` method on the MemoryClient with full JSDoc

- **Comprehensive test suite** (`src/lib/query/recent-changes.test.ts`, `src/query-recent-changes-route.test.ts`):
  - Integration test with real database setup/teardown covering edge cases: superseded claims, reference-scoped claims, stale claims, structural nodes, and nodeTypes filtering
  - Route handler test validating request parsing, default limit application, and schema validation

## Notable Implementation Details

- Uses `GREATEST(createdAt, updatedAt)` to determine claim change time, ordering by most recent change
- Merges added and updated nodes from separate queries, then sorts and limits the combined result to avoid double-counting
- Filters claims by both subject and object node types using a correlated EXISTS subquery to avoid self-join type inference issues
- Derives source titles from metadata with fallback chain (title → filename → null)
- Handles empty time ranges gracefully (since > until returns empty feed)

https://claude.ai/code/session_015Se2dNXXAv6pUCx1kyGPWu