### PR TITLE
Add environment variable defaults for cleanup operations tests

### DIFF
--- a/src/lib/jobs/cleanup-operations.test.ts
+++ b/src/lib/jobs/cleanup-operations.test.ts
@@ -36,6 +36,17 @@ const adminDsn = () =>
 const dsnFor = (dbName: string) =>
   `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
 
+process.env["DATABASE_URL"] ??= adminDsn();
+process.env["JINA_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_BASE_URL"] ??= "https://api.openai.com/v1";
+process.env["MODEL_ID_GRAPH_EXTRACTION"] ??= "test-model";
+process.env["REDIS_URL"] ??= "redis://localhost:6380";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
 async function isServerReachable(): Promise<boolean> {
   const client = new Client({ connectionString: adminDsn() });
   try {


### PR DESCRIPTION
## Summary
Added default environment variable initialization to the cleanup operations test file to ensure all required configuration values are present before tests run.

## Key Changes
- Set default values for 12 environment variables using the nullish coalescing assignment operator (`??=`):
  - `DATABASE_URL`: defaults to admin DSN
  - `JINA_API_KEY`: defaults to "test"
  - `MEMORY_OPENAI_API_KEY`: defaults to "test"
  - `MEMORY_OPENAI_API_BASE_URL`: defaults to OpenAI API endpoint
  - `MODEL_ID_GRAPH_EXTRACTION`: defaults to "test-model"
  - `REDIS_URL`: defaults to localhost on port 6380
  - `MINIO_ENDPOINT`: defaults to "localhost"
  - `MINIO_ACCESS_KEY`: defaults to "test"
  - `MINIO_SECRET_KEY`: defaults to "test"
  - `SOURCES_BUCKET`: defaults to "test"

## Implementation Details
- Uses the nullish coalescing assignment operator to only set values if they're not already defined, allowing environment variables to be overridden when needed
- Placed at the module level before test execution to ensure all dependencies are configured
- Provides sensible test defaults for external services (OpenAI, Jina, MinIO, Redis) to enable tests to run in isolated environments

https://claude.ai/code/session_016MnUoT4xrtWDW3zQeAXUV3