### PR TITLE
Make LLM extraction schema lenient about omitted collections

### DIFF
--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -403,15 +403,20 @@ ${
     }
   }
 
-  const uniqueParsedLlmNodes = _deduplicateLlmNodes(parsedLlmOutput.nodes);
+  // `?? []`: the extraction provider isn't strict structured output, so any of
+  // these collections may be omitted/null when the model has nothing to emit
+  // (see llmExtractionSchema). Treat a missing collection as empty.
+  const uniqueParsedLlmNodes = _deduplicateLlmNodes(
+    parsedLlmOutput.nodes ?? [],
+  );
   const uniqueParsedLlmClaims = _deduplicateLlmClaims(
-    parsedLlmOutput.relationshipClaims,
+    parsedLlmOutput.relationshipClaims ?? [],
   );
   const uniqueParsedLlmAttributeClaims = _deduplicateLlmAttributeClaims(
-    parsedLlmOutput.attributeClaims,
+    parsedLlmOutput.attributeClaims ?? [],
   );
   const uniqueParsedLlmAliases = _deduplicateLlmAliases(
-    parsedLlmOutput.aliases,
+    parsedLlmOutput.aliases ?? [],
   );
 
   const parentSourceScope = await _fetchSourceScope(db, userId, sourceId);

--- a/src/lib/schemas/llm-extraction.ts
+++ b/src/lib/schemas/llm-extraction.ts
@@ -113,11 +113,21 @@ export const llmMetricsSchema = z.object({
   standalone: z.array(llmMetricStandaloneObservationSchema).nullish(),
 });
 
+// The top-level collections are `.nullish()`, not required, on purpose. The
+// extraction endpoint is an OpenAI-*compatible* provider, not OpenAI strict
+// structured outputs, so it does NOT backfill an omitted/empty array to `[]`.
+// Models routinely drop a collection they have nothing to emit for — most often
+// `aliases`, since most sources introduce no nickname — which otherwise fails
+// the entire parse with `expected array, received undefined`. Absent/null
+// coerces to `[]` at the read sites in `extractGraph`. The item shapes above
+// stay strict so a genuinely malformed entry still surfaces (and the job
+// retries) rather than being silently swallowed: lax about an empty collection,
+// not about a broken one.
 export const llmExtractionSchema = z.object({
-  nodes: z.array(llmNodeSchema),
-  relationshipClaims: z.array(llmRelationshipClaimSchema),
-  attributeClaims: z.array(llmAttributeClaimSchema),
-  aliases: z.array(llmAliasSchema),
+  nodes: z.array(llmNodeSchema).nullish(),
+  relationshipClaims: z.array(llmRelationshipClaimSchema).nullish(),
+  attributeClaims: z.array(llmAttributeClaimSchema).nullish(),
+  aliases: z.array(llmAliasSchema).nullish(),
   metrics: llmMetricsSchema.nullish(),
 });
 

--- a/src/lib/structured-output-schemas.test.ts
+++ b/src/lib/structured-output-schemas.test.ts
@@ -14,3 +14,39 @@ describe("structured output JSON schemas", () => {
     ).not.toThrow();
   });
 });
+
+describe("llmExtractionSchema leniency", () => {
+  const validNode = { id: "temp_person_1", type: "Person", label: "Ada" };
+
+  it("parses a response that omits empty top-level collections", () => {
+    // A non-strict provider drops collections it has nothing for — most often
+    // `aliases`. This is the exact shape that previously threw
+    // `ZodError: expected array, received undefined` at path `aliases`.
+    const parsed = llmExtractionSchema.parse({
+      nodes: [validNode],
+      relationshipClaims: [],
+      attributeClaims: [],
+    });
+    expect(parsed.nodes).toHaveLength(1);
+    expect(parsed.aliases ?? []).toEqual([]);
+  });
+
+  it("parses when a collection arrives as null", () => {
+    const parsed = llmExtractionSchema.parse({
+      nodes: null,
+      relationshipClaims: null,
+      attributeClaims: null,
+      aliases: null,
+    });
+    expect(parsed.nodes ?? []).toEqual([]);
+    expect(parsed.aliases ?? []).toEqual([]);
+  });
+
+  it("still rejects a structurally malformed item (lax about empty, not broken)", () => {
+    expect(() =>
+      llmExtractionSchema.parse({
+        nodes: [{ id: "temp_1", type: "NotARealNodeType", label: "x" }],
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Updated the LLM extraction schema to gracefully handle cases where LLM providers omit or return null for empty collections, rather than failing validation. This improves compatibility with non-strict structured output providers.

## Key Changes
- Modified `llmExtractionSchema` to mark top-level collections (`nodes`, `relationshipClaims`, `attributeClaims`, `aliases`) as `.nullish()` instead of required arrays
- Updated `extractGraph` to coerce missing/null collections to empty arrays using the nullish coalescing operator (`?? []`)
- Added comprehensive test coverage for the new leniency behavior:
  - Parsing responses that omit empty collections
  - Parsing when collections arrive as null
  - Verifying that structurally malformed items are still rejected (lax about empty, strict about broken)

## Implementation Details
The extraction endpoint uses OpenAI-compatible providers rather than strict structured outputs, so models routinely omit collections they have nothing to emit for (particularly `aliases`). Previously this would fail with `ZodError: expected array, received undefined`. 

The fix maintains validation strictness at the item level—malformed entries in a collection still cause validation to fail and trigger job retries—while being lenient about missing collections at the top level. This prevents silent data loss while improving robustness against provider variations.

https://claude.ai/code/session_01LaRoEkvdFzpqTbyMCq9Hgx