### PR TITLE
Guard HAS_TASK_STATUS vocabulary at write and read boundaries

### DIFF
--- a/drizzle/0017_task_status_vocabulary_backfill.sql
+++ b/drizzle/0017_task_status_vocabulary_backfill.sql
@@ -1,0 +1,47 @@
+-- Repair HAS_TASK_STATUS claims whose objectValue drifted off the canonical
+-- TaskStatusEnum vocabulary ('pending' | 'in_progress' | 'done' | 'abandoned').
+--
+-- These reached the store via the extraction pipeline's bulk insert, which —
+-- unlike `createClaim` — did not validate the value against the enum. The
+-- open-commitments read model parses every active status with that enum, so a
+-- single off-vocabulary row 500s the whole /commitments/open endpoint
+-- (the ZodError that surfaced this).
+--
+-- This is the SQL twin of `coerceTaskStatus` in src/lib/claims/task-status.ts:
+--   1. normalize: trim + lowercase + collapse runs of whitespace/hyphens to '_'
+--   2. map the normalized form onto a canonical value (the four canonical
+--      values are included so casing/spacing variants like 'Done' or
+--      'In Progress' are repaired alongside synonyms like 'completed').
+-- Genuinely unmappable values (e.g. 'blocked') are left untouched; the hardened
+-- read path now skips them instead of throwing.
+--
+-- Idempotent: rows already on an exact canonical value don't match (guarded by
+-- object_value <> canonical) and are left alone. Scoped strictly to
+-- predicate = 'HAS_TASK_STATUS'. Keep this map in sync with task-status.ts.
+
+UPDATE "claims" c
+SET "object_value" = m.canonical,
+    "updated_at" = now()
+FROM (
+  VALUES
+    ('pending',     'pending'),
+    ('in_progress', 'in_progress'),
+    ('done',        'done'),
+    ('abandoned',   'abandoned'),
+    ('completed',   'done'),
+    ('complete',    'done'),
+    ('finished',    'done'),
+    ('cancelled',   'abandoned'),
+    ('canceled',    'abandoned'),
+    ('dropped',     'abandoned'),
+    ('todo',        'pending'),
+    ('to_do',       'pending'),
+    ('not_started', 'pending'),
+    ('doing',       'in_progress'),
+    ('started',     'in_progress'),
+    ('wip',         'in_progress')
+) AS m(synonym, canonical)
+WHERE c."predicate" = 'HAS_TASK_STATUS'
+  AND c."object_value" IS NOT NULL
+  AND regexp_replace(lower(btrim(c."object_value")), '[[:space:]-]+', '_', 'g') = m.synonym
+  AND c."object_value" <> m.canonical;

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1938 @@
+{
+  "id": "26114c1e-93a1-4828-a9ef-09abea97ad3e",
+  "prevId": "d75113f7-b410-4b63-a34c-0224a12cdb51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780724666106,
       "tag": "0016_even_zaladane",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780725000000,
+      "tag": "0017_task_status_vocabulary_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/claims/task-status.test.ts
+++ b/src/lib/claims/task-status.test.ts
@@ -1,0 +1,35 @@
+import { coerceTaskStatus } from "./task-status";
+import { describe, expect, it } from "vitest";
+
+describe("coerceTaskStatus", () => {
+  it("passes canonical values through unchanged", () => {
+    expect(coerceTaskStatus("pending")).toBe("pending");
+    expect(coerceTaskStatus("in_progress")).toBe("in_progress");
+    expect(coerceTaskStatus("done")).toBe("done");
+    expect(coerceTaskStatus("abandoned")).toBe("abandoned");
+  });
+
+  it("normalizes casing and spacing/hyphen variants", () => {
+    expect(coerceTaskStatus("Done")).toBe("done");
+    expect(coerceTaskStatus("In Progress")).toBe("in_progress");
+    expect(coerceTaskStatus("in-progress")).toBe("in_progress");
+    expect(coerceTaskStatus("  PENDING  ")).toBe("pending");
+  });
+
+  it("maps known off-vocabulary synonyms onto the canonical enum", () => {
+    expect(coerceTaskStatus("completed")).toBe("done");
+    expect(coerceTaskStatus("complete")).toBe("done");
+    expect(coerceTaskStatus("cancelled")).toBe("abandoned");
+    expect(coerceTaskStatus("canceled")).toBe("abandoned");
+    expect(coerceTaskStatus("todo")).toBe("pending");
+    expect(coerceTaskStatus("doing")).toBe("in_progress");
+  });
+
+  it("returns null for values it can't confidently map", () => {
+    expect(coerceTaskStatus("blocked")).toBeNull();
+    expect(coerceTaskStatus("")).toBeNull();
+    expect(coerceTaskStatus("   ")).toBeNull();
+    expect(coerceTaskStatus(null)).toBeNull();
+    expect(coerceTaskStatus(undefined)).toBeNull();
+  });
+});

--- a/src/lib/claims/task-status.ts
+++ b/src/lib/claims/task-status.ts
@@ -1,0 +1,55 @@
+import { TaskStatusEnum, type TaskStatus } from "~/types/graph";
+
+/**
+ * Off-vocabulary `HAS_TASK_STATUS` labels mapped back onto the canonical
+ * {@link TaskStatusEnum}. Keys are already normalized (see {@link normalize}):
+ * lowercased and with runs of whitespace/hyphens collapsed to a single `_`.
+ *
+ * Kept deliberately conservative — only labels whose intent is unambiguous.
+ * This guards the read model against the `completed`/`cancelled` vocabulary
+ * drift documented in docs/sdk-consumer-migration.md, where a consumer's tool
+ * schema diverged from the SDK enum.
+ *
+ * NOTE: the SQL twin of this map lives in
+ * `drizzle/0016_task_status_vocabulary_backfill.sql`. Keep the two in sync.
+ */
+const TASK_STATUS_SYNONYMS: Readonly<Record<string, TaskStatus>> = {
+  completed: "done",
+  complete: "done",
+  finished: "done",
+  cancelled: "abandoned",
+  canceled: "abandoned",
+  dropped: "abandoned",
+  todo: "pending",
+  to_do: "pending",
+  not_started: "pending",
+  doing: "in_progress",
+  started: "in_progress",
+  wip: "in_progress",
+};
+
+function normalize(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+/**
+ * Coerce a raw `HAS_TASK_STATUS` objectValue — from the extraction LLM, an SDK
+ * consumer, or a legacy row — onto the canonical {@link TaskStatusEnum}.
+ *
+ * Normalization handles casing/spacing variants ("In Progress" → "in_progress"),
+ * and a small synonym table handles well-known aliases ("completed" → "done").
+ * Returns `null` when the value can't be confidently mapped, so callers can
+ * skip or reject it rather than crash the request.
+ */
+export function coerceTaskStatus(
+  raw: string | null | undefined,
+): TaskStatus | null {
+  if (raw === null || raw === undefined) return null;
+  const normalized = normalize(raw);
+  const direct = TaskStatusEnum.safeParse(normalized);
+  if (direct.success) return direct.data;
+  return TASK_STATUS_SYNONYMS[normalized] ?? null;
+}

--- a/src/lib/commitments.ts
+++ b/src/lib/commitments.ts
@@ -3,6 +3,7 @@ import { format, parseISO } from "date-fns";
 import { and, desc, eq } from "drizzle-orm";
 import { claims, nodeMetadata, nodes } from "~/db/schema";
 import { createClaim, updateClaim, NodesNotFoundError } from "~/lib/claim";
+import { coerceTaskStatus } from "~/lib/claims/task-status";
 import { createNode } from "~/lib/node";
 import type {
   CommitmentActionRequest,
@@ -16,7 +17,6 @@ import type {
 import type { CreateNodeInitialClaim } from "~/lib/schemas/node";
 import type { SetCommitmentDueRequest } from "~/lib/schemas/set-commitment-due";
 import { ensureDayNode } from "~/lib/temporal";
-import { TaskStatusEnum } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
@@ -26,6 +26,22 @@ export class TaskNotFoundError extends Error {
     super(`Task not found: ${taskId}`);
     this.name = "TaskNotFoundError";
     this.taskId = taskId;
+  }
+}
+
+/**
+ * The Task's active `HAS_TASK_STATUS` carries an objectValue outside the
+ * canonical vocabulary and couldn't be coerced — corrupt state that predates
+ * the write-time guard (and should have been swept by migration 0016).
+ */
+export class InvalidTaskStatusError extends Error {
+  readonly taskId: TypeId<"node">;
+  readonly objectValue: string;
+  constructor(taskId: TypeId<"node">, objectValue: string) {
+    super(`Task ${taskId} has an unrecognized status: ${objectValue}`);
+    this.name = "InvalidTaskStatusError";
+    this.taskId = taskId;
+    this.objectValue = objectValue;
   }
 }
 
@@ -257,7 +273,10 @@ export async function confirmCommitment(
     throw new TaskNotFoundError(taskId);
   }
 
-  const status = TaskStatusEnum.parse(statusRow.objectValue);
+  const status = coerceTaskStatus(statusRow.objectValue);
+  if (status === null) {
+    throw new InvalidTaskStatusError(taskId, statusRow.objectValue);
+  }
 
   const created = await createClaim({
     userId,

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -1,6 +1,7 @@
 import { parseStructuredCompletion } from "./ai";
 import { createAlias, normalizeAliasText } from "./alias";
 import { applyClaimLifecycle, fetchClaimsByIds } from "./claims/lifecycle";
+import { coerceTaskStatus } from "./claims/task-status";
 import { debugGraph } from "./debug-utils";
 import {
   generateAndInsertNodeEmbeddings,
@@ -991,10 +992,29 @@ async function _processAndInsertLlmClaims(
     const provenance = _resolveAssertedByKind(llmClaim, sourceType, speakerMap);
     if (provenance === null) continue;
 
+    // HAS_TASK_STATUS carries the canonical TaskStatusEnum vocabulary the
+    // open-commitments read model parses. The LLM is *instructed* to emit one
+    // of the four values but doesn't always comply, and this bulk insert
+    // bypasses `createClaim`'s validation — so coerce here and drop anything
+    // we can't confidently map rather than poisoning the store.
+    let objectValue = llmClaim.objectValue;
+    if (llmClaim.predicate === "HAS_TASK_STATUS") {
+      const coerced = coerceTaskStatus(objectValue);
+      if (coerced === null) {
+        console.warn(
+          `Skipping HAS_TASK_STATUS claim with off-vocabulary objectValue: ${JSON.stringify(
+            llmClaim.objectValue,
+          )}`,
+        );
+        continue;
+      }
+      objectValue = coerced;
+    }
+
     claimInserts.push({
       userId,
       subjectNodeId,
-      objectValue: llmClaim.objectValue,
+      objectValue,
       predicate: llmClaim.predicate,
       statement: llmClaim.statement,
       description: llmClaim.statement,

--- a/src/lib/query/open-commitments.ts
+++ b/src/lib/query/open-commitments.ts
@@ -10,11 +10,12 @@ import {
   sql,
 } from "drizzle-orm";
 import { claims, nodeMetadata, nodes } from "~/db/schema";
+import { coerceTaskStatus } from "~/lib/claims/task-status";
 import {
   type OpenCommitment,
   type OpenCommitmentsRequest,
 } from "~/lib/schemas/open-commitments";
-import { TaskStatusEnum, type TaskStatus } from "~/types/graph";
+import { type TaskStatus } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
@@ -208,7 +209,19 @@ async function queryCommitments(
     if (seenTaskIds.has(row.taskId)) continue;
     seenTaskIds.add(row.taskId);
 
-    const status = TaskStatusEnum.parse(row.status);
+    // Off-vocabulary status values can reach the store via the extraction
+    // path (the LLM doesn't always honor the enum), so coerce known synonyms
+    // and skip anything genuinely unmappable. A single bad row must not 500
+    // the whole read — see `coerceTaskStatus`.
+    const status = coerceTaskStatus(row.status);
+    if (status === null) {
+      console.warn(
+        `Skipping Task ${row.taskId} with off-vocabulary HAS_TASK_STATUS: ${JSON.stringify(
+          row.status,
+        )}`,
+      );
+      continue;
+    }
     if (!isOpenTaskStatus(status)) continue;
     if (!matchesDueBefore(row.dueOn, dueBefore)) continue;
 


### PR DESCRIPTION
## Problem

`/commitments/open` was 500ing with a `ZodError` from `TaskStatusEnum.parse()` in `queryCommitments`. This was **not** a stale enum — the read parser is in sync with `TaskStatusEnum`; the error&#39;s allowed values (`pending|in_progress|done|abandoned`) are exactly its options. The real bug is the inverse: a `HAS_TASK_STATUS` claim whose `objectValue` is **outside** that vocabulary reached the DB, and the read model parsed every active status with `.parse()`, so a single bad row took down the entire endpoint.

**Root cause:** the extraction pipeline (`extract-graph.ts`) bulk-inserts claims directly, bypassing `createClaim`&#39;s `HAS_TASK_STATUS → TaskStatusEnum` validation. The enum is only a *soft instruction* in the LLM prompt (the schema field is `z.string()`), so off-vocabulary values like `completed`/`cancelled` could be persisted unvalidated (see the drift noted in `docs/sdk-consumer-migration.md`).

## Changes

- **`src/lib/claims/task-status.ts`** (new) — `coerceTaskStatus()`: normalizes casing/spacing (`"In Progress"` → `in_progress`) and maps known synonyms (`completed`→`done`, `cancelled`→`abandoned`, …) onto the canonical enum, returning `null` when it can&#39;t confidently map. Unit-tested.
- **`extract-graph.ts`** (close the write hole) — coerce `HAS_TASK_STATUS` object values before the bulk insert; drop (warn) anything unmappable instead of poisoning the store.
- **`open-commitments.ts`** (defence-in-depth on the read) — coerce, and skip+warn off-vocabulary rows instead of throwing. Note: this branch was rebased onto `main` after #(the commitments-query speedup) landed, which now also filters `objectValue IN ('pending','in_progress')` in SQL — so the loop-level guard is belt-and-suspenders for the open/candidate views.
- **`commitments.ts`** — `confirmCommitment` coerces the stored status; throws a typed `InvalidTaskStatusError` if genuinely corrupt.
- **`drizzle/0017_task_status_vocabulary_backfill.sql`** (new migration) — backfills existing off-vocabulary `HAS_TASK_STATUS` rows onto the canonical vocabulary. SQL twin of `coerceTaskStatus`, idempotent, scoped strictly to `predicate = 'HAS_TASK_STATUS'`. Coerces known synonyms rather than deleting; genuinely-unknown values are left in place and skipped by the hardened read path. (Renumbered from 0016 → 0017 after rebasing onto the newly-merged `0016_even_zaladane`.)

## Verification

`tsc --noEmit`, eslint, prettier, and the new `coerceTaskStatus` unit tests pass. The DB-integration tests (`open-commitments.test.ts`) require a live Postgres and were not run in this environment.

To preview the offending prod data:
```sql
SELECT object_value, count(*) FROM claims
WHERE predicate = 'HAS_TASK_STATUS'
  AND object_value NOT IN ('pending','in_progress','done','abandoned')
GROUP BY object_value;
```

https://claude.ai/code/session_01TfkgJRm8kW1da1Up5iibfe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfkgJRm8kW1da1Up5iibfe)_