### PR TITLE
✨ feat(citations): citation resolution + node-merge redirects

### DIFF
--- a/docs/citations-sdk.md
+++ b/docs/citations-sdk.md
@@ -1,0 +1,19 @@
+# Citation resolution (SDK)
+
+Petals' inline-citation feature cites memory `node_*` / `claim_*` / `src_*` ids inside
+assistant answers. Two capabilities this repo provides:
+
+## `POST /citations/resolve` → `resolveCitations(ids)`
+Batch-resolve a mix of node/claim/source ids to citation-ready records:
+`{ requestedId, kind, available, canonicalId, title, snippet, source }`.
+- **Nodes** follow merge redirects to their current survivor; a deleted node →
+  `available: false`.
+- **Claims** are durable (supersession keeps the id); each returns its provenance
+  `source` (the document/transcript it was extracted from).
+- **Sources** return their title; soft-deleted (`deletedAt`) → `available: false`.
+
+## Node-merge redirects
+`mergeNodes` previously hard-deleted consumed nodes, so any external reference to a
+consumed id 404'd forever. It now writes a `node_redirects(user_id, from_node_id →
+to_node_id)` row per consumed node (re-pointing existing chains to stay flat) before the
+delete, so `resolveCitations` can follow `consumed → survivor` indefinitely.

--- a/docs/citations-sdk.md
+++ b/docs/citations-sdk.md
@@ -4,8 +4,10 @@ Petals' inline-citation feature cites memory `node_*` / `claim_*` / `src_*` ids 
 assistant answers. Two capabilities this repo provides:
 
 ## `POST /citations/resolve` → `resolveCitations(ids)`
+
 Batch-resolve a mix of node/claim/source ids to citation-ready records:
 `{ requestedId, kind, available, canonicalId, title, snippet, source }`.
+
 - **Nodes** follow merge redirects to their current survivor; a deleted node →
   `available: false`.
 - **Claims** are durable (supersession keeps the id); each returns its provenance
@@ -13,6 +15,7 @@ Batch-resolve a mix of node/claim/source ids to citation-ready records:
 - **Sources** return their title; soft-deleted (`deletedAt`) → `available: false`.
 
 ## Node-merge redirects
+
 `mergeNodes` previously hard-deleted consumed nodes, so any external reference to a
 consumed id 404'd forever. It now writes a `node_redirects(user_id, from_node_id →
 to_node_id)` row per consumed node (re-pointing existing chains to stay flat) before the

--- a/drizzle/0020_clever_jimmy_woo.sql
+++ b/drizzle/0020_clever_jimmy_woo.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "node_redirects" (
+	"user_id" text NOT NULL,
+	"from_node_id" text NOT NULL,
+	"to_node_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "node_redirects_user_id_from_node_id_pk" PRIMARY KEY("user_id","from_node_id")
+);
+--> statement-breakpoint
+ALTER TABLE "node_redirects" ADD CONSTRAINT "node_redirects_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "node_redirects" ADD CONSTRAINT "node_redirects_to_node_id_nodes_id_fk" FOREIGN KEY ("to_node_id") REFERENCES "public"."nodes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "node_redirects_user_to_node_idx" ON "node_redirects" USING btree ("user_id","to_node_id");

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2061 @@
+{
+  "id": "c1971493-4051-4ce8-ab7f-4a956b766fae",
+  "prevId": "49707dad-8b8c-4207-b438-84d220584fff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780903673936,
       "tag": "0019_high_gressill",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1780909705240,
+      "tag": "0020_clever_jimmy_woo",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@marcelsamyn/memory",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "main": "dist/server/index.mjs",
   "types": "dist/server/index.d.ts",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,6 +10,7 @@ import {
   vector,
   index,
   unique,
+  primaryKey,
   integer,
   boolean,
   type AnyPgColumn,
@@ -442,6 +443,30 @@ export const sourceLinksRelations = relations(sourceLinks, ({ one }) => ({
     references: [nodes.id],
   }),
 }));
+
+/**
+ * Records that a consumed node was merged into a survivor, so stale references
+ * (e.g. citations) can follow `from → to`. `from_node_id` intentionally has NO
+ * FK: the consumed node row is deleted by the merge, but the redirect must
+ * survive it. Common aliases: node redirect, merge tombstone, node alias.
+ */
+export const nodeRedirects = pgTable(
+  "node_redirects",
+  {
+    userId: text()
+      .references(() => users.id)
+      .notNull(),
+    fromNodeId: typeIdNoDefault("node", { name: "from_node_id" }).notNull(),
+    toNodeId: typeId("node", { name: "to_node_id" })
+      .references(() => nodes.id, { onDelete: "cascade" })
+      .notNull(),
+    createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.fromNodeId] }),
+    index("node_redirects_user_to_node_idx").on(table.userId, table.toNodeId),
+  ],
+);
 
 // --- Specialized Data ---
 

--- a/src/evals/memory/db-fixture.ts
+++ b/src/evals/memory/db-fixture.ts
@@ -133,6 +133,14 @@ const HARNESS_DDL = `
     "created_at" timestamp with time zone DEFAULT now() NOT NULL,
     UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
   );
+  CREATE TABLE IF NOT EXISTS "node_redirects" (
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "from_node_id" text NOT NULL,
+    "to_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "node_redirects_user_id_from_node_id_pk"
+      PRIMARY KEY ("user_id","from_node_id")
+  );
   CREATE TABLE IF NOT EXISTS "user_profiles" (
     "id" text PRIMARY KEY NOT NULL,
     "user_id" text NOT NULL REFERENCES "users"("id"),

--- a/src/lib/jobs/cleanup-operations.test.ts
+++ b/src/lib/jobs/cleanup-operations.test.ts
@@ -135,6 +135,14 @@ async function createTables(client: Client): Promise<void> {
       "created_at" timestamp with time zone DEFAULT now() NOT NULL,
       UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
     );
+    CREATE TABLE IF NOT EXISTS "node_redirects" (
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "from_node_id" text NOT NULL,
+      "to_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_redirects_user_id_from_node_id_pk"
+        PRIMARY KEY ("user_id","from_node_id")
+    );
   `);
 }
 
@@ -293,7 +301,7 @@ describeIfServer("cleanup operation helpers", () => {
   afterEach(async () => {
     // Truncate user-scoped data so tests don't bleed.
     await rootClient.query(
-      `TRUNCATE "aliases", "claims", "source_links",
+      `TRUNCATE "node_redirects", "aliases", "claims", "source_links",
               "node_metadata", "nodes", "sources", "users" CASCADE`,
     );
   });

--- a/src/lib/node-redirects.test.ts
+++ b/src/lib/node-redirects.test.ts
@@ -1,9 +1,9 @@
+import { resolveNodeRedirects, writeNodeRedirects } from "./node-redirects";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import * as schema from "~/db/schema";
 import { newTypeId } from "~/types/typeid";
-import { resolveNodeRedirects, writeNodeRedirects } from "./node-redirects";
 
 const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
 const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);

--- a/src/lib/node-redirects.test.ts
+++ b/src/lib/node-redirects.test.ts
@@ -1,0 +1,116 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+import { resolveNodeRedirects, writeNodeRedirects } from "./node-redirects";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("node redirects", () => {
+  const dbName = `memory_redirects_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("writes redirects, re-points chains, and resolves stale ids", async () => {
+    const userId = "user_A";
+    const survivor = newTypeId("node");
+    const consumedA = newTypeId("node");
+    const consumedB = newTypeId("node");
+    const older = newTypeId("node");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_redirects" (
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "from_node_id" text NOT NULL,
+          "to_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "node_redirects_user_id_from_node_id_pk"
+            PRIMARY KEY ("user_id","from_node_id")
+        );
+      `);
+      await client.query(`INSERT INTO "users" ("id") VALUES ('user_A')`);
+      await client.query(
+        `INSERT INTO "nodes" ("id","user_id","node_type") VALUES
+          ($1,'user_A','Object'),($2,'user_A','Object'),
+          ($3,'user_A','Object'),($4,'user_A','Object')`,
+        [survivor, consumedA, consumedB, older],
+      );
+
+      // Pre-existing chain: older -> consumedA
+      await writeNodeRedirects(database, userId, consumedA, [older]);
+      // Merge consumedA + consumedB into survivor (must re-point older -> survivor)
+      await writeNodeRedirects(database, userId, survivor, [
+        consumedA,
+        consumedB,
+      ]);
+
+      const map = await resolveNodeRedirects(database, userId, [
+        consumedA,
+        consumedB,
+        older,
+        survivor,
+      ]);
+      expect(map.get(consumedA)).toBe(survivor);
+      expect(map.get(consumedB)).toBe(survivor);
+      expect(map.get(older)).toBe(survivor); // chain re-pointed, stays flat
+      expect(map.get(survivor)).toBe(survivor); // no redirect → maps to self
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/src/lib/node-redirects.ts
+++ b/src/lib/node-redirects.ts
@@ -1,0 +1,78 @@
+/** Node merge redirects: follow a consumed node id to its current survivor. */
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { nodeRedirects } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+
+/** Accepts the db or an open transaction. */
+type Database =
+  | DrizzleDB
+  | Parameters<Parameters<DrizzleDB["transaction"]>[0]>[0];
+
+/**
+ * Record that `consumedIds` merged into `survivorId`. Re-points any existing
+ * redirect that targeted a consumed id at the new survivor so chains stay flat
+ * (max one hop). Idempotent on (userId, fromNodeId).
+ */
+export async function writeNodeRedirects(
+  db: Database,
+  userId: string,
+  survivorId: TypeId<"node">,
+  consumedIds: TypeId<"node">[],
+): Promise<void> {
+  if (consumedIds.length === 0) return;
+
+  await db
+    .update(nodeRedirects)
+    .set({ toNodeId: survivorId })
+    .where(
+      and(
+        eq(nodeRedirects.userId, userId),
+        inArray(nodeRedirects.toNodeId, consumedIds),
+      ),
+    );
+
+  await db
+    .insert(nodeRedirects)
+    .values(
+      consumedIds.map((fromNodeId) => ({
+        userId,
+        fromNodeId,
+        toNodeId: survivorId,
+      })),
+    )
+    .onConflictDoUpdate({
+      target: [nodeRedirects.userId, nodeRedirects.fromNodeId],
+      set: { toNodeId: survivorId },
+    });
+}
+
+/**
+ * Map possibly-stale node ids to their current canonical id. Ids with no
+ * redirect map to themselves. One round-trip.
+ */
+export async function resolveNodeRedirects(
+  db: Database,
+  userId: string,
+  ids: TypeId<"node">[],
+): Promise<Map<TypeId<"node">, TypeId<"node">>> {
+  const out = new Map<TypeId<"node">, TypeId<"node">>(
+    ids.map((id) => [id, id]),
+  );
+  if (ids.length === 0) return out;
+
+  const rows = await db
+    .select({
+      fromNodeId: nodeRedirects.fromNodeId,
+      toNodeId: nodeRedirects.toNodeId,
+    })
+    .from(nodeRedirects)
+    .where(
+      and(
+        eq(nodeRedirects.userId, userId),
+        inArray(nodeRedirects.fromNodeId, ids),
+      ),
+    );
+  for (const r of rows) out.set(r.fromNodeId, r.toNodeId);
+  return out;
+}

--- a/src/lib/node-redirects.ts
+++ b/src/lib/node-redirects.ts
@@ -25,6 +25,7 @@ export async function writeNodeRedirects(
   consumedIds: TypeId<"node">[],
 ): Promise<void> {
   if (consumedIds.length === 0) return;
+  const uniqueConsumedIds = [...new Set(consumedIds)];
 
   await db
     .update(nodeRedirects)
@@ -32,14 +33,14 @@ export async function writeNodeRedirects(
     .where(
       and(
         eq(nodeRedirects.userId, userId),
-        inArray(nodeRedirects.toNodeId, consumedIds),
+        inArray(nodeRedirects.toNodeId, uniqueConsumedIds),
       ),
     );
 
   await db
     .insert(nodeRedirects)
     .values(
-      consumedIds.map((fromNodeId) => ({
+      uniqueConsumedIds.map((fromNodeId) => ({
         userId,
         fromNodeId,
         toNodeId: survivorId,
@@ -64,6 +65,7 @@ export async function resolveNodeRedirects(
     ids.map((id) => [id, id]),
   );
   if (ids.length === 0) return out;
+  const uniqueIds = [...new Set(ids)];
 
   const rows = await db
     .select({
@@ -74,7 +76,7 @@ export async function resolveNodeRedirects(
     .where(
       and(
         eq(nodeRedirects.userId, userId),
-        inArray(nodeRedirects.fromNodeId, ids),
+        inArray(nodeRedirects.fromNodeId, uniqueIds),
       ),
     );
   for (const r of rows) out.set(r.fromNodeId, r.toNodeId);

--- a/src/lib/node-redirects.ts
+++ b/src/lib/node-redirects.ts
@@ -13,6 +13,10 @@ type Database =
  * Record that `consumedIds` merged into `survivorId`. Re-points any existing
  * redirect that targeted a consumed id at the new survivor so chains stay flat
  * (max one hop). Idempotent on (userId, fromNodeId).
+ *
+ * @remarks
+ * Performs a two-step UPDATE-then-INSERT that is only atomic when called inside
+ * a DB transaction; `mergeNodes` already wraps it in one.
  */
 export async function writeNodeRedirects(
   db: Database,

--- a/src/lib/node.test.ts
+++ b/src/lib/node.test.ts
@@ -270,8 +270,10 @@ describeIfServer("node operations", () => {
 
   async function ensureMergeTables(client: Client): Promise<void> {
     // The first test in this file creates the core tables inline. Merge-path
-    // tests additionally need `node_embeddings`. Idempotent so subsequent
-    // tests can call this without conflicting with the inline creation above.
+    // tests additionally need `node_embeddings` and `node_redirects` (the merge
+    // transaction now records a redirect per consumed node). Idempotent so
+    // subsequent tests can call this without conflicting with the inline
+    // creation above.
     await client.query(`
       CREATE TABLE IF NOT EXISTS "node_embeddings" (
         "id" text PRIMARY KEY NOT NULL,
@@ -279,6 +281,14 @@ describeIfServer("node operations", () => {
         "embedding" jsonb,
         "model_name" varchar(100),
         "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS "node_redirects" (
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "from_node_id" text NOT NULL,
+        "to_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "node_redirects_user_id_from_node_id_pk"
+          PRIMARY KEY ("user_id","from_node_id")
       );
     `);
   }
@@ -387,6 +397,62 @@ describeIfServer("node operations", () => {
     } finally {
       vi.doUnmock("~/utils/db");
       vi.doUnmock("~/lib/embeddings");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+
+  it("writes a node redirect when merging", async () => {
+    const userId = "user_merge_redirect";
+    const survivor = newTypeId("node");
+    const consumed = newTypeId("node");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+    vi.doMock("~/lib/embeddings", () => ({
+      generateEmbeddings: async () => ({
+        data: [{ embedding: Array.from({ length: 1024 }, () => 0) }],
+        usage: { total_tokens: 0 },
+      }),
+    }));
+    vi.doMock("~/lib/sources", () => ({
+      sourceService: { fetchRaw: async () => [] },
+    }));
+
+    try {
+      await ensureMergeTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "nodes" ("id","user_id","node_type") VALUES
+          ($1,$3,'Object'),($2,$3,'Object')`,
+        [survivor, consumed, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id","node_id","label") VALUES ($1,$2,'Acme'),($3,$4,'Acme Inc')`,
+        [
+          newTypeId("node_metadata"),
+          survivor,
+          newTypeId("node_metadata"),
+          consumed,
+        ],
+      );
+
+      const { mergeNodes } = await import("./node");
+      await mergeNodes(userId, [survivor, consumed]);
+
+      const { rows } = await client.query(
+        `SELECT "from_node_id","to_node_id" FROM "node_redirects" WHERE "user_id" = $1`,
+        [userId],
+      );
+      expect(rows).toEqual([{ from_node_id: consumed, to_node_id: survivor }]);
+    } finally {
+      vi.doUnmock("~/utils/db");
+      vi.doUnmock("~/lib/embeddings");
+      vi.doUnmock("~/lib/sources");
       vi.resetModules();
       await client.end();
     }

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -25,6 +25,7 @@ import {
 } from "~/lib/graph";
 import { ensureUser } from "~/lib/ingestion/ensure-user";
 import { normalizeLabel } from "~/lib/label";
+import { writeNodeRedirects } from "~/lib/node-redirects";
 import { getEffectiveNodeScopes } from "~/lib/node-scope";
 import { ensureSystemSource, sourceService } from "~/lib/sources";
 import { ensureDayNode } from "~/lib/temporal";
@@ -648,6 +649,9 @@ export async function mergeNodes(
 
       await tx.delete(sourceLinks).where(eq(sourceLinks.nodeId, consumedId));
     }
+
+    // Record redirects so stale references (e.g. citations) follow consumed → survivor.
+    await writeNodeRedirects(tx, userId, survivorId, consumedIds);
 
     // Delete consumed nodes
     await tx

--- a/src/lib/resolve-citations.test.ts
+++ b/src/lib/resolve-citations.test.ts
@@ -62,7 +62,9 @@ describeIfServer("resolveCitations", () => {
     const missingNode = newTypeId("node");
     const src1 = newTypeId("source");
     const src2 = newTypeId("source");
+    const srcDeleted = newTypeId("source");
     const claim1 = newTypeId("claim");
+    const claimSuperseded = newTypeId("claim");
 
     const client = new Client({ connectionString: dsnFor(dbName) });
     await client.connect();
@@ -161,6 +163,21 @@ describeIfServer("resolveCitations", () => {
         [claim1, liveNode, src1],
       );
 
+      // soft-deleted source: row exists but deleted_at is set
+      await client.query(
+        `INSERT INTO "sources" ("id","user_id","type","external_id","metadata","deleted_at")
+         VALUES ($1,'user_A','document','ext_deleted',$2,now())`,
+        [srcDeleted, JSON.stringify({ title: "Deleted doc" })],
+      );
+
+      // superseded claim: row exists but status is 'superseded'
+      await client.query(
+        `INSERT INTO "claims"
+          ("id","user_id","subject_node_id","object_value","predicate","statement","source_id","asserted_by_kind","stated_at","status")
+         VALUES ($1,'user_A',$2,'Oct 1','HAS_STATUS','Launch was Oct 1',$3,'user',now(),'superseded')`,
+        [claimSuperseded, liveNode, src1],
+      );
+
       // mergedAway was merged into liveNode (node row gone, redirect remains)
       await writeNodeRedirects(database, userId, liveNode, [mergedAway]);
 
@@ -170,6 +187,8 @@ describeIfServer("resolveCitations", () => {
         claim1,
         src2,
         missingNode,
+        srcDeleted,
+        claimSuperseded,
       ]);
 
       const by = new Map(result.map((r) => [r.requestedId, r]));
@@ -203,6 +222,20 @@ describeIfServer("resolveCitations", () => {
         canonicalId: null,
         title: null,
       });
+      // soft-deleted source: row exists but deleted_at set → unavailable
+      expect(by.get(srcDeleted)).toMatchObject({
+        kind: "source",
+        available: false,
+        canonicalId: null,
+        title: "Deleted doc",
+      });
+      // superseded claim: row exists but status !== 'active' → unavailable; title still returned
+      expect(by.get(claimSuperseded)).toMatchObject({
+        kind: "claim",
+        available: false,
+        canonicalId: null,
+        title: "Launch was Oct 1",
+      });
       // input order preserved
       expect(result.map((r) => r.requestedId)).toEqual([
         liveNode,
@@ -210,6 +243,8 @@ describeIfServer("resolveCitations", () => {
         claim1,
         src2,
         missingNode,
+        srcDeleted,
+        claimSuperseded,
       ]);
     } finally {
       await client.end();

--- a/src/lib/resolve-citations.test.ts
+++ b/src/lib/resolve-citations.test.ts
@@ -1,10 +1,10 @@
+import { writeNodeRedirects } from "./node-redirects";
+import { resolveCitations } from "./resolve-citations";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import * as schema from "~/db/schema";
 import { newTypeId } from "~/types/typeid";
-import { writeNodeRedirects } from "./node-redirects";
-import { resolveCitations } from "./resolve-citations";
 
 const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
 const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);

--- a/src/lib/resolve-citations.test.ts
+++ b/src/lib/resolve-citations.test.ts
@@ -1,0 +1,218 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+import { writeNodeRedirects } from "./node-redirects";
+import { resolveCitations } from "./resolve-citations";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("resolveCitations", () => {
+  const dbName = `memory_resolve_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("resolves nodes (with redirects), claims (+ provenance), sources, and marks missing unavailable", async () => {
+    const userId = "user_A";
+    const liveNode = newTypeId("node");
+    const mergedAway = newTypeId("node");
+    const missingNode = newTypeId("node");
+    const src1 = newTypeId("source");
+    const src2 = newTypeId("source");
+    const claim1 = newTypeId("claim");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_metadata" (
+          "id" text PRIMARY KEY NOT NULL,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "label" text,
+          "canonical_label" text,
+          "description" text,
+          "additional_data" jsonb,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+        );
+        CREATE TABLE "sources" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "type" varchar(50) NOT NULL,
+          "external_id" text NOT NULL,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "metadata" jsonb,
+          "status" varchar(20) DEFAULT 'completed',
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "deleted_at" timestamp with time zone,
+          CONSTRAINT "sources_user_type_external_unique"
+            UNIQUE ("user_id","type","external_id")
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_value" text,
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "description" text,
+          "metadata" jsonb,
+          "object_instant" timestamp with time zone,
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "asserted_by_kind" varchar(24) NOT NULL,
+          "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+          "superseded_by_claim_id" text,
+          "contradicted_by_claim_id" text,
+          "stated_at" timestamp with time zone NOT NULL,
+          "valid_from" timestamp with time zone,
+          "valid_to" timestamp with time zone,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_redirects" (
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "from_node_id" text NOT NULL,
+          "to_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "node_redirects_user_id_from_node_id_pk"
+            PRIMARY KEY ("user_id","from_node_id")
+        );
+      `);
+
+      await client.query(`INSERT INTO "users" ("id") VALUES ('user_A')`);
+      await client.query(
+        `INSERT INTO "nodes" ("id","user_id","node_type") VALUES ($1,'user_A','Object')`,
+        [liveNode],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id","node_id","label","description") VALUES ($1,$2,'Acme','A company')`,
+        [newTypeId("node_metadata"), liveNode],
+      );
+      await client.query(
+        `INSERT INTO "sources" ("id","user_id","type","external_id","metadata") VALUES
+          ($1,'user_A','document','ext1',$2),
+          ($3,'user_A','meeting_transcript','ext2',$4)`,
+        [
+          src1,
+          JSON.stringify({ title: "2026 plan" }),
+          src2,
+          JSON.stringify({ title: "Standup" }),
+        ],
+      );
+      await client.query(
+        `INSERT INTO "claims"
+          ("id","user_id","subject_node_id","object_value","predicate","statement","source_id","asserted_by_kind","stated_at")
+         VALUES ($1,'user_A',$2,'Nov 14','HAS_STATUS','Launch moved to Nov 14',$3,'user',now())`,
+        [claim1, liveNode, src1],
+      );
+
+      // mergedAway was merged into liveNode (node row gone, redirect remains)
+      await writeNodeRedirects(database, userId, liveNode, [mergedAway]);
+
+      const result = await resolveCitations(database, userId, [
+        liveNode,
+        mergedAway,
+        claim1,
+        src2,
+        missingNode,
+      ]);
+
+      const by = new Map(result.map((r) => [r.requestedId, r]));
+
+      expect(by.get(liveNode)).toMatchObject({
+        kind: "node",
+        available: true,
+        canonicalId: liveNode,
+        title: "Acme",
+      });
+      expect(by.get(mergedAway)).toMatchObject({
+        kind: "node",
+        available: true,
+        canonicalId: liveNode, // followed the redirect
+        title: "Acme",
+      });
+      expect(by.get(claim1)).toMatchObject({
+        kind: "claim",
+        available: true,
+        title: "Launch moved to Nov 14",
+        source: { id: src1, title: "2026 plan", type: "document" },
+      });
+      expect(by.get(src2)).toMatchObject({
+        kind: "source",
+        available: true,
+        title: "Standup",
+      });
+      expect(by.get(missingNode)).toMatchObject({
+        kind: "node",
+        available: false,
+        canonicalId: null,
+        title: null,
+      });
+      // input order preserved
+      expect(result.map((r) => r.requestedId)).toEqual([
+        liveNode,
+        mergedAway,
+        claim1,
+        src2,
+        missingNode,
+      ]);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/src/lib/resolve-citations.ts
+++ b/src/lib/resolve-citations.ts
@@ -35,13 +35,15 @@ export async function resolveCitations(
   userId: string,
   ids: string[],
 ): Promise<ResolvedCitation[]> {
-  const nodeIds = ids.filter((i) => prefixOf(i) === "node") as TypeId<"node">[];
-  const claimIds = ids.filter(
-    (i) => prefixOf(i) === "claim",
-  ) as TypeId<"claim">[];
-  const sourceIds = ids.filter(
-    (i) => prefixOf(i) === "src",
-  ) as TypeId<"source">[];
+  const nodeIds = [
+    ...new Set(ids.filter((i) => prefixOf(i) === "node")),
+  ] as TypeId<"node">[];
+  const claimIds = [
+    ...new Set(ids.filter((i) => prefixOf(i) === "claim")),
+  ] as TypeId<"claim">[];
+  const sourceIds = [
+    ...new Set(ids.filter((i) => prefixOf(i) === "src")),
+  ] as TypeId<"source">[];
 
   // --- nodes: follow merge redirects, then load metadata ---
   const redirects = await resolveNodeRedirects(db, userId, nodeIds);

--- a/src/lib/resolve-citations.ts
+++ b/src/lib/resolve-citations.ts
@@ -82,6 +82,7 @@ export async function resolveCitations(
           statement: claims.statement,
           description: claims.description,
           sourceId: claims.sourceId,
+          status: claims.status,
           sourceType: sources.type,
           sourceMetadata: sources.metadata,
         })
@@ -92,11 +93,12 @@ export async function resolveCitations(
   const claimById = new Map(claimRows.map((r) => [r.id, r]));
   const claimCitations: ResolvedCitation[] = claimIds.map((requestedId) => {
     const row = claimById.get(requestedId);
+    const active = row?.status === "active";
     return {
       requestedId,
       kind: "claim",
-      available: Boolean(row),
-      canonicalId: row ? requestedId : null,
+      available: active,
+      canonicalId: active ? requestedId : null,
       title: row?.statement ?? null,
       snippet: row?.description ?? null,
       source: row

--- a/src/lib/resolve-citations.ts
+++ b/src/lib/resolve-citations.ts
@@ -1,10 +1,10 @@
 /** Batch-resolve node/claim/source ids to citation-ready records. */
+import { resolveNodeRedirects } from "./node-redirects";
+import type { ResolvedCitation } from "./schemas/resolve-citations";
 import { and, eq, inArray } from "drizzle-orm";
 import type { DrizzleDB } from "~/db";
 import { claims, nodeMetadata, nodes, sources } from "~/db/schema";
 import type { TypeId } from "~/types/typeid";
-import { resolveNodeRedirects } from "./node-redirects";
-import type { ResolvedCitation } from "./schemas/resolve-citations";
 
 type Database =
   | DrizzleDB

--- a/src/lib/resolve-citations.ts
+++ b/src/lib/resolve-citations.ts
@@ -1,0 +1,147 @@
+/** Batch-resolve node/claim/source ids to citation-ready records. */
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes, sources } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+import { resolveNodeRedirects } from "./node-redirects";
+import type { ResolvedCitation } from "./schemas/resolve-citations";
+
+type Database =
+  | DrizzleDB
+  | Parameters<Parameters<DrizzleDB["transaction"]>[0]>[0];
+
+function prefixOf(id: string): "node" | "claim" | "src" | "other" {
+  if (id.startsWith("node_")) return "node";
+  if (id.startsWith("claim_")) return "claim";
+  if (id.startsWith("src_")) return "src";
+  return "other";
+}
+
+function titleFromMetadata(metadata: unknown): string | null {
+  if (metadata && typeof metadata === "object" && "title" in metadata) {
+    const t = (metadata as { title?: unknown }).title;
+    return typeof t === "string" ? t : null;
+  }
+  return null;
+}
+
+/**
+ * Resolve a mix of `node_*`/`claim_*`/`src_*` ids. Ids of other namespaces are
+ * ignored (other Petals providers own them). Output preserves input order and
+ * contains one entry per recognized id.
+ */
+export async function resolveCitations(
+  db: Database,
+  userId: string,
+  ids: string[],
+): Promise<ResolvedCitation[]> {
+  const nodeIds = ids.filter((i) => prefixOf(i) === "node") as TypeId<"node">[];
+  const claimIds = ids.filter(
+    (i) => prefixOf(i) === "claim",
+  ) as TypeId<"claim">[];
+  const sourceIds = ids.filter(
+    (i) => prefixOf(i) === "src",
+  ) as TypeId<"source">[];
+
+  // --- nodes: follow merge redirects, then load metadata ---
+  const redirects = await resolveNodeRedirects(db, userId, nodeIds);
+  const canonicalNodeIds = [...new Set(redirects.values())];
+  const nodeRows = canonicalNodeIds.length
+    ? await db
+        .select({
+          id: nodes.id,
+          label: nodeMetadata.label,
+          description: nodeMetadata.description,
+        })
+        .from(nodes)
+        .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+        .where(
+          and(eq(nodes.userId, userId), inArray(nodes.id, canonicalNodeIds)),
+        )
+    : [];
+  const nodeById = new Map(nodeRows.map((r) => [r.id, r]));
+  const nodeCitations: ResolvedCitation[] = nodeIds.map((requestedId) => {
+    const canonical = redirects.get(requestedId) ?? requestedId;
+    const row = nodeById.get(canonical);
+    return {
+      requestedId,
+      kind: "node",
+      available: Boolean(row),
+      canonicalId: row ? canonical : null,
+      title: row?.label ?? null,
+      snippet: row?.description ?? null,
+      source: null,
+    };
+  });
+
+  // --- claims: durable; attach provenance source ---
+  const claimRows = claimIds.length
+    ? await db
+        .select({
+          id: claims.id,
+          statement: claims.statement,
+          description: claims.description,
+          sourceId: claims.sourceId,
+          sourceType: sources.type,
+          sourceMetadata: sources.metadata,
+        })
+        .from(claims)
+        .leftJoin(sources, eq(sources.id, claims.sourceId))
+        .where(and(eq(claims.userId, userId), inArray(claims.id, claimIds)))
+    : [];
+  const claimById = new Map(claimRows.map((r) => [r.id, r]));
+  const claimCitations: ResolvedCitation[] = claimIds.map((requestedId) => {
+    const row = claimById.get(requestedId);
+    return {
+      requestedId,
+      kind: "claim",
+      available: Boolean(row),
+      canonicalId: row ? requestedId : null,
+      title: row?.statement ?? null,
+      snippet: row?.description ?? null,
+      source: row
+        ? {
+            id: row.sourceId,
+            title: titleFromMetadata(row.sourceMetadata),
+            type: row.sourceType ?? "unknown",
+          }
+        : null,
+    };
+  });
+
+  // --- sources: stable; soft-deleted → unavailable ---
+  const sourceRows = sourceIds.length
+    ? await db
+        .select({
+          id: sources.id,
+          metadata: sources.metadata,
+          deletedAt: sources.deletedAt,
+        })
+        .from(sources)
+        .where(and(eq(sources.userId, userId), inArray(sources.id, sourceIds)))
+    : [];
+  const sourceById = new Map(sourceRows.map((r) => [r.id, r]));
+  const sourceCitations: ResolvedCitation[] = sourceIds.map((requestedId) => {
+    const row = sourceById.get(requestedId);
+    const present = Boolean(row && !row.deletedAt);
+    return {
+      requestedId,
+      kind: "source",
+      available: present,
+      canonicalId: present ? requestedId : null,
+      title: row ? titleFromMetadata(row.metadata) : null,
+      snippet: null,
+      source: null,
+    };
+  });
+
+  const byId = new Map<string, ResolvedCitation>(
+    [...nodeCitations, ...claimCitations, ...sourceCitations].map((c) => [
+      c.requestedId,
+      c,
+    ]),
+  );
+  return ids
+    .map((id) => byId.get(id))
+    .filter((c): c is ResolvedCitation => c !== undefined);
+}

--- a/src/lib/schemas/resolve-citations.ts
+++ b/src/lib/schemas/resolve-citations.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const resolveCitationsRequestSchema = z.object({
   userId: z.string(),
-  ids: z.array(z.string()).max(200),
+  ids: z.array(z.string().max(200)).max(200),
 });
 export type ResolveCitationsRequest = z.infer<
   typeof resolveCitationsRequestSchema

--- a/src/lib/schemas/resolve-citations.ts
+++ b/src/lib/schemas/resolve-citations.ts
@@ -1,0 +1,37 @@
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+export const resolveCitationsRequestSchema = z.object({
+  userId: z.string(),
+  ids: z.array(z.string()).max(200),
+});
+export type ResolveCitationsRequest = z.infer<
+  typeof resolveCitationsRequestSchema
+>;
+
+export const resolvedCitationSchema = z.object({
+  /** The id as requested (may be a since-merged node id). */
+  requestedId: z.string(),
+  kind: z.enum(["node", "claim", "source"]),
+  available: z.boolean(),
+  /** For nodes, the survivor after following redirects; null when unavailable. */
+  canonicalId: z.string().nullable(),
+  title: z.string().nullable(),
+  snippet: z.string().nullable(),
+  /** Provenance: for a claim, the source it was extracted from. */
+  source: z
+    .object({
+      id: typeIdSchema("source"),
+      title: z.string().nullable(),
+      type: z.string(),
+    })
+    .nullable(),
+});
+export type ResolvedCitation = z.infer<typeof resolvedCitationSchema>;
+
+export const resolveCitationsResponseSchema = z.object({
+  citations: z.array(resolvedCitationSchema),
+});
+export type ResolveCitationsResponse = z.infer<
+  typeof resolveCitationsResponseSchema
+>;

--- a/src/routes/citations/resolve.post.ts
+++ b/src/routes/citations/resolve.post.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler } from "h3";
+import { defineEventHandler, readBody } from "h3";
 import { resolveCitations } from "~/lib/resolve-citations";
 import {
   resolveCitationsRequestSchema,

--- a/src/routes/citations/resolve.post.ts
+++ b/src/routes/citations/resolve.post.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler } from "h3";
+import { resolveCitations } from "~/lib/resolve-citations";
+import {
+  resolveCitationsRequestSchema,
+  resolveCitationsResponseSchema,
+} from "~/lib/schemas/resolve-citations";
+import { useDatabase } from "~/utils/db";
+
+export default defineEventHandler(async (event) => {
+  const { userId, ids } = resolveCitationsRequestSchema.parse(
+    await readBody(event),
+  );
+  const db = await useDatabase();
+  const citations = await resolveCitations(db, userId, ids);
+  return resolveCitationsResponseSchema.parse({ citations });
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -16,6 +16,7 @@ export {
   type ProposedMetricDefinition,
 } from "../lib/schemas/metric-definition.js";
 export * from "../lib/schemas/query-search.js";
+export * from "../lib/schemas/resolve-citations.js";
 export * from "../lib/schemas/query-atlas.js";
 export * from "../lib/schemas/query-day.js";
 export * from "../lib/schemas/query-node-type.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -208,6 +208,11 @@ import {
   queryTimelineResponseSchema,
 } from "../lib/schemas/query-timeline.js";
 import {
+  resolveCitationsResponseSchema,
+  type ResolveCitationsRequest,
+  type ResolveCitationsResponse,
+} from "../lib/schemas/resolve-citations.js";
+import {
   ScratchpadReadRequest,
   ScratchpadWriteRequest,
   ScratchpadEditRequest,
@@ -931,6 +936,17 @@ export class MemoryClient {
 
   async getNode(payload: GetNodeRequest): Promise<GetNodeResponse> {
     return this._fetch("POST", "/node/get", getNodeResponseSchema, payload);
+  }
+
+  async resolveCitations(
+    payload: ResolveCitationsRequest,
+  ): Promise<ResolveCitationsResponse> {
+    return this._fetch(
+      "POST",
+      "/citations/resolve",
+      resolveCitationsResponseSchema,
+      payload,
+    );
   }
 
   async getNodeSources(


### PR DESCRIPTION
## What & why

Adds the memory-side support for Petals' new inline-citation feature:

- **`resolveCitations(ids)`** — a batch endpoint (`POST /citations/resolve`) + SDK client method that resolves a mix of `node_*` / `claim_*` / `src_*` ids to citation-ready records (`title`, `snippet`, provenance `source`, `available`, `canonicalId`).
- **Node-merge redirects** — `mergeNodes` previously hard-deleted consumed nodes, so any external reference (e.g. a stored citation) to a merged node id 404'd forever. It now writes a `node_redirects(user_id, from_node_id → to_node_id)` row per consumed node (re-pointing existing chains so they stay flat) **before** the delete, and `resolveCitations` follows them.

Bumps `@marcelsamyn/memory` to **1.18.0**.

## Changes

- `node_redirects` table + migration; no FK on `from_node_id` (the consumed node is gone — the redirect must outlive it).
- `writeNodeRedirects` / `resolveNodeRedirects` helpers; `mergeNodes` writes redirects inside its merge transaction.
- `resolveCitations` lib + `/citations/resolve` route + SDK client method + schema exports.
- Superseded/retracted claims and soft-deleted sources resolve as `available: false` (id durability preserved; staleness flagged).

## How to test

- `pnpm test --run src/lib/node-redirects.test.ts src/lib/resolve-citations.test.ts` (needs Postgres on `:5431`).
- `pnpm run build:check && pnpm run build-sdk && pnpm run lint`.

## Checklist

- [x] build:check
- [x] tests (375 pass)
- [x] lint / format
- [ ] migration applied to deploy DB
- [ ] publish `1.18.0` after merge

Design note: `docs/citations-sdk.md`. Consumed by the Petals inline-citations PR (Plan 3 / Source Peek).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
