### PR TITLE
✨ feat(commitments): active creation + candidate curation loop

### DIFF
--- a/docs/superpowers/specs/2026-06-04-commitment-curation-loop-design.md
+++ b/docs/superpowers/specs/2026-06-04-commitment-curation-loop-design.md
@@ -1,0 +1,123 @@
+# Commitment Curation Loop — Design
+
+**Date:** 2026-06-04
+**Status:** Approved (pending spec review)
+**Related:** `2026-04-24-claims-layer-design.md` (claims/lifecycle/predicate policies), the `createCommitment` mutation added 2026-06-04.
+
+## Problem
+
+Commitments (`Task` nodes + `HAS_TASK_STATUS` claims) come from two places: the ingestion graph extractor (automatic) and, as of 2026-06-04, the `createCommitment` mutation (deliberate, LM/SDK-driven). Two gaps remain:
+
+1. **Inferred commitments are invisible and un-actionable.** When the extractor is unsure ("the user _might_ be committing to X"), it stamps the `HAS_TASK_STATUS` claim `assertedByKind: "assistant_inferred"`. `getOpenCommitments` deliberately filters those out (`ne(claims.assertedByKind, "assistant_inferred")`). They exist in the graph but nothing surfaces them and there is no way to confirm or reject one.
+2. **The extractor duplicates them.** Extractor prompt seeding (`_formatOpenCommitmentsSection`) is fed from `getOpenCommitments` (trusted-only), so the extractor is blind to existing _inferred_ tasks. When the same thing resurfaces it mints a **new** Task node instead of reusing the existing one. Identity resolution by canonical label catches some, not reliably.
+
+The goal is a curation loop: inferred commitments are **candidates**; they can be surfaced, confirmed, or dismissed; corroboration promotes them automatically; and the extractor stops duplicating them.
+
+## Key insight: the confidence axis already exists
+
+We do **not** add a confidence dimension. `assertedByKind: "assistant_inferred"` _is_ the candidate marker, and the lifecycle already encodes the trust ordering we need:
+
+```
+user = 5, user_confirmed = 5, participant = 4, document_author = 3, assistant_inferred = 2, system = 1
+```
+
+`HAS_TASK_STATUS` is `single_current_value` / `supersede_previous`. So a `user`/`user_confirmed` status claim supersedes an `assistant_inferred` one for the same task — promotion is just supersession by a higher-trust assertion. The cleanup job's `promoteAssertion` already does exactly this (stamps `user_confirmed`).
+
+## Decisions (from brainstorming)
+
+- **Scope:** full curation loop — surface candidates + confirm/dismiss + convergence fix.
+- **Confirm trigger:** proactive (bootstrap surfaces candidates; assistant raises them in chat) **plus** auto-promote on corroboration (emergent from the convergence fix + lifecycle trust).
+- **Dismiss:** retract the active `HAS_TASK_STATUS` claim only. No sticky rejection marker. Re-surfacing after a much-later re-inference is accepted.
+- **No schema or enum changes.** No new `TaskStatus` value, no migration, `claims.metadata` untouched.
+
+## Non-goals / out of scope
+
+- Numeric per-claim confidence in `claims.metadata` (can layer on later if the binary inferred flag proves too coarse).
+- A sticky "user rejected this" marker that survives re-ingestion.
+- Any new `TaskStatus` enum value or claim predicate.
+
+## Architecture
+
+Five components. Net new surface: ~2 lib fns + 1 query refactor + 1 bootstrap section + 2 routes/SDK methods/MCP tools + an extractor-seeding change.
+
+### 1. Candidate read model
+
+Refactor the `getOpenCommitments` query core (`src/lib/query/open-commitments.ts`) to take a provenance selector instead of hard-coding the trusted filter:
+
+```ts
+type CommitmentProvenance = "trusted" | "candidate";
+// internal: _queryCommitments({ userId, provenance, ownedBy?, dueBefore? })
+//   "trusted"   → ne(assertedByKind, "assistant_inferred")   (current behavior)
+//   "candidate" → eq(assertedByKind, "assistant_inferred")
+```
+
+- `getOpenCommitments(params)` keeps its current public signature and calls the core with `provenance: "trusted"`.
+- New `getCandidateCommitments(params)` calls the core with `provenance: "candidate"`. Returns the same `OpenCommitment` shape (latest active personal `HAS_TASK_STATUS` = `assistant_inferred`, status pending/in_progress).
+- The OWNED_BY / DUE_ON metadata sub-joins are NOT symmetric with the status filter. The trusted path keeps `ne(assistant_inferred)` (trusted metadata only); the candidate path applies NO provenance constraint, so a candidate task surfaces its owner/due whether those claims are inferred OR trusted (e.g. a user-set due date on a not-yet-confirmed candidate must not be hidden). A naive "invert to `eq(assistant_inferred)`" would drop trusted metadata on candidates.
+
+### 2. Bootstrap "candidates to confirm" section
+
+Add an optional `candidate_commitments` section to the `ContextBundle` (`src/lib/context/types.ts` + a new section assembler in `src/lib/context/sections/`, mirroring the existing open-commitments section). Skipped when empty. Populated via `getCandidateCommitments`. The model-facing copy frames these as _unconfirmed_ — the assistant should raise them for confirmation, not state them as settled fact.
+
+### 3. Confirm / dismiss surface
+
+Two lib functions in `src/lib/commitments.ts`, both verifying the subject is a `Task` owned by the user (reuse `TaskNotFoundError`):
+
+- `confirmCommitment({ userId, taskId })` — read the task's active `HAS_TASK_STATUS`; create a superseding claim with the **same status value** but `assertedByKind: "user_confirmed"` and `statedAt: now`. Lifecycle supersedes the prior (inferred) claim; the task now passes the trusted filter and appears in `getOpenCommitments`. Idempotent-ish: confirming an already-trusted task simply re-affirms it.
+- `dismissCommitment({ userId, taskId })` — retract every active `HAS_TASK_STATUS` claim on the task (status → `retracted`), mirroring `setCommitmentDue`'s clear path. The task drops out of _both_ the candidate and open views (both require an active `HAS_TASK_STATUS`). The Task node remains and is left to orphan pruning.
+
+Transport: routes `POST /commitments/confirm` and `POST /commitments/dismiss`; SDK `confirmCommitment` / `dismissCommitment`; MCP tools `confirm_commitment` / `dismiss_commitment` (descriptions pinned in `tool-descriptions.test.ts`). Schemas: `{ userId, taskId }` request; response echoes `taskId`, resulting `status`/visibility, and affected claim ids.
+
+### 4. Convergence fix (extractor seeding)
+
+In `extract-graph.ts`, additionally fetch `getCandidateCommitments` and render candidates in `_formatOpenCommitmentsSection` under a distinct heading, e.g.:
+
+```
+CANDIDATE TASKS (unconfirmed — the assistant inferred these; treat as tentative):
+- existingNodeId: <id>; label: <label>; status: <status>
+  If THIS source shows the user explicitly stating, acting on, or agreeing to this task,
+  emit a HAS_TASK_STATUS attribute claim with assertionKind "user" against this existingNodeId
+  (this confirms it). If the source completes/abandons it, emit the matching status. Never
+  create a new Task node for one of these.
+```
+
+This:
+
+- **Dedupes:** the extractor reuses the candidate's node id instead of minting a duplicate.
+- **Auto-promotes:** a `user`-asserted status against the existing node supersedes the inferred one (trust 5 > 2), so corroboration promotes the candidate with no separate mechanism.
+
+### 5. Assistant-proposed candidates (no code)
+
+Already supported: `create_commitment`'s existing optional `assertedByKind` lets the assistant mint a candidate by passing `"assistant_inferred"` (hidden from open commitments, shown in candidates). Action item is documentation only — note this in the `create_commitment` tool description so the model knows the option exists.
+
+## Data flow
+
+1. **Ingestion** → uncertain commitment → `HAS_TASK_STATUS` (`assistant_inferred`) → candidate.
+2. **Bootstrap** → `candidate_commitments` section lists it → assistant raises it in chat.
+3. **User confirms** → `confirm_commitment` → superseding `user_confirmed` claim → now in `getOpenCommitments`.
+   **User dismisses** → `dismiss_commitment` → retract → gone from both views.
+4. **Re-ingestion corroborates** (user explicitly states it) → extractor sees the candidate in seeding → emits `user` status against the existing node → supersedes inferred → promoted, no duplicate.
+
+## Error handling
+
+- Confirm/dismiss on a non-Task or cross-user node → `TaskNotFoundError` → route maps to 404 (mirrors `setCommitmentDue`).
+- Confirm a task with no active `HAS_TASK_STATUS` → `TaskNotFoundError`-style "no active status" error → 404/409; the route surfaces a structured message.
+- All boundaries parse through Zod request schemas; the lib functions trust the parsed types.
+
+## Testing strategy
+
+DB-backed (`describeIfServer`, port 5431, `setSkipEmbeddingPersistence`) unless noted:
+
+- **Query:** `getCandidateCommitments` returns only active personal `assistant_inferred` pending/in_progress tasks; `getOpenCommitments` still excludes them (no regression). A task with an inferred owner/due surfaces its owner/due in the candidate view.
+- **Confirm:** confirming a candidate creates a `user_confirmed` superseding claim; the task leaves the candidate view and enters `getOpenCommitments`; the prior inferred claim is `superseded`.
+- **Dismiss:** retracts the active status; task disappears from both views; Task node still present.
+- **Lifecycle tiebreak (pinned):** `confirmCommitment` (statedAt=now) reliably wins over the inferred claim; a corroborating `user` status on realistic timestamps promotes rather than the inferred one winning.
+- **Convergence:** an extraction pass seeded with a candidate, given corroborating content, emits a `user` status against the existing node id and creates **no** new Task (exercise via the `eval:ingest` probe path or a focused extractor unit test with the stubbed completion client).
+- **Schema tests** (fast, no DB): confirm/dismiss request schemas.
+- **Tool-description snapshots:** pin `confirm_commitment` / `dismiss_commitment` and the updated `create_commitment` description.
+
+## Risks
+
+- **Lifecycle tiebreak ordering.** Supersession ranks by `(statedAt, createdAt)` with trust as tiebreaker, so a _newer_ inferred claim could in principle supersede an older `user` one. Pre-existing behavior; the pinned tiebreak test guards the confirm/auto-promote paths. If it bites, escalate to making trusted kinds strictly dominate inferred regardless of recency for `HAS_TASK_STATUS` — out of scope unless the test forces it.
+- **Re-nag after dismiss.** "Retract only" means a much-later re-inference can resurface a dismissed candidate. Accepted; a sticky marker is the documented follow-up if it becomes a nuisance.
+- **Candidate owner/due joins.** The metadata sub-joins must apply no provenance constraint on the candidate path (not `eq(assistant_inferred)`), or a _trusted_ owner/due set on a candidate is silently dropped. Covered by the candidate-with-inferred-metadata and candidate-with-trusted-metadata tests.

--- a/src/lib/commitment-curation.test.ts
+++ b/src/lib/commitment-curation.test.ts
@@ -1,0 +1,534 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+process.env["DATABASE_URL"] ??= adminDsn();
+process.env["JINA_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_BASE_URL"] ??= "https://api.openai.com/v1";
+process.env["MODEL_ID_GRAPH_EXTRACTION"] ??= "test-model";
+process.env["REDIS_URL"] ??= "redis://localhost:6380";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+async function provisionSchema(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "sources" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "type" varchar(50) NOT NULL,
+      "external_id" text NOT NULL,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "status" varchar(20) DEFAULT 'completed',
+      "parent_source" text,
+      "metadata" jsonb,
+      "last_ingested_at" timestamp with time zone,
+      "deleted_at" timestamp with time zone,
+      "content_type" varchar(100),
+      "content_length" integer,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "sources_user_type_external_unique"
+        UNIQUE ("user_id", "type", "external_id")
+    );
+    CREATE TABLE IF NOT EXISTS "source_links" (
+      "id" text PRIMARY KEY NOT NULL,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "specific_location" text,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "source_links_source_node_unique" UNIQUE ("source_id", "node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "claims" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_value" text,
+      "predicate" varchar(80) NOT NULL,
+      "statement" text NOT NULL,
+      "description" text,
+      "metadata" jsonb,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "asserted_by_kind" varchar(24) NOT NULL,
+      "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+      "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "stated_at" timestamp with time zone NOT NULL,
+      "valid_from" timestamp with time zone,
+      "valid_to" timestamp with time zone,
+      "status" varchar(30) DEFAULT 'active' NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "claims_object_shape_xor_ck"
+        CHECK (num_nonnulls("object_node_id", "object_value") = 1)
+    );
+  `);
+}
+
+describeIfServer("commitment curation", () => {
+  const dbName = `memory_commitment_curation_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("getCandidateCommitments returns inferred tasks (with inferred owner/due) that getOpenCommitments hides", async () => {
+    const userId = "user_curation_candidate_query";
+    const trustedTaskId = newTypeId("node");
+    const candidateTaskId = newTypeId("node");
+    const ownerNodeId = newTypeId("node");
+    const dueNodeId = newTypeId("node");
+    const sourceId = newTypeId("source");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "status")
+           VALUES ($1, $2, 'manual', 'manual:curation', 'personal', 'completed')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES
+           ($1, $5, 'Task'),
+           ($2, $5, 'Task'),
+           ($3, $5, 'Person'),
+           ($4, $5, 'Temporal')`,
+        [trustedTaskId, candidateTaskId, ownerNodeId, dueNodeId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES
+           ($1, $5, 'Confirmed task', 'confirmed task'),
+           ($2, $6, 'Inferred task', 'inferred task'),
+           ($3, $7, 'Marcel', 'marcel'),
+           ($4, $8, '2026-08-01', '2026-08-01')`,
+        [
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          trustedTaskId,
+          candidateTaskId,
+          ownerNodeId,
+          dueNodeId,
+        ],
+      );
+      await client.query(
+        `INSERT INTO "claims" (
+           "id", "user_id", "subject_node_id", "object_node_id", "object_value",
+           "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+         ) VALUES
+           ($1, $9, $5, NULL, 'pending', 'HAS_TASK_STATUS', 'Confirmed task is pending.', $8, 'personal', 'user', '2026-06-01T10:00:00Z', 'active'),
+           ($2, $9, $6, NULL, 'pending', 'HAS_TASK_STATUS', 'Inferred task is pending.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:00:00Z', 'active'),
+           ($3, $9, $6, $7, NULL, 'OWNED_BY', 'Inferred task owned by Marcel.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:01:00Z', 'active'),
+           ($4, $9, $6, $10, NULL, 'DUE_ON', 'Inferred task due on 2026-08-01.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:02:00Z', 'active')`,
+        [
+          newTypeId("claim"),
+          newTypeId("claim"),
+          newTypeId("claim"),
+          newTypeId("claim"),
+          trustedTaskId,
+          candidateTaskId,
+          ownerNodeId,
+          sourceId,
+          userId,
+          dueNodeId,
+        ],
+      );
+
+      const { getOpenCommitments, getCandidateCommitments } = await import(
+        "./query/open-commitments"
+      );
+
+      const open = await getOpenCommitments({ userId });
+      expect(open.map((c) => c.taskId)).toEqual([trustedTaskId]);
+
+      const candidates = await getCandidateCommitments({ userId });
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        taskId: candidateTaskId,
+        label: "Inferred task",
+        status: "pending",
+        owner: { nodeId: ownerNodeId, label: "Marcel" },
+        dueOn: "2026-08-01",
+      });
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("getCandidateCommitments surfaces a candidate's TRUSTED owner/due (e.g. user set a due date before confirming)", async () => {
+    const userId = "user_curation_candidate_trusted_meta";
+    const candidateTaskId = newTypeId("node");
+    const ownerNodeId = newTypeId("node");
+    const dueNodeId = newTypeId("node");
+    const sourceId = newTypeId("source");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "status")
+           VALUES ($1, $2, 'manual', 'manual:trusted_meta', 'personal', 'completed')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES
+           ($1, $4, 'Task'), ($2, $4, 'Person'), ($3, $4, 'Temporal')`,
+        [candidateTaskId, ownerNodeId, dueNodeId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES
+           ($1, $4, 'Inferred task', 'inferred task'),
+           ($2, $5, 'Marcel', 'marcel'),
+           ($3, $6, '2026-09-09', '2026-09-09')`,
+        [
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          candidateTaskId,
+          ownerNodeId,
+          dueNodeId,
+        ],
+      );
+      // Inferred status (→ candidate), but TRUSTED owner + due (user-asserted).
+      await client.query(
+        `INSERT INTO "claims" (
+           "id", "user_id", "subject_node_id", "object_node_id", "object_value",
+           "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+         ) VALUES
+           ($1, $6, $4, NULL, 'pending', 'HAS_TASK_STATUS', 'Inferred task is pending.', $5, 'personal', 'assistant_inferred', '2026-06-01T10:00:00Z', 'active'),
+           ($2, $6, $4, $7, NULL, 'OWNED_BY', 'Marcel owns inferred task.', $5, 'personal', 'user', '2026-06-02T10:00:00Z', 'active'),
+           ($3, $6, $4, $8, NULL, 'DUE_ON', 'Inferred task due on 2026-09-09.', $5, 'personal', 'user', '2026-06-02T10:01:00Z', 'active')`,
+        [
+          newTypeId("claim"),
+          newTypeId("claim"),
+          newTypeId("claim"),
+          candidateTaskId,
+          sourceId,
+          userId,
+          ownerNodeId,
+          dueNodeId,
+        ],
+      );
+
+      const { getCandidateCommitments } = await import(
+        "./query/open-commitments"
+      );
+
+      const candidates = await getCandidateCommitments({ userId });
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        taskId: candidateTaskId,
+        status: "pending",
+        owner: { nodeId: ownerNodeId, label: "Marcel" },
+        dueOn: "2026-09-09",
+      });
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("assembleCandidateCommitmentsSection renders candidates and returns null when there are none", async () => {
+    const userId = "user_curation_section";
+    const emptyUserId = "user_curation_section_empty";
+    const candidateTaskId = newTypeId("node");
+    const sourceId = newTypeId("source");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1), ($2)`, [
+        userId,
+        emptyUserId,
+      ]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "status")
+           VALUES ($1, $2, 'manual', 'manual:section', 'personal', 'completed')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Task')`,
+        [candidateTaskId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label")
+           VALUES ($1, $2, 'Draft the proposal', 'draft the proposal')`,
+        [newTypeId("node_metadata"), candidateTaskId],
+      );
+      await client.query(
+        `INSERT INTO "claims" (
+           "id", "user_id", "subject_node_id", "object_value", "predicate",
+           "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+         ) VALUES ($1, $2, $3, 'pending', 'HAS_TASK_STATUS',
+           'Draft the proposal is pending.', $4, 'personal', 'assistant_inferred', '2026-06-01T10:00:00Z', 'active')`,
+        [newTypeId("claim"), userId, candidateTaskId, sourceId],
+      );
+
+      const { assembleCandidateCommitmentsSection } = await import(
+        "./context/sections/candidate-commitments"
+      );
+
+      const section = await assembleCandidateCommitmentsSection(userId);
+      expect(section).not.toBeNull();
+      expect(section?.kind).toBe("candidate_commitments");
+      expect(section?.content).toContain("Draft the proposal");
+
+      expect(await assembleCandidateCommitmentsSection(emptyUserId)).toBeNull();
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("confirmCommitment promotes a candidate into the open view and supersedes the inferred claim", async () => {
+    const userId = "user_curation_confirm";
+    const candidateTaskId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    const inferredClaimId = newTypeId("claim");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+    // Confirm supersedes the prior HAS_TASK_STATUS (a forceRefreshOnSupersede
+    // predicate), which would otherwise reach BullMQ/Redis via a dynamic
+    // queues import. Stub the enqueue side-effect; the DB-level supersession is
+    // still exercised and asserted below.
+    vi.doMock("~/lib/jobs/atlas-invalidation", () => ({
+      maybeEnqueueAtlasInvalidation: async () => false,
+    }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "status")
+           VALUES ($1, $2, 'manual', 'manual:confirm', 'personal', 'completed')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Task')`,
+        [candidateTaskId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label")
+           VALUES ($1, $2, 'Inferred task', 'inferred task')`,
+        [newTypeId("node_metadata"), candidateTaskId],
+      );
+      await client.query(
+        `INSERT INTO "claims" (
+           "id", "user_id", "subject_node_id", "object_value", "predicate",
+           "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+         ) VALUES ($1, $2, $3, 'pending', 'HAS_TASK_STATUS',
+           'Inferred task is pending.', $4, 'personal', 'assistant_inferred', '2026-06-01T10:00:00Z', 'active')`,
+        [inferredClaimId, userId, candidateTaskId, sourceId],
+      );
+
+      const { setSkipEmbeddingPersistence, resetTestOverrides } = await import(
+        "~/utils/test-overrides"
+      );
+      setSkipEmbeddingPersistence(true);
+
+      try {
+        const { confirmCommitment } = await import("./commitments");
+        const { getOpenCommitments, getCandidateCommitments } = await import(
+          "./query/open-commitments"
+        );
+
+        const result = await confirmCommitment({
+          userId,
+          taskId: candidateTaskId,
+        });
+        expect(result).toMatchObject({
+          taskId: candidateTaskId,
+          status: "pending",
+        });
+        expect(result.claimId).toBeTruthy();
+
+        expect(await getCandidateCommitments({ userId })).toHaveLength(0);
+        const open = await getOpenCommitments({ userId });
+        expect(open.map((c) => c.taskId)).toEqual([candidateTaskId]);
+
+        const inferredRow = await client.query<{ status: string }>(
+          `SELECT "status" FROM "claims" WHERE "id" = $1`,
+          [inferredClaimId],
+        );
+        expect(inferredRow.rows[0]?.status).toBe("superseded");
+      } finally {
+        resetTestOverrides();
+      }
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.doUnmock("~/lib/jobs/atlas-invalidation");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("dismissCommitment retracts the inferred status so the task leaves both views", async () => {
+    const userId = "user_curation_dismiss";
+    const candidateTaskId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    const inferredClaimId = newTypeId("claim");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "status")
+           VALUES ($1, $2, 'manual', 'manual:dismiss', 'personal', 'completed')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Task')`,
+        [candidateTaskId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label")
+           VALUES ($1, $2, 'Inferred task', 'inferred task')`,
+        [newTypeId("node_metadata"), candidateTaskId],
+      );
+      await client.query(
+        `INSERT INTO "claims" (
+           "id", "user_id", "subject_node_id", "object_value", "predicate",
+           "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+         ) VALUES ($1, $2, $3, 'pending', 'HAS_TASK_STATUS',
+           'Inferred task is pending.', $4, 'personal', 'assistant_inferred', '2026-06-01T10:00:00Z', 'active')`,
+        [inferredClaimId, userId, candidateTaskId, sourceId],
+      );
+
+      const { setSkipEmbeddingPersistence, resetTestOverrides } = await import(
+        "~/utils/test-overrides"
+      );
+      setSkipEmbeddingPersistence(true);
+
+      try {
+        const { dismissCommitment } = await import("./commitments");
+        const { getOpenCommitments, getCandidateCommitments } = await import(
+          "./query/open-commitments"
+        );
+
+        const result = await dismissCommitment({
+          userId,
+          taskId: candidateTaskId,
+        });
+        expect(result.retractedClaimIds).toEqual([inferredClaimId]);
+
+        expect(await getCandidateCommitments({ userId })).toHaveLength(0);
+        expect(await getOpenCommitments({ userId })).toHaveLength(0);
+
+        const row = await client.query<{ status: string }>(
+          `SELECT "status" FROM "claims" WHERE "id" = $1`,
+          [inferredClaimId],
+        );
+        expect(row.rows[0]?.status).toBe("retracted");
+      } finally {
+        resetTestOverrides();
+      }
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+});

--- a/src/lib/commitments.test.ts
+++ b/src/lib/commitments.test.ts
@@ -1,0 +1,278 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+import { createCommitmentRequestSchema } from "~/lib/schemas/create-commitment";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+process.env["DATABASE_URL"] ??= adminDsn();
+process.env["JINA_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_BASE_URL"] ??= "https://api.openai.com/v1";
+process.env["MODEL_ID_GRAPH_EXTRACTION"] ??= "test-model";
+process.env["REDIS_URL"] ??= "redis://localhost:6380";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+/**
+ * Provision the minimal table set `createCommitment` exercises end-to-end:
+ * `createNode` (nodes/metadata/sources/source_links + today's day node),
+ * `createClaim` + lifecycle (claims), and the `getOpenCommitments` read model.
+ * Embedding tables are intentionally omitted — the test flips on the
+ * skip-embedding-persistence seam so no embedding rows are written.
+ */
+async function provisionSchema(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "sources" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "type" varchar(50) NOT NULL,
+      "external_id" text NOT NULL,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "status" varchar(20) DEFAULT 'completed',
+      "parent_source" text,
+      "metadata" jsonb,
+      "last_ingested_at" timestamp with time zone,
+      "deleted_at" timestamp with time zone,
+      "content_type" varchar(100),
+      "content_length" integer,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "sources_user_type_external_unique"
+        UNIQUE ("user_id", "type", "external_id")
+    );
+    CREATE TABLE IF NOT EXISTS "source_links" (
+      "id" text PRIMARY KEY NOT NULL,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "specific_location" text,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "source_links_source_node_unique" UNIQUE ("source_id", "node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "claims" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_value" text,
+      "predicate" varchar(80) NOT NULL,
+      "statement" text NOT NULL,
+      "description" text,
+      "metadata" jsonb,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "asserted_by_kind" varchar(24) NOT NULL,
+      "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+      "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "stated_at" timestamp with time zone NOT NULL,
+      "valid_from" timestamp with time zone,
+      "valid_to" timestamp with time zone,
+      "status" varchar(30) DEFAULT 'active' NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "claims_object_shape_xor_ck"
+        CHECK (num_nonnulls("object_node_id", "object_value") = 1)
+    );
+  `);
+}
+
+describeIfServer("createCommitment", () => {
+  const dbName = `memory_create_commitment_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("opens a pending commitment that surfaces in the open-commitments view", async () => {
+    const userId = "user_create_commitment_min";
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+
+      const { setSkipEmbeddingPersistence, resetTestOverrides } = await import(
+        "~/utils/test-overrides"
+      );
+      setSkipEmbeddingPersistence(true);
+
+      try {
+        const { createCommitment } = await import("./commitments");
+        const { getOpenCommitments } = await import("./query/open-commitments");
+
+        const created = await createCommitment(
+          createCommitmentRequestSchema.parse({
+            userId,
+            label: "Send the spec",
+          }),
+        );
+
+        expect(created).toMatchObject({
+          label: "Send the spec",
+          status: "pending",
+          dueOn: null,
+          owner: null,
+          dueClaimId: null,
+          ownerClaimId: null,
+        });
+        expect(created.taskId).toBeTruthy();
+        expect(created.statusClaimId).toBeTruthy();
+
+        const commitments = await getOpenCommitments({ userId });
+        expect(commitments).toHaveLength(1);
+        expect(commitments[0]).toMatchObject({
+          taskId: created.taskId,
+          label: "Send the spec",
+          status: "pending",
+          owner: null,
+          dueOn: null,
+        });
+      } finally {
+        resetTestOverrides();
+      }
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("opens an in_progress commitment with a due date and owner", async () => {
+    const userId = "user_create_commitment_full";
+    const ownerNodeId = newTypeId("node");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    try {
+      await provisionSchema(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Person')`,
+        [ownerNodeId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label")
+           VALUES ($1, $2, 'Marcel', 'marcel')`,
+        [newTypeId("node_metadata"), ownerNodeId],
+      );
+
+      const { setSkipEmbeddingPersistence, resetTestOverrides } = await import(
+        "~/utils/test-overrides"
+      );
+      setSkipEmbeddingPersistence(true);
+
+      try {
+        const { createCommitment } = await import("./commitments");
+        const { getOpenCommitments } = await import("./query/open-commitments");
+
+        const created = await createCommitment(
+          createCommitmentRequestSchema.parse({
+            userId,
+            label: "Review the memo",
+            status: "in_progress",
+            dueOn: "2026-07-15",
+            ownedBy: ownerNodeId,
+          }),
+        );
+
+        expect(created).toMatchObject({
+          label: "Review the memo",
+          status: "in_progress",
+          dueOn: "2026-07-15",
+          owner: { nodeId: ownerNodeId, label: "Marcel" },
+        });
+        expect(created.dueClaimId).toBeTruthy();
+        expect(created.ownerClaimId).toBeTruthy();
+
+        const commitments = await getOpenCommitments({ userId });
+        expect(commitments).toHaveLength(1);
+        expect(commitments[0]).toMatchObject({
+          taskId: created.taskId,
+          label: "Review the memo",
+          status: "in_progress",
+          owner: { nodeId: ownerNodeId, label: "Marcel" },
+          dueOn: "2026-07-15",
+        });
+      } finally {
+        resetTestOverrides();
+      }
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+});

--- a/src/lib/commitments.ts
+++ b/src/lib/commitments.ts
@@ -1,10 +1,22 @@
 /** Lifecycle-aware commitment operations (Task subject helpers). */
 import { format, parseISO } from "date-fns";
-import { and, eq } from "drizzle-orm";
-import { claims, nodes } from "~/db/schema";
-import { createClaim, updateClaim } from "~/lib/claim";
+import { and, desc, eq } from "drizzle-orm";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+import { createClaim, updateClaim, NodesNotFoundError } from "~/lib/claim";
+import { createNode } from "~/lib/node";
+import type {
+  CommitmentActionRequest,
+  ConfirmCommitmentResponse,
+  DismissCommitmentResponse,
+} from "~/lib/schemas/commitment-action";
+import type {
+  CreateCommitmentRequest,
+  CreateCommitmentResponse,
+} from "~/lib/schemas/create-commitment";
+import type { CreateNodeInitialClaim } from "~/lib/schemas/node";
 import type { SetCommitmentDueRequest } from "~/lib/schemas/set-commitment-due";
 import { ensureDayNode } from "~/lib/temporal";
+import { TaskStatusEnum } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
@@ -14,6 +26,23 @@ export class TaskNotFoundError extends Error {
     super(`Task not found: ${taskId}`);
     this.name = "TaskNotFoundError";
     this.taskId = taskId;
+  }
+}
+
+/** Verify `taskId` is a `Task` owned by `userId`; throws {@link TaskNotFoundError} otherwise. */
+async function requireOwnedTask(
+  db: Awaited<ReturnType<typeof useDatabase>>,
+  userId: string,
+  taskId: TypeId<"node">,
+): Promise<void> {
+  const [taskRow] = await db
+    .select({ id: nodes.id, nodeType: nodes.nodeType })
+    .from(nodes)
+    .where(and(eq(nodes.id, taskId), eq(nodes.userId, userId)))
+    .limit(1);
+
+  if (!taskRow || taskRow.nodeType !== "Task") {
+    throw new TaskNotFoundError(taskId);
   }
 }
 
@@ -40,15 +69,7 @@ export async function setCommitmentDue(
   const { userId, taskId, dueOn, note, assertedByKind } = input;
   const db = await useDatabase();
 
-  const [taskRow] = await db
-    .select({ id: nodes.id, nodeType: nodes.nodeType })
-    .from(nodes)
-    .where(and(eq(nodes.id, taskId), eq(nodes.userId, userId)))
-    .limit(1);
-
-  if (!taskRow || taskRow.nodeType !== "Task") {
-    throw new TaskNotFoundError(taskId);
-  }
+  await requireOwnedTask(db, userId, taskId);
 
   if (dueOn === null) {
     const activeDueClaims = await db
@@ -97,4 +118,197 @@ export async function setCommitmentDue(
     claimId: created.id,
     retractedClaimIds: [],
   };
+}
+
+/**
+ * Open a new commitment as a `Task` node bootstrapped with its claims.
+ *
+ * Delegates node creation (metadata, embedding, manual source, today's day
+ * link) to {@link createNode}, supplying the commitment-specific
+ * `initialClaims`: a mandatory `HAS_TASK_STATUS` (so the task is never
+ * observable without a status), plus an optional `DUE_ON` — resolving the
+ * canonical Temporal node via {@link ensureDayNode} — and an optional
+ * `OWNED_BY`. Because `createNode` rolls the node back if any claim fails, a
+ * bad `ownedBy` leaves nothing behind.
+ *
+ * Always creates a new Task; callers wanting to advance an existing task's
+ * status or date use `createClaim` / {@link setCommitmentDue} instead.
+ */
+export async function createCommitment(
+  input: CreateCommitmentRequest,
+): Promise<CreateCommitmentResponse> {
+  const { userId, label, description, status, dueOn, ownedBy, assertedByKind } =
+    input;
+  const db = await useDatabase();
+
+  // Resolve the owner up-front: it yields a natural-language OWNED_BY statement
+  // and lets the response echo the same `{ nodeId, label }` shape as the
+  // open-commitments view. Existence is enforced here (createClaim re-checks)
+  // so a bad owner fails before any node is written.
+  let ownerLabel: string | null = null;
+  if (ownedBy !== undefined) {
+    const [ownerRow] = await db
+      .select({ label: nodeMetadata.label })
+      .from(nodes)
+      .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .where(and(eq(nodes.id, ownedBy), eq(nodes.userId, userId)))
+      .limit(1);
+    if (!ownerRow) throw new NodesNotFoundError(userId, [ownedBy]);
+    ownerLabel = ownerRow.label ?? null;
+  }
+
+  // HAS_TASK_STATUS first so its claim id is index 0; DUE_ON and OWNED_BY are
+  // appended only when supplied, and their positions are captured so we can map
+  // createNode's ordered `initialClaimIds` back onto the response.
+  const initialClaims: CreateNodeInitialClaim[] = [
+    {
+      predicate: "HAS_TASK_STATUS",
+      statement: `${label} is ${status}.`,
+      objectValue: status,
+      assertedByKind,
+    },
+  ];
+
+  let dueIndex: number | null = null;
+  if (dueOn !== undefined) {
+    const dueNodeId = await ensureDayNode(db, userId, parseISO(dueOn));
+    dueIndex =
+      initialClaims.push({
+        predicate: "DUE_ON",
+        statement: `${label} is due on ${dueOn}.`,
+        objectNodeId: dueNodeId,
+        assertedByKind,
+      }) - 1;
+  }
+
+  let ownerIndex: number | null = null;
+  if (ownedBy !== undefined) {
+    ownerIndex =
+      initialClaims.push({
+        predicate: "OWNED_BY",
+        statement: ownerLabel
+          ? `${label} is owned by ${ownerLabel}.`
+          : `${label} is owned by a referenced entity.`,
+        objectNodeId: ownedBy,
+        assertedByKind,
+      }) - 1;
+  }
+
+  const created = await createNode(
+    userId,
+    "Task",
+    label,
+    description,
+    initialClaims,
+  );
+
+  const ids = created.initialClaimIds;
+  const statusClaimId = ids[0];
+  if (statusClaimId === undefined) {
+    throw new Error("createCommitment: status claim was not created");
+  }
+
+  return {
+    taskId: created.id,
+    label: created.label,
+    status,
+    dueOn: dueOn ?? null,
+    owner:
+      ownedBy !== undefined ? { nodeId: ownedBy, label: ownerLabel } : null,
+    statusClaimId,
+    dueClaimId: dueIndex === null ? null : (ids[dueIndex] ?? null),
+    ownerClaimId: ownerIndex === null ? null : (ids[ownerIndex] ?? null),
+  };
+}
+
+/**
+ * Confirm a candidate commitment: re-assert its current `HAS_TASK_STATUS` as
+ * `user_confirmed`. The lifecycle engine supersedes the prior (typically
+ * `assistant_inferred`) claim, so the task graduates from the candidate view
+ * into {@link getOpenCommitments}. The status value is preserved — confirmation
+ * elevates provenance, not progress.
+ *
+ * Throws {@link TaskNotFoundError} if the subject isn't a Task owned by the
+ * user, or has no active `HAS_TASK_STATUS` to confirm.
+ */
+export async function confirmCommitment(
+  input: CommitmentActionRequest,
+): Promise<ConfirmCommitmentResponse> {
+  const { userId, taskId } = input;
+  const db = await useDatabase();
+
+  await requireOwnedTask(db, userId, taskId);
+
+  const [statusRow] = await db
+    .select({ objectValue: claims.objectValue })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.subjectNodeId, taskId),
+        eq(claims.predicate, "HAS_TASK_STATUS"),
+        eq(claims.status, "active"),
+      ),
+    )
+    .orderBy(desc(claims.statedAt), desc(claims.createdAt))
+    .limit(1);
+
+  if (!statusRow || statusRow.objectValue === null) {
+    throw new TaskNotFoundError(taskId);
+  }
+
+  const status = TaskStatusEnum.parse(statusRow.objectValue);
+
+  const created = await createClaim({
+    userId,
+    subjectNodeId: taskId,
+    predicate: "HAS_TASK_STATUS",
+    statement: `Task confirmed as ${status}.`,
+    objectValue: status,
+    assertedByKind: "user_confirmed",
+    statedAt: new Date(),
+  });
+
+  return { taskId, status, claimId: created.id };
+}
+
+/**
+ * Dismiss a commitment: retract every active `HAS_TASK_STATUS` claim on the
+ * task. With no active status it disappears from both the open and candidate
+ * views (both require one). Per the "retract only" policy this records no
+ * sticky rejection — a much-later re-inference may resurface it.
+ *
+ * Idempotent: a task with nothing active retracts nothing and returns an empty
+ * list. Throws {@link TaskNotFoundError} only when the subject isn't a Task
+ * owned by the user.
+ */
+export async function dismissCommitment(
+  input: CommitmentActionRequest,
+): Promise<DismissCommitmentResponse> {
+  const { userId, taskId } = input;
+  const db = await useDatabase();
+
+  await requireOwnedTask(db, userId, taskId);
+
+  const activeStatusClaims = await db
+    .select({ id: claims.id })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.subjectNodeId, taskId),
+        eq(claims.predicate, "HAS_TASK_STATUS"),
+        eq(claims.status, "active"),
+      ),
+    );
+
+  const retractedClaimIds: TypeId<"claim">[] = [];
+  for (const claim of activeStatusClaims) {
+    const updated = await updateClaim(userId, claim.id, {
+      status: "retracted",
+    });
+    if (updated) retractedClaimIds.push(updated.id);
+  }
+
+  return { taskId, retractedClaimIds };
 }

--- a/src/lib/context/assemble-bootstrap-context.test.ts
+++ b/src/lib/context/assemble-bootstrap-context.test.ts
@@ -530,6 +530,7 @@ describeIfServer("getConversationBootstrapContext", () => {
           openCommitmentsCalls += 1;
           return realModule.getOpenCommitments(...args);
         },
+        getCandidateCommitments: realModule.getCandidateCommitments,
       }));
 
       try {

--- a/src/lib/context/assemble-bootstrap-context.ts
+++ b/src/lib/context/assemble-bootstrap-context.ts
@@ -10,6 +10,7 @@
  */
 import { getCachedBundle, setCachedBundle } from "./cache";
 import { assembleAtlasSection } from "./sections/atlas";
+import { assembleCandidateCommitmentsSection } from "./sections/candidate-commitments";
 import { assembleOpenCommitmentsSection } from "./sections/open-commitments";
 import { assemblePinnedSection } from "./sections/pinned";
 import { assemblePreferencesSection } from "./sections/preferences";
@@ -46,19 +47,27 @@ export async function getConversationBootstrapContext(
 
   // Run independent reads in parallel; each assembler returns null when its
   // section is empty, so the order below is purely the render order.
-  const [pinned, atlas, openCommitments, recent, preferences] =
-    await Promise.all([
-      assemblePinnedSection(db, userId),
-      assembleAtlasSection(db, userId),
-      assembleOpenCommitmentsSection(userId),
-      assembleRecentSupersessionsSection(db, userId, asOf),
-      assemblePreferencesSection(db, userId),
-    ]);
+  const [
+    pinned,
+    atlas,
+    openCommitments,
+    candidateCommitments,
+    recent,
+    preferences,
+  ] = await Promise.all([
+    assemblePinnedSection(db, userId),
+    assembleAtlasSection(db, userId),
+    assembleOpenCommitmentsSection(userId),
+    assembleCandidateCommitmentsSection(userId),
+    assembleRecentSupersessionsSection(db, userId, asOf),
+    assemblePreferencesSection(db, userId),
+  ]);
 
   const sections: ContextSection[] = [
     pinned,
     atlas,
     openCommitments,
+    candidateCommitments,
     recent,
     preferences,
   ].filter((section): section is ContextSection => section !== null);

--- a/src/lib/context/sections/candidate-commitments.ts
+++ b/src/lib/context/sections/candidate-commitments.ts
@@ -1,0 +1,52 @@
+/**
+ * Candidate commitments section assembler.
+ *
+ * Surfaces the inferred-but-unconfirmed tasks that `getCandidateCommitments`
+ * returns (the band `getOpenCommitments` deliberately hides). The usage copy
+ * frames these as tentative so the assistant raises them for confirmation
+ * rather than stating them as settled work. Empty list → no section. Capped at
+ * 20 by stated_at desc.
+ *
+ * Confirmation/dismissal happen through the `confirm_commitment` /
+ * `dismiss_commitment` tools, keyed by the task node id.
+ */
+import type { ContextSectionCandidateCommitments } from "../types";
+import { getCandidateCommitments } from "~/lib/query/open-commitments";
+import type { OpenCommitment } from "~/lib/schemas/open-commitments";
+
+const MAX_CANDIDATES = 20;
+const USAGE =
+  "Unconfirmed commitments the assistant inferred — NOT authoritative open work. Raise them with the user to confirm ('looks like you committed to X — track it?'); on agreement call confirm_commitment with the task's node id, on rejection call dismiss_commitment. Never present these as settled tasks.";
+
+function renderLine(commitment: OpenCommitment): string {
+  const label = commitment.label ?? "(unlabeled task)";
+  const parts: string[] = [
+    `- ${label} [${commitment.status}] id=${commitment.taskId}`,
+  ];
+  if (commitment.owner !== null) {
+    parts.push(`owner=${commitment.owner.label ?? "(unlabeled)"}`);
+  }
+  if (commitment.dueOn !== null) {
+    parts.push(`due=${commitment.dueOn}`);
+  }
+  return parts.join(" ");
+}
+
+export async function assembleCandidateCommitmentsSection(
+  userId: string,
+): Promise<ContextSectionCandidateCommitments | null> {
+  const all = await getCandidateCommitments({ userId });
+  if (all.length === 0) return null;
+
+  const sorted = [...all].sort(
+    (a, b) => b.statedAt.getTime() - a.statedAt.getTime(),
+  );
+  const top = sorted.slice(0, MAX_CANDIDATES);
+  const content = top.map(renderLine).join("\n");
+
+  return {
+    kind: "candidate_commitments",
+    content,
+    usage: USAGE,
+  };
+}

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -45,6 +45,14 @@ export type ContextSectionOpenCommitments = z.infer<
   typeof contextSectionOpenCommitmentsSchema
 >;
 
+export const contextSectionCandidateCommitmentsSchema = z.object({
+  kind: z.literal("candidate_commitments"),
+  ...baseSectionFields,
+});
+export type ContextSectionCandidateCommitments = z.infer<
+  typeof contextSectionCandidateCommitmentsSchema
+>;
+
 export const contextSectionRecentSupersessionsSchema = z.object({
   kind: z.literal("recent_supersessions"),
   ...baseSectionFields,
@@ -65,6 +73,7 @@ export const contextSectionSchema = z.discriminatedUnion("kind", [
   contextSectionPinnedSchema,
   contextSectionAtlasSchema,
   contextSectionOpenCommitmentsSchema,
+  contextSectionCandidateCommitmentsSchema,
   contextSectionRecentSupersessionsSchema,
   contextSectionPreferencesSchema,
 ]);

--- a/src/lib/extract-graph.test.ts
+++ b/src/lib/extract-graph.test.ts
@@ -184,7 +184,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
     vi.doMock("./debug-utils", () => ({
       debugGraph: () => undefined,
     }));
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -460,7 +461,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
     vi.doMock("./debug-utils", () => ({
       debugGraph: () => undefined,
     }));
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -646,7 +648,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
     vi.doMock("./debug-utils", () => ({
       debugGraph: () => undefined,
     }));
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -773,7 +776,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
     vi.doMock("./debug-utils", () => ({
       debugGraph: () => undefined,
     }));
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -985,7 +989,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
         // the spy's signature without forging a fake Job.
         return undefined as never;
       });
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -1157,7 +1162,8 @@ describeIfServer("extractGraph claim-native insertion", () => {
     vi.doMock("./debug-utils", () => ({
       debugGraph: () => undefined,
     }));
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -11,7 +11,10 @@ import { findSimilarNodes, findOneHopNodes, findNodesByType } from "./graph";
 import { resolveIdentity } from "./identity-resolution";
 import { normalizeLabel } from "./label";
 import { recordMetricObservations } from "./metrics/observations";
-import { getOpenCommitments } from "./query/open-commitments";
+import {
+  getCandidateCommitments,
+  getOpenCommitments,
+} from "./query/open-commitments";
 import { safeToISOString } from "./safe-date";
 import {
   llmExtractionSchema,
@@ -146,20 +149,27 @@ export async function extractGraph({
     )
     .join("\n");
 
-  const [embeddingSimilar, oneHopNeighbors, allPersonNodes, openCommitments] =
-    await Promise.all([
-      findSimilarNodes({
-        userId,
-        text: content,
-        limit: 50,
-        minimumSimilarity: 0.3,
-      }),
-      findOneHopNodes(db, userId, [linkedNodeId]),
-      findNodesByType(userId, "Person"),
-      getOpenCommitments({ userId }),
-    ]);
+  const [
+    embeddingSimilar,
+    oneHopNeighbors,
+    allPersonNodes,
+    openCommitments,
+    candidateCommitments,
+  ] = await Promise.all([
+    findSimilarNodes({
+      userId,
+      text: content,
+      limit: 50,
+      minimumSimilarity: 0.3,
+    }),
+    findOneHopNodes(db, userId, [linkedNodeId]),
+    findNodesByType(userId, "Person"),
+    getOpenCommitments({ userId }),
+    getCandidateCommitments({ userId }),
+  ]);
 
   const cappedOpenCommitments = openCommitments.slice(0, 20);
+  const cappedCandidateCommitments = candidateCommitments.slice(0, 20);
 
   // Deduplicate by node ID: open commitments first (so the LLM sees them),
   // then person nodes (most duplicated type), then embedding results, then
@@ -167,7 +177,10 @@ export async function extractGraph({
   const seenIds = new Set<TypeId<"node">>();
   const similarNodesForProcessing: SimilarNodeForPrompt[] = [];
 
-  for (const commitment of cappedOpenCommitments) {
+  for (const commitment of [
+    ...cappedOpenCommitments,
+    ...cappedCandidateCommitments,
+  ]) {
     if (seenIds.has(commitment.taskId)) continue;
     seenIds.add(commitment.taskId);
     similarNodesForProcessing.push({
@@ -205,6 +218,10 @@ export async function extractGraph({
     cappedOpenCommitments,
   );
 
+  const candidateCommitmentsPromptSection = _formatCandidateCommitmentsSection(
+    cappedCandidateCommitments,
+  );
+
   const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
 
   const { createCompletionClient } = await import("./ai");
@@ -228,6 +245,8 @@ ${formatNodesForPrompt(nodesForPromptFormatting)}
 }
 
 ${openCommitmentsPromptSection}
+
+${candidateCommitmentsPromptSection}
 
 ${speakerMapPromptSection}
 
@@ -676,6 +695,39 @@ These are the user's currently open Task nodes. Each line lists the task's exist
   }
 
   const lines = openCommitments.map((commitment) => {
+    const label = commitment.label ?? "(unlabeled task)";
+    const ownerPart = commitment.owner?.label
+      ? `; owner: ${commitment.owner.label}`
+      : commitment.owner
+        ? `; ownerNodeId: ${commitment.owner.nodeId}`
+        : "";
+    const duePart = commitment.dueOn ? `; dueOn: ${commitment.dueOn}` : "";
+    return `- existingNodeId: ${commitment.taskId}; label: ${label}; status: ${commitment.status}${ownerPart}${duePart}`;
+  });
+
+  return `${header}
+${lines.join("\n")}`;
+}
+
+/**
+ * Render the unconfirmed candidate tasks (inferred status) so the extractor
+ * can reuse their nodes instead of minting duplicates, and can *promote* one
+ * when the source corroborates it. Distinct from open tasks: these are
+ * tentative until the user confirms. Empty list → section omitted entirely.
+ */
+function _formatCandidateCommitmentsSection(
+  candidateCommitments: OpenCommitment[],
+): string {
+  if (candidateCommitments.length === 0) return "";
+
+  const header = `CANDIDATE TASKS (UNCONFIRMED):
+These are tasks the assistant previously *inferred* but the user has not confirmed. Each line lists the candidate's existing nodeId, label, status, owner, and due date. RULES:
+- If THIS source shows the user explicitly stating, acting on, or agreeing to one of these, emit a \`HAS_TASK_STATUS\` attribute claim with assertionKind "user" whose subjectId is the candidate's existingNodeId below. This confirms it — DO NOT create a new Task node.
+- If the source completes or abandons one, emit the matching \`HAS_TASK_STATUS\` (assertionKind "user") against its existingNodeId.
+- If the source neither corroborates nor changes a candidate, do NOT re-emit it.
+- NEVER create a new Task node for something already listed here.`;
+
+  const lines = candidateCommitments.map((commitment) => {
     const label = commitment.label ?? "(unlabeled task)";
     const ownerPart = commitment.owner?.label
       ? `; owner: ${commitment.owner.label}`

--- a/src/lib/ingest-search.test.ts
+++ b/src/lib/ingest-search.test.ts
@@ -203,7 +203,8 @@ describeIfServer("ingest -> search end-to-end", () => {
     // Mock the LLM: deterministic extraction of one Project + one Object,
     // both linked back to the existing Person, plus an attribute claim and
     // an alias.
-    vi.doMock("./ai", () => ({
+    vi.doMock("./ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {

--- a/src/lib/jobs/ingest-transcript.test.ts
+++ b/src/lib/jobs/ingest-transcript.test.ts
@@ -312,7 +312,8 @@ describeIfServer("ingestTranscript", () => {
     const database = drizzle(client, { schema, casing: "snake_case" });
 
     applyCommonMocks(database);
-    vi.doMock("../ai", () => ({
+    vi.doMock("../ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -628,7 +629,8 @@ describeIfServer("ingestTranscript", () => {
     const database = drizzle(client, { schema, casing: "snake_case" });
 
     applyCommonMocks(database);
-    vi.doMock("../ai", () => ({
+    vi.doMock("../ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {
@@ -705,7 +707,8 @@ describeIfServer("ingestTranscript", () => {
     const database = drizzle(client, { schema, casing: "snake_case" });
 
     applyCommonMocks(database);
-    vi.doMock("../ai", () => ({
+    vi.doMock("../ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../ai")>()),
       createCompletionClient: async () => ({
         beta: {
           chat: {

--- a/src/lib/mcp/mcp-server.ts
+++ b/src/lib/mcp/mcp-server.ts
@@ -1,7 +1,10 @@
 import { SSEServerTransport } from "./sse";
 import {
   BOOTSTRAP_MEMORY_DESCRIPTION,
+  CONFIRM_COMMITMENT_DESCRIPTION,
   CREATE_CLAIM_DESCRIPTION,
+  CREATE_COMMITMENT_DESCRIPTION,
+  DISMISS_COMMITMENT_DESCRIPTION,
   GET_METRIC_SERIES_DESCRIPTION,
   GET_METRIC_SUMMARY_DESCRIPTION,
   GET_ENTITY_DESCRIPTION,
@@ -16,7 +19,13 @@ import {
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createClaim } from "~/lib/claim";
+import { createClaim, NodesNotFoundError } from "~/lib/claim";
+import {
+  confirmCommitment,
+  createCommitment,
+  dismissCommitment,
+  TaskNotFoundError,
+} from "~/lib/commitments";
 import { getConversationBootstrapContext } from "~/lib/context/assemble-bootstrap-context";
 import { getNodeCard } from "~/lib/context/node-card";
 import { nodeCardSchema } from "~/lib/context/node-card-types";
@@ -41,6 +50,11 @@ import {
   createClaimResponseSchema,
 } from "~/lib/schemas/claim";
 import {
+  commitmentActionRequestSchema,
+  confirmCommitmentResponseSchema,
+  dismissCommitmentResponseSchema,
+} from "~/lib/schemas/commitment-action";
+import {
   bootstrapMemoryRequestSchema,
   getEntityRequestSchema,
 } from "~/lib/schemas/context";
@@ -48,6 +62,10 @@ import {
   cardSearchToolInputSchema,
   contextSearchResponseSchema,
 } from "~/lib/schemas/context-search";
+import {
+  createCommitmentRequestSchema,
+  createCommitmentResponseSchema,
+} from "~/lib/schemas/create-commitment";
 import { ingestDocumentRequestSchema } from "~/lib/schemas/ingest-document-request";
 import {
   getMetricSeriesRequestSchema,
@@ -250,6 +268,96 @@ server.tool(
         },
       ],
     };
+  },
+);
+
+server.tool(
+  "create_commitment",
+  CREATE_COMMITMENT_DESCRIPTION,
+  createCommitmentRequestSchema.shape,
+  async (params) => {
+    try {
+      const input = createCommitmentRequestSchema.parse(params);
+      const result = await createCommitment(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              createCommitmentResponseSchema.parse(result),
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (e) {
+      if (e instanceof NodesNotFoundError) {
+        return {
+          content: [{ type: "text", text: e.message }],
+          isError: true,
+        };
+      }
+      throw e;
+    }
+  },
+);
+
+server.tool(
+  "confirm_commitment",
+  CONFIRM_COMMITMENT_DESCRIPTION,
+  commitmentActionRequestSchema.shape,
+  async (params) => {
+    try {
+      const input = commitmentActionRequestSchema.parse(params);
+      const result = await confirmCommitment(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              confirmCommitmentResponseSchema.parse(result),
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (e) {
+      if (e instanceof TaskNotFoundError) {
+        return { content: [{ type: "text", text: e.message }], isError: true };
+      }
+      throw e;
+    }
+  },
+);
+
+server.tool(
+  "dismiss_commitment",
+  DISMISS_COMMITMENT_DESCRIPTION,
+  commitmentActionRequestSchema.shape,
+  async (params) => {
+    try {
+      const input = commitmentActionRequestSchema.parse(params);
+      const result = await dismissCommitment(input);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              dismissCommitmentResponseSchema.parse(result),
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (e) {
+      if (e instanceof TaskNotFoundError) {
+        return { content: [{ type: "text", text: e.message }], isError: true };
+      }
+      throw e;
+    }
   },
 );
 

--- a/src/lib/mcp/tool-descriptions.test.ts
+++ b/src/lib/mcp/tool-descriptions.test.ts
@@ -1,6 +1,9 @@
 import {
   BOOTSTRAP_MEMORY_DESCRIPTION,
+  CONFIRM_COMMITMENT_DESCRIPTION,
   CREATE_CLAIM_DESCRIPTION,
+  CREATE_COMMITMENT_DESCRIPTION,
+  DISMISS_COMMITMENT_DESCRIPTION,
   GET_METRIC_SERIES_DESCRIPTION,
   GET_METRIC_SUMMARY_DESCRIPTION,
   GET_ENTITY_DESCRIPTION,
@@ -54,6 +57,24 @@ describe("MCP tool descriptions", () => {
   it("pins create_claim description", () => {
     expect(CREATE_CLAIM_DESCRIPTION).toMatchInlineSnapshot(
       `"Creates a claim between an existing subject node and either an existing object node or a scalar object value. Returns the created claim plus subjectLabel and objectLabel so callers can immediately reflect the new relationship in the UI."`,
+    );
+  });
+
+  it("pins create_commitment description", () => {
+    expect(CREATE_COMMITMENT_DESCRIPTION).toMatchInlineSnapshot(
+      `"Opens a new task/commitment for the user as a Task with status pending or in_progress, plus an optional due date (YYYY-MM-DD) and owner node id. Call the moment the user commits to doing something, asks you to track a to-do, or says to remind them. To propose a tentative commitment you are not sure about, pass assertedByKind "assistant_inferred" so it lands as a candidate for the user to confirm rather than a confirmed task. Always creates a new commitment — to advance, complete, or re-date an existing task use create_claim with HAS_TASK_STATUS instead of creating a duplicate."`,
+    );
+  });
+
+  it("pins confirm_commitment description", () => {
+    expect(CONFIRM_COMMITMENT_DESCRIPTION).toMatchInlineSnapshot(
+      `"Confirms a candidate (inferred, unconfirmed) commitment the user agrees is real, promoting it so it appears in their open commitments. Call when the user affirms a task you surfaced from the candidates-to-confirm list ('yes, track that'). Pass the task's node id. Use dismiss_commitment instead when the user says it is not a real commitment."`,
+    );
+  });
+
+  it("pins dismiss_commitment description", () => {
+    expect(DISMISS_COMMITMENT_DESCRIPTION).toMatchInlineSnapshot(
+      `"Dismisses a commitment by retracting its current status, removing it from both the open and candidate lists. Call when the user rejects a candidate you surfaced ('no, that is not a commitment') or wants to drop a tracked task without marking it done. Pass the task's node id."`,
     );
   });
 

--- a/src/lib/mcp/tool-descriptions.ts
+++ b/src/lib/mcp/tool-descriptions.ts
@@ -31,6 +31,15 @@ export const GET_ENTITY_DESCRIPTION =
 export const CREATE_CLAIM_DESCRIPTION =
   "Creates a claim between an existing subject node and either an existing object node or a scalar object value. Returns the created claim plus subjectLabel and objectLabel so callers can immediately reflect the new relationship in the UI.";
 
+export const CREATE_COMMITMENT_DESCRIPTION =
+  'Opens a new task/commitment for the user as a Task with status pending or in_progress, plus an optional due date (YYYY-MM-DD) and owner node id. Call the moment the user commits to doing something, asks you to track a to-do, or says to remind them. To propose a tentative commitment you are not sure about, pass assertedByKind "assistant_inferred" so it lands as a candidate for the user to confirm rather than a confirmed task. Always creates a new commitment — to advance, complete, or re-date an existing task use create_claim with HAS_TASK_STATUS instead of creating a duplicate.';
+
+export const CONFIRM_COMMITMENT_DESCRIPTION =
+  "Confirms a candidate (inferred, unconfirmed) commitment the user agrees is real, promoting it so it appears in their open commitments. Call when the user affirms a task you surfaced from the candidates-to-confirm list ('yes, track that'). Pass the task's node id. Use dismiss_commitment instead when the user says it is not a real commitment.";
+
+export const DISMISS_COMMITMENT_DESCRIPTION =
+  "Dismisses a commitment by retracting its current status, removing it from both the open and candidate lists. Call when the user rejects a candidate you surfaced ('no, that is not a commitment') or wants to drop a tracked task without marking it done. Pass the task's node id.";
+
 export const RECORD_METRIC_DESCRIPTION =
   'Records a single numeric reading the user is tracking (weight, distance, sleep duration, mood score). Provide a metric definition (slug, label, unit, aggregation hint) — the system reuses existing definitions for similar concepts and creates new ones automatically. Use for ad-hoc readings the user mentions in chat ("log that I weighed 78kg"). Do not use for retrospective bulk imports.';
 

--- a/src/lib/query/open-commitments.ts
+++ b/src/lib/query/open-commitments.ts
@@ -35,9 +35,69 @@ function isOpenTaskStatus(
   return status === "pending" || status === "in_progress";
 }
 
+/**
+ * Which provenance band of Task statuses to return:
+ * - `"trusted"` — every kind EXCEPT `assistant_inferred` (the open-commitments
+ *   view the assistant and user act on).
+ * - `"candidate"` — ONLY `assistant_inferred` (unconfirmed tasks awaiting
+ *   confirmation; hidden from the trusted view).
+ */
+type CommitmentProvenance = "trusted" | "candidate";
+
+/**
+ * Provenance predicate for the *defining* `HAS_TASK_STATUS` claim — this is
+ * what splits the two bands: candidate = inferred status, trusted = everything
+ * else.
+ */
+function provenanceFilter(
+  column: typeof claims.assertedByKind,
+  provenance: CommitmentProvenance,
+) {
+  return provenance === "candidate"
+    ? eq(column, "assistant_inferred")
+    : ne(column, "assistant_inferred");
+}
+
+/**
+ * Provenance predicate for the OWNED_BY / DUE_ON metadata sub-joins, which is
+ * NOT symmetric with the status filter. The trusted view shows only trusted
+ * metadata (excludes inferred). The candidate view applies NO provenance
+ * constraint, so a *trusted* owner/due set on a not-yet-confirmed candidate
+ * (e.g. via `setCommitmentDue`) still surfaces rather than being hidden behind
+ * an `assistant_inferred`-only match.
+ */
+function subJoinProvenanceFilter(
+  column: typeof claims.assertedByKind,
+  provenance: CommitmentProvenance,
+) {
+  return provenance === "trusted"
+    ? ne(column, "assistant_inferred")
+    : undefined;
+}
+
 /** List lifecycle-current open Task nodes. Common aliases: open tasks, commitments, todos. */
 export async function getOpenCommitments(
   params: OpenCommitmentsRequest,
+): Promise<OpenCommitment[]> {
+  return queryCommitments(params, "trusted");
+}
+
+/**
+ * List lifecycle-current *candidate* Task nodes — open tasks whose latest
+ * trusted-band status is `assistant_inferred`, i.e. the extractor proposed
+ * them but the user hasn't confirmed. Surfaced for proactive confirmation;
+ * deliberately excluded from {@link getOpenCommitments}. Common aliases:
+ * candidate commitments, inferred tasks, unconfirmed tasks, tasks to confirm.
+ */
+export async function getCandidateCommitments(
+  params: OpenCommitmentsRequest,
+): Promise<OpenCommitment[]> {
+  return queryCommitments(params, "candidate");
+}
+
+async function queryCommitments(
+  params: OpenCommitmentsRequest,
+  provenance: CommitmentProvenance,
 ): Promise<OpenCommitment[]> {
   const { userId, ownedBy, dueBefore } = params;
   const db = await useDatabase();
@@ -75,7 +135,7 @@ export async function getOpenCommitments(
         eq(ownerClaim.predicate, "OWNED_BY"),
         eq(ownerClaim.status, "active"),
         eq(ownerClaim.scope, "personal"),
-        ne(ownerClaim.assertedByKind, "assistant_inferred"),
+        subJoinProvenanceFilter(ownerClaim.assertedByKind, provenance),
         isNotNull(ownerClaim.objectNodeId),
       ),
     )
@@ -88,7 +148,7 @@ export async function getOpenCommitments(
         eq(dueClaim.predicate, "DUE_ON"),
         eq(dueClaim.status, "active"),
         eq(dueClaim.scope, "personal"),
-        ne(dueClaim.assertedByKind, "assistant_inferred"),
+        subJoinProvenanceFilter(dueClaim.assertedByKind, provenance),
         isNotNull(dueClaim.objectNodeId),
       ),
     )
@@ -99,7 +159,7 @@ export async function getOpenCommitments(
         eq(claims.predicate, "HAS_TASK_STATUS"),
         eq(claims.status, "active"),
         eq(claims.scope, "personal"),
-        ne(claims.assertedByKind, "assistant_inferred"),
+        provenanceFilter(claims.assertedByKind, provenance),
         ownedBy === undefined
           ? undefined
           : eq(ownerClaim.objectNodeId, ownedBy),

--- a/src/lib/schemas/commitment-action.ts
+++ b/src/lib/schemas/commitment-action.ts
@@ -1,0 +1,42 @@
+import { TaskStatusEnum } from "../../types/graph.js";
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+/**
+ * Confirm or dismiss an existing commitment, addressed by its Task node id.
+ * Both actions share this request shape; the verbs differ in effect:
+ *
+ * - confirm → promote the task's current `HAS_TASK_STATUS` to `user_confirmed`
+ *   (supersedes any inferred claim), making it visible in the open-commitments
+ *   view.
+ * - dismiss → retract the active `HAS_TASK_STATUS`, removing the task from both
+ *   the open and candidate views.
+ */
+export const commitmentActionRequestSchema = z.object({
+  userId: z.string(),
+  taskId: typeIdSchema("node"),
+});
+
+export const confirmCommitmentResponseSchema = z.object({
+  taskId: typeIdSchema("node"),
+  /** The status preserved by confirmation (it elevates provenance, not status). */
+  status: TaskStatusEnum,
+  /** ID of the new `user_confirmed` `HAS_TASK_STATUS` claim. */
+  claimId: typeIdSchema("claim"),
+});
+
+export const dismissCommitmentResponseSchema = z.object({
+  taskId: typeIdSchema("node"),
+  /** IDs of the `HAS_TASK_STATUS` claims this call retracted (may be empty). */
+  retractedClaimIds: z.array(typeIdSchema("claim")),
+});
+
+export type CommitmentActionRequest = z.infer<
+  typeof commitmentActionRequestSchema
+>;
+export type ConfirmCommitmentResponse = z.infer<
+  typeof confirmCommitmentResponseSchema
+>;
+export type DismissCommitmentResponse = z.infer<
+  typeof dismissCommitmentResponseSchema
+>;

--- a/src/lib/schemas/create-commitment.test.ts
+++ b/src/lib/schemas/create-commitment.test.ts
@@ -1,0 +1,70 @@
+import { newTypeId } from "../../types/typeid";
+import { createCommitmentRequestSchema } from "./create-commitment";
+import { describe, expect, it } from "vitest";
+
+describe("createCommitmentRequestSchema", () => {
+  it("defaults status to pending when omitted", () => {
+    const parsed = createCommitmentRequestSchema.parse({
+      userId: "user_1",
+      label: "Send the spec",
+    });
+    expect(parsed.status).toBe("pending");
+    expect(parsed.dueOn).toBeUndefined();
+    expect(parsed.ownedBy).toBeUndefined();
+  });
+
+  it("accepts in_progress as an open status", () => {
+    const parsed = createCommitmentRequestSchema.parse({
+      userId: "user_1",
+      label: "Migrate the worker",
+      status: "in_progress",
+    });
+    expect(parsed.status).toBe("in_progress");
+  });
+
+  it("rejects done and abandoned — a commitment opens only as pending or in_progress", () => {
+    for (const status of ["done", "abandoned"]) {
+      expect(() =>
+        createCommitmentRequestSchema.parse({
+          userId: "user_1",
+          label: "x",
+          status,
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("requires a non-empty label", () => {
+    expect(() =>
+      createCommitmentRequestSchema.parse({ userId: "user_1", label: "" }),
+    ).toThrow();
+  });
+
+  it("accepts a YYYY-MM-DD due date and rejects other formats", () => {
+    expect(
+      createCommitmentRequestSchema.parse({
+        userId: "user_1",
+        label: "x",
+        dueOn: "2026-06-06",
+      }).dueOn,
+    ).toBe("2026-06-06");
+    expect(() =>
+      createCommitmentRequestSchema.parse({
+        userId: "user_1",
+        label: "x",
+        dueOn: "2026/06/06",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts an owner node id", () => {
+    const ownedBy = newTypeId("node");
+    expect(
+      createCommitmentRequestSchema.parse({
+        userId: "user_1",
+        label: "x",
+        ownedBy,
+      }).ownedBy,
+    ).toBe(ownedBy);
+  });
+});

--- a/src/lib/schemas/create-commitment.ts
+++ b/src/lib/schemas/create-commitment.ts
@@ -1,0 +1,77 @@
+import { AssertedByKindEnum, TaskStatusEnum } from "../../types/graph.js";
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+/**
+ * Open a new commitment (a `Task` node) in one call.
+ *
+ * Counterpart to the read-only `getOpenCommitments` view and the
+ * `setCommitmentDue` mutation: where those surface and re-date commitments the
+ * ingestion extractor already minted, this lets a trusted client (assistant or
+ * UI) create one deliberately the moment the user commits to something.
+ *
+ * The server creates the `Task` node and bootstraps it with a `HAS_TASK_STATUS`
+ * claim (so it is never observable in a half-bootstrapped, status-less state),
+ * plus an optional `DUE_ON` claim — resolving the canonical Temporal node
+ * internally — and an optional `OWNED_BY` claim to a referenced entity. A fresh
+ * commitment therefore deserialises identically to one returned by
+ * `getOpenCommitments`.
+ *
+ * Always creates a new Task; it does not dedupe against existing open
+ * commitments with the same label.
+ */
+export const createCommitmentRequestSchema = z.object({
+  userId: z.string(),
+  label: z.string().min(1),
+  description: z.string().min(1).optional(),
+  /**
+   * Status at creation. A commitment can only open as `pending` or
+   * `in_progress`; `done`/`abandoned` are reached later via a superseding
+   * `HAS_TASK_STATUS` claim, not at creation. Defaults to `pending`.
+   */
+  status: TaskStatusEnum.extract(["pending", "in_progress"]).default("pending"),
+  /**
+   * Optional due date as `YYYY-MM-DD`. The server resolves (or creates) the
+   * canonical Temporal day node and asserts a `DUE_ON` claim.
+   */
+  dueOn: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "dueOn must be YYYY-MM-DD")
+    .optional(),
+  /**
+   * Optional owner: the node id of the entity (typically a `Person`) that owns
+   * the commitment. Emits an `OWNED_BY` claim. Must be an existing node owned
+   * by `userId`, otherwise the call fails before any node is written.
+   */
+  ownedBy: typeIdSchema("node").optional(),
+  /**
+   * Provenance for the asserted claims. Defaults to `"user"`.
+   */
+  assertedByKind: AssertedByKindEnum.optional(),
+});
+
+export const createCommitmentResponseSchema = z.object({
+  taskId: typeIdSchema("node"),
+  label: z.string(),
+  status: TaskStatusEnum.extract(["pending", "in_progress"]),
+  dueOn: z.string().nullable(),
+  owner: z
+    .object({
+      nodeId: typeIdSchema("node"),
+      label: z.string().nullable(),
+    })
+    .nullable(),
+  /** ID of the bootstrapped `HAS_TASK_STATUS` claim. Always present. */
+  statusClaimId: typeIdSchema("claim"),
+  /** ID of the `DUE_ON` claim, or `null` when no due date was supplied. */
+  dueClaimId: typeIdSchema("claim").nullable(),
+  /** ID of the `OWNED_BY` claim, or `null` when no owner was supplied. */
+  ownerClaimId: typeIdSchema("claim").nullable(),
+});
+
+export type CreateCommitmentRequest = z.infer<
+  typeof createCommitmentRequestSchema
+>;
+export type CreateCommitmentResponse = z.infer<
+  typeof createCommitmentResponseSchema
+>;

--- a/src/routes/commitments/confirm.post.ts
+++ b/src/routes/commitments/confirm.post.ts
@@ -1,0 +1,23 @@
+import { defineEventHandler, createError } from "h3";
+import { confirmCommitment, TaskNotFoundError } from "~/lib/commitments";
+import {
+  commitmentActionRequestSchema,
+  confirmCommitmentResponseSchema,
+} from "~/lib/schemas/commitment-action";
+
+export default defineEventHandler(async (event) => {
+  const params = commitmentActionRequestSchema.parse(await readBody(event));
+  try {
+    const result = await confirmCommitment(params);
+    return confirmCommitmentResponseSchema.parse(result);
+  } catch (e) {
+    if (e instanceof TaskNotFoundError) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: e.message,
+        data: { name: e.name, taskId: e.taskId },
+      });
+    }
+    throw e;
+  }
+});

--- a/src/routes/commitments/create.post.ts
+++ b/src/routes/commitments/create.post.ts
@@ -1,0 +1,24 @@
+import { defineEventHandler, createError } from "h3";
+import { NodesNotFoundError } from "~/lib/claim";
+import { createCommitment } from "~/lib/commitments";
+import {
+  createCommitmentRequestSchema,
+  createCommitmentResponseSchema,
+} from "~/lib/schemas/create-commitment";
+
+export default defineEventHandler(async (event) => {
+  const params = createCommitmentRequestSchema.parse(await readBody(event));
+  try {
+    const result = await createCommitment(params);
+    return createCommitmentResponseSchema.parse(result);
+  } catch (e) {
+    if (e instanceof NodesNotFoundError) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: e.message,
+        data: { name: e.name, missingNodeIds: e.missingNodeIds },
+      });
+    }
+    throw e;
+  }
+});

--- a/src/routes/commitments/dismiss.post.ts
+++ b/src/routes/commitments/dismiss.post.ts
@@ -1,0 +1,23 @@
+import { defineEventHandler, createError } from "h3";
+import { dismissCommitment, TaskNotFoundError } from "~/lib/commitments";
+import {
+  commitmentActionRequestSchema,
+  dismissCommitmentResponseSchema,
+} from "~/lib/schemas/commitment-action";
+
+export default defineEventHandler(async (event) => {
+  const params = commitmentActionRequestSchema.parse(await readBody(event));
+  try {
+    const result = await dismissCommitment(params);
+    return dismissCommitmentResponseSchema.parse(result);
+  } catch (e) {
+    if (e instanceof TaskNotFoundError) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: e.message,
+        data: { name: e.name, taskId: e.taskId },
+      });
+    }
+    throw e;
+  }
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -40,6 +40,8 @@ export * from "../lib/schemas/user-self-aliases.js";
 export * from "../lib/schemas/user-profile-metadata.js";
 export * from "../lib/schemas/enums.js";
 export * from "../lib/schemas/set-commitment-due.js";
+export * from "../lib/schemas/create-commitment.js";
+export * from "../lib/schemas/commitment-action.js";
 export * from "../lib/schemas/sources.js";
 export * from "../lib/schemas/nodes-by-source.js";
 export * from "../lib/schemas/ingest-file.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -32,6 +32,13 @@ import {
   dedupSweepResponseSchema,
 } from "../lib/schemas/cleanup.js";
 import {
+  CommitmentActionRequest,
+  ConfirmCommitmentResponse,
+  DismissCommitmentResponse,
+  confirmCommitmentResponseSchema,
+  dismissCommitmentResponseSchema,
+} from "../lib/schemas/commitment-action.js";
+import {
   ContextSearchRequest,
   ContextSearchResponse,
   contextSearchResponseSchema,
@@ -40,6 +47,11 @@ import {
   BootstrapMemoryRequest,
   bootstrapMemoryRequestSchema,
 } from "../lib/schemas/context.js";
+import {
+  CreateCommitmentRequest,
+  CreateCommitmentResponse,
+  createCommitmentResponseSchema,
+} from "../lib/schemas/create-commitment.js";
 import {
   GetDigestRequest,
   GetDigestResponse,
@@ -690,6 +702,54 @@ export class MemoryClient {
       "POST",
       "/commitments/due",
       setCommitmentDueResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Open a new commitment as a Task: creates the node and bootstraps it with a
+   * `HAS_TASK_STATUS` claim (pending or in_progress), plus an optional `DUE_ON`
+   * (server resolves the Temporal node) and `OWNED_BY` claim. Always creates a
+   * new Task — use `createClaim`/`setCommitmentDue` to advance an existing one.
+   */
+  async createCommitment(
+    payload: CreateCommitmentRequest,
+  ): Promise<CreateCommitmentResponse> {
+    return this._fetch(
+      "POST",
+      "/commitments/create",
+      createCommitmentResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Confirm a candidate (inferred) commitment, promoting its `HAS_TASK_STATUS`
+   * to `user_confirmed` so it graduates from the candidate view into
+   * `getOpenCommitments`. The status value is preserved.
+   */
+  async confirmCommitment(
+    payload: CommitmentActionRequest,
+  ): Promise<ConfirmCommitmentResponse> {
+    return this._fetch(
+      "POST",
+      "/commitments/confirm",
+      confirmCommitmentResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Dismiss a commitment by retracting its active `HAS_TASK_STATUS`, removing
+   * it from both the open and candidate views. Records no sticky rejection.
+   */
+  async dismissCommitment(
+    payload: CommitmentActionRequest,
+  ): Promise<DismissCommitmentResponse> {
+    return this._fetch(
+      "POST",
+      "/commitments/dismiss",
+      dismissCommitmentResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## What & why

Shifts commitments from purely ingestion-extracted toward **active management**, then closes the loop so inferred guesses don't pollute the user's open work.

**Active creation** — `createCommitment` (lib + `POST /commitments/create` + SDK `createCommitment` + MCP `create_commitment`) lets the assistant/SDK open a commitment the moment the user states one, instead of waiting for batch extraction. Status `pending`/`in_progress`, optional `dueOn`/`ownedBy`.

**Candidate curation loop** — the extractor stamps uncertain commitments `assertedByKind: "assistant_inferred"`, which `getOpenCommitments` already hides. We make that band actionable rather than invisible:
- `getCandidateCommitments` — provenance-aware sibling of `getOpenCommitments` (query core refactored to take `trusted | candidate`; the trusted view is unchanged).
- `candidate_commitments` bootstrap section — surfaces candidates as *tentative* so the assistant raises them for confirmation, not as settled facts.
- `confirm_commitment` / `dismiss_commitment` (lib + routes + SDK + MCP) — confirm re-asserts the status as `user_confirmed` (lifecycle supersedes the inferred claim → it graduates into open commitments); dismiss retracts it.
- **Convergence fix** — the extractor now seeds existing candidates into its prompt, so re-ingestion reuses their nodes instead of duplicating, and a corroborating `user`-asserted status auto-promotes a candidate by trust rank.

No new `TaskStatus`, no new predicate, **no migration** — it all rides on the existing `assertedByKind` provenance axis and the claim lifecycle.

Design doc: `docs/superpowers/specs/2026-06-04-commitment-curation-loop-design.md`. Consumer follow-up (chat assistant prompts/tooling) tracked at marcelsamyn-org/petals#271.

The second commit is unrelated pre-existing test rot surfaced while getting the suite green: the `./ai` mocks in `extract-graph` / `ingest-transcript` / `ingest-search` only stubbed `createCompletionClient` and broke once `extractGraph` moved to the `parseStructuredCompletion` wrapper. Fixed by spreading the real module via `importOriginal`.

## How to test

Requires the local services (`docker compose up -d db redis minio`; test PG on `:5431`).

```
pnpm run build:check        # tsc --noEmit + structured-output check
pnpm run lint
pnpm run format
pnpm exec vitest run        # full suite
# focused:
pnpm exec vitest run src/lib/commitment-curation.test.ts src/lib/commitments.test.ts
```

New tests prove the loop end-to-end: a candidate is hidden from the open view, `confirmCommitment` supersedes the inferred claim and promotes it, `dismissCommitment` retracts it, and the bootstrap section renders candidates / is omitted when empty.

## Checklist
- [x] Build / typecheck clean (`tsc --noEmit`)
- [x] Tests pass — full suite **302/302** across 66 files
- [x] Lint clean (eslint)
- [x] Prettier clean
- [x] No schema migration / enum change
