### PR TITLE
Ensure user row exists before scratchpad upsert

### DIFF
--- a/src/lib/scratchpad.test.ts
+++ b/src/lib/scratchpad.test.ts
@@ -1,0 +1,116 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+process.env["DATABASE_URL"] ??= adminDsn();
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+/**
+ * Provision just the tables the scratchpad write path touches: `users` and the
+ * `scratchpads` table with its FK back to `users` (the constraint that fired
+ * for a brand-new user whose first action was a scratchpad write).
+ */
+async function provisionSchema(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "scratchpads" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "content" text DEFAULT '' NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "scratchpads_user_id_unique" UNIQUE ("user_id")
+    );
+  `);
+}
+
+describeIfServer("writeScratchpad", () => {
+  const dbName = `memory_scratchpad_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("creates the user on a brand-new user's first write", async () => {
+    // The user row does not exist yet — this mirrors the new-user flow where
+    // the very first assistant action is a scratchpad write.
+    const userId = "user_scratchpad_first_write";
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/db", () => ({ default: database }));
+
+    try {
+      await provisionSchema(client);
+
+      const { writeScratchpad, readScratchpad } = await import("./scratchpad");
+
+      const written = await writeScratchpad({
+        userId,
+        content: "remember the milk",
+        mode: "overwrite",
+      });
+      expect(written.content).toBe("remember the milk");
+
+      // The user row was created as a side effect, so the FK held.
+      const users = await client.query(
+        `SELECT "id" FROM "users" WHERE "id" = $1`,
+        [userId],
+      );
+      expect(users.rows).toHaveLength(1);
+
+      const read = await readScratchpad({ userId });
+      expect(read.content).toBe("remember the milk");
+    } finally {
+      vi.doUnmock("~/db");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+});

--- a/src/lib/scratchpad.ts
+++ b/src/lib/scratchpad.ts
@@ -7,6 +7,7 @@ import type {
 } from "./schemas/scratchpad";
 import db from "~/db";
 import { scratchpads } from "~/db/schema";
+import { ensureUser } from "~/lib/ingestion/ensure-user";
 
 export async function readScratchpad(
   params: ScratchpadReadRequest,
@@ -71,6 +72,8 @@ async function upsertScratchpad(
   userId: string,
   content: string,
 ): Promise<ScratchpadResponse> {
+  await ensureUser(db, userId);
+
   const now = new Date();
   const rows = await db
     .insert(scratchpads)


### PR DESCRIPTION
## Problem

In the new-user flow, when the assistant's **first** action is a scratchpad write, the write fails with a foreign key violation:

```
insert or update on table "scratchpads" violates foreign key constraint "scratchpads_user_id_users_id_fk"
detail: Key (user_id)=(user_RW…) is not present in table "users".
```

`scratchpads.userId` has an FK to `users.id`, but no `users` row exists yet for a brand-new user. Other write paths usually create the user via an ingestion call before the scratchpad is ever touched, which is why this only surfaces when the scratchpad write comes first.

## Fix

The codebase already has a convention for exactly this: every FK-to-`users` write path calls `ensureUser(db, userId)` (an upsert into `users` with `onConflictDoNothing`) before inserting — see the ingestion jobs, `atlas.ts`, `node.ts`, `transcript/ingest`, etc. The scratchpad lib was simply missing that call.

This adds `ensureUser` to `upsertScratchpad`, which covers both the `write` and `edit` paths. It's the consistent fix rather than relaxing the constraint.

## Test

Adds `src/lib/scratchpad.test.ts` with a regression test for the new-user-first-write case. Verified it reproduces the exact FK violation without the fix and passes with it. The test follows the existing db-backed test harness (provisions a minimal schema, skips when no Postgres is reachable).

https://claude.ai/code/session_013nCwWtTeVgaWLGSMjcE9qL

---
_Generated by [Claude Code](https://claude.ai/code/session_013nCwWtTeVgaWLGSMjcE9qL)_