### PR TITLE
✨ feat(commitments): expose candidate commitments endpoint + SDK client

### DIFF
--- a/src/routes/commitments/candidates.post.ts
+++ b/src/routes/commitments/candidates.post.ts
@@ -1,0 +1,11 @@
+import { getCandidateCommitments } from "~/lib/query/open-commitments";
+import {
+  openCommitmentsRequestSchema,
+  openCommitmentsResponseSchema,
+} from "~/lib/schemas/open-commitments";
+
+export default defineEventHandler(async (event) => {
+  const params = openCommitmentsRequestSchema.parse(await readBody(event));
+  const commitments = await getCandidateCommitments(params);
+  return openCommitmentsResponseSchema.parse({ commitments });
+});

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -690,6 +690,23 @@ export class MemoryClient {
   }
 
   /**
+   * Candidate commitments view: open Task nodes whose latest trusted personal
+   * `HAS_TASK_STATUS` is `assistant_inferred` — extractor-proposed work the user
+   * hasn't confirmed. Deliberately excluded from `getOpenCommitments`; surface
+   * these for proactive confirmation via `confirmCommitment` / `dismissCommitment`.
+   */
+  async getCandidateCommitments(
+    payload: OpenCommitmentsRequest,
+  ): Promise<OpenCommitmentsResponse> {
+    return this._fetch(
+      "POST",
+      "/commitments/candidates",
+      openCommitmentsResponseSchema,
+      payload,
+    );
+  }
+
+  /**
    * Set or clear a Task's due date. Pass `dueOn: "YYYY-MM-DD"` to assert a
    * new `DUE_ON` claim (the predicate lifecycle supersedes any prior date),
    * or `dueOn: null` to retract every active `DUE_ON` claim on the task.


### PR DESCRIPTION
## What & why

`getCandidateCommitments()` already existed server-side (`src/lib/query/open-commitments.ts`) but wasn't reachable over HTTP or the SDK. Candidate commitments are the inferred-but-unconfirmed Tasks (`HAS_TASK_STATUS = assistant_inferred`) that `getOpenCommitments` deliberately hides — needed by the chat app to proactively surface them for confirmation/dismissal.

This mirrors the open-commitments plumbing across all three layers:

- **Route** — `src/routes/commitments/candidates.post.ts`, a clone of `open.post.ts` calling `getCandidateCommitments`. Nitro file-based routing auto-registers it as `POST /commitments/candidates`.
- **SDK client** — `getCandidateCommitments(payload)` in `src/sdk/memory-client.ts`, placed next to `getOpenCommitments` and returning the same `OpenCommitmentsResponse` (`{ commitments }`) wrapper for sibling-method symmetry.
- **Schema** — reuses `openCommitmentsRequestSchema` (only `userId` required; `ownedBy`/`dueBefore` optional and honored by the query) and `openCommitmentsResponseSchema`. No new schema.

## How to test

```ts
const { commitments } = await client.getCandidateCommitments({ userId });
// → inferred, unconfirmed tasks awaiting confirmation
```

Or directly: `POST /commitments/candidates` with `{ "userId": "..." }`.

The candidate query band itself is already covered in `src/lib/query/open-commitments.test.ts`; the route/SDK are pure transport over that tested query (consistent with the repo's existing convention of no per-route/per-SDK-method tests).

## Checklist

- [x] Build — `pnpm run build:check` ✓ and `pnpm run build-sdk` (incl. `verify-sdk-build`) ✓
- [x] Tests — no new tests; query band already covered, matches repo convention
- [x] Lint — eslint clean on both files
- [x] Prettier — clean
- [ ] Coverage — n/a (transport-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)