### PR TITLE
Add per-task model routing and LLM usage telemetry

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,6 +7,11 @@ import type {
 } from "openai/resources.mjs";
 import { z } from "zod";
 import { env } from "~/utils/env";
+import {
+  MODEL_MAX_OUTPUT_TOKENS,
+  modelForTask,
+  type ModelTask,
+} from "~/utils/models";
 import { getExtractionClientOverride } from "~/utils/test-overrides";
 
 /**
@@ -119,7 +124,10 @@ export async function parseStructuredCompletion<
   throw lastError;
 }
 
-export async function createCompletionClient(userId: string): Promise<OpenAI> {
+export async function createCompletionClient(
+  userId: string,
+  opts?: { task?: ModelTask | undefined },
+): Promise<OpenAI> {
   const override = getExtractionClientOverride();
   if (override) return override as OpenAI;
   const { OpenAI } = await import("openai");
@@ -131,6 +139,9 @@ export async function createCompletionClient(userId: string): Promise<OpenAI> {
         ? {
             "Helicone-Auth": `Bearer ${env.HELICONE_API_KEY}`,
             "Helicone-User-Id": userId,
+            // Custom property → lets Helicone break spend down per task,
+            // even while several tasks still share one model.
+            ...(opts?.task ? { "Helicone-Property-Task": opts.task } : {}),
           }
         : {}),
       "HTTP-Referer": "https://github.com/iamarcel/assistant-memory",
@@ -143,12 +154,17 @@ export async function crateTextCompletion({
   userId,
   prompt,
   systemPrompt,
+  task,
+  maxTokens,
 }: {
   userId: string;
   prompt: string;
   systemPrompt?: string;
+  /** Routes the model (via {@link modelForTask}) and tags Helicone. */
+  task?: ModelTask;
+  maxTokens?: number;
 }): Promise<string> {
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, { task });
   const completion = await client.chat.completions.create({
     messages: [
       ...(systemPrompt
@@ -164,7 +180,8 @@ export async function crateTextCompletion({
         content: prompt,
       } satisfies ChatCompletionUserMessageParam,
     ],
-    model: env.MODEL_ID_GRAPH_EXTRACTION,
+    model: task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION,
+    max_tokens: maxTokens ?? MODEL_MAX_OUTPUT_TOKENS,
   });
 
   return completion.choices[0]?.message.content ?? "";
@@ -177,15 +194,20 @@ export async function performStructuredAnalysis<
   prompt,
   systemPrompt,
   schema,
+  task,
+  maxTokens,
 }: {
   userId: string;
   prompt: string;
   systemPrompt?: string;
   schema: S;
+  /** Routes the model (via {@link modelForTask}) and tags Helicone. */
+  task?: ModelTask;
+  maxTokens?: number;
 }): Promise<z.infer<S>> {
   if (!schema.description) throw new Error("Schema must have a description");
 
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, { task });
   const completion = await parseStructuredCompletion(client, {
     messages: [
       ...(systemPrompt
@@ -201,7 +223,8 @@ export async function performStructuredAnalysis<
         content: prompt,
       } satisfies ChatCompletionUserMessageParam,
     ],
-    model: env.MODEL_ID_GRAPH_EXTRACTION,
+    model: task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION,
+    max_tokens: maxTokens ?? MODEL_MAX_OUTPUT_TOKENS,
     response_format: zodResponseFormat(schema, schema.description),
   });
   const parsed = completion.choices[0]?.message.parsed;

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,6 +7,7 @@ import type {
 } from "openai/resources.mjs";
 import { z } from "zod";
 import { env } from "~/utils/env";
+import { normalizeUsage, recordLlmUsage } from "~/utils/llm-telemetry";
 import {
   MODEL_MAX_OUTPUT_TOKENS,
   modelForTask,
@@ -91,7 +92,15 @@ function isRetryableCompletionError(err: unknown): boolean {
  */
 export async function parseStructuredCompletion<
   Body extends ChatCompletionCreateParamsNonStreaming,
->(client: OpenAI, body: Body) {
+>(
+  client: OpenAI,
+  body: Body,
+  opts?: { task?: ModelTask | undefined; userId?: string | undefined },
+) {
+  // `user` is the OpenAI-standard, vendor-neutral per-request attribution
+  // field (passed through by OpenRouter); set it without disturbing the
+  // generic `Body` inference that keeps `.parsed` typed.
+  if (opts?.userId) body.user = opts.userId;
   let lastError: unknown;
   for (
     let attempt = 1;
@@ -99,7 +108,14 @@ export async function parseStructuredCompletion<
     attempt++
   ) {
     try {
-      return await client.chat.completions.parse(body);
+      const completion = await client.chat.completions.parse(body);
+      recordLlmUsage({
+        task: opts?.task ?? "unknown",
+        model: body.model,
+        userId: opts?.userId ?? "unknown",
+        ...normalizeUsage(completion.usage),
+      });
+      return completion;
     } catch (err) {
       lastError = isMalformedUpstreamCompletion(err)
         ? new MalformedUpstreamCompletionError({ cause: err })
@@ -164,6 +180,7 @@ export async function crateTextCompletion({
   task?: ModelTask;
   maxTokens?: number;
 }): Promise<string> {
+  const model = task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION;
   const client = await createCompletionClient(userId, { task });
   const completion = await client.chat.completions.create({
     messages: [
@@ -180,10 +197,17 @@ export async function crateTextCompletion({
         content: prompt,
       } satisfies ChatCompletionUserMessageParam,
     ],
-    model: task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION,
+    model,
     max_tokens: maxTokens ?? MODEL_MAX_OUTPUT_TOKENS,
+    user: userId,
   });
 
+  recordLlmUsage({
+    task: task ?? "unknown",
+    model,
+    userId,
+    ...normalizeUsage(completion.usage),
+  });
   return completion.choices[0]?.message.content ?? "";
 }
 
@@ -208,25 +232,29 @@ export async function performStructuredAnalysis<
   if (!schema.description) throw new Error("Schema must have a description");
 
   const client = await createCompletionClient(userId, { task });
-  const completion = await parseStructuredCompletion(client, {
-    messages: [
-      ...(systemPrompt
-        ? [
-            {
-              role: "system",
-              content: systemPrompt,
-            } satisfies ChatCompletionSystemMessageParam,
-          ]
-        : []),
-      {
-        role: "user",
-        content: prompt,
-      } satisfies ChatCompletionUserMessageParam,
-    ],
-    model: task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION,
-    max_tokens: maxTokens ?? MODEL_MAX_OUTPUT_TOKENS,
-    response_format: zodResponseFormat(schema, schema.description),
-  });
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [
+        ...(systemPrompt
+          ? [
+              {
+                role: "system",
+                content: systemPrompt,
+              } satisfies ChatCompletionSystemMessageParam,
+            ]
+          : []),
+        {
+          role: "user",
+          content: prompt,
+        } satisfies ChatCompletionUserMessageParam,
+      ],
+      model: task ? modelForTask(task) : env.MODEL_ID_GRAPH_EXTRACTION,
+      max_tokens: maxTokens ?? MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(schema, schema.description),
+    },
+    { task, userId },
+  );
   const parsed = completion.choices[0]?.message.parsed;
   if (!parsed) throw new Error("Failed to parse response");
   return parsed;

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -98,9 +98,12 @@ export async function parseStructuredCompletion<
   opts?: { task?: ModelTask | undefined; userId?: string | undefined },
 ) {
   // `user` is the OpenAI-standard, vendor-neutral per-request attribution
-  // field (passed through by OpenRouter); set it without disturbing the
-  // generic `Body` inference that keeps `.parsed` typed.
-  if (opts?.userId) body.user = opts.userId;
+  // field (passed through by OpenRouter). Copy rather than mutate the
+  // caller's body; the `as Body` cast keeps the generic inference that
+  // preserves `.parsed`'s type.
+  const finalBody = opts?.userId
+    ? ({ ...body, user: opts.userId } as Body)
+    : body;
   let lastError: unknown;
   for (
     let attempt = 1;
@@ -108,7 +111,7 @@ export async function parseStructuredCompletion<
     attempt++
   ) {
     try {
-      const completion = await client.chat.completions.parse(body);
+      const completion = await client.chat.completions.parse(finalBody);
       recordLlmUsage({
         task: opts?.task ?? "unknown",
         model: body.model,

--- a/src/lib/extract-graph.test.ts
+++ b/src/lib/extract-graph.test.ts
@@ -191,7 +191,7 @@ describeIfServer("extractGraph claim-native insertion", () => {
         chat: {
           completions: {
             parse: async (input: { messages: Array<{ content: string }> }) => {
-              prompt = input.messages[0]?.content ?? "";
+              prompt = input.messages.map((m) => m.content).join("\n\n");
               return {
                 choices: [
                   {
@@ -464,7 +464,7 @@ describeIfServer("extractGraph claim-native insertion", () => {
         chat: {
           completions: {
             parse: async (input: { messages: Array<{ content: string }> }) => {
-              prompt = input.messages[0]?.content ?? "";
+              prompt = input.messages.map((m) => m.content).join("\n\n");
               return {
                 choices: [
                   {
@@ -647,7 +647,7 @@ describeIfServer("extractGraph claim-native insertion", () => {
         chat: {
           completions: {
             parse: async (input: { messages: Array<{ content: string }> }) => {
-              prompt = input.messages[0]?.content ?? "";
+              prompt = input.messages.map((m) => m.content).join("\n\n");
               return {
                 choices: [
                   {
@@ -1407,7 +1407,9 @@ describeIfServer("extractGraph claim-native insertion", () => {
         chat: {
           completions: {
             parse: async (input: { messages: Array<{ content: string }> }) => {
-              capturedPrompt = input.messages[0]?.content ?? "";
+              capturedPrompt = input.messages
+                .map((m) => m.content)
+                .join("\n\n");
               return {
                 choices: [{ message: { parsed: llmResponse } }],
               };

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -230,37 +230,16 @@ export async function extractGraph({
     task: "graph_extraction",
   });
 
-  const prompt = `You are a knowledge graph extraction expert. Your task is to analyze the following ${sourceType} and extract entities, concepts, events, and their relationships to create a knowledge graph.
+  // Static instruction block. Depends only on `sourceType` (and whether a
+  // speaker map is present), so it is byte-identical across every ingest of
+  // the same shape. Sent as the leading `system` message — i.e. the request
+  // prefix — so OpenRouter/OpenAI auto-cache it (the rule block is well over
+  // the ~1024-token minimum). The per-call dynamic payload goes in the
+  // trailing user message (below) so it never invalidates the cached prefix.
+  const systemPrompt = `You are a knowledge graph extraction expert. Your task is to analyze the provided ${sourceType} and extract entities, concepts, events, and their relationships to create a knowledge graph.
 
 IMPORTANT:
 - Do NOT respond to the content. Instead, analyze it and extract a structured graph representation.
-${
-  nodesForPromptFormatting.length > 0
-    ? `
-- Do NOT extract anything from the context—only from the ${sourceType} given at the end. The context is only provided to help you understand the ${sourceType} better.
-	- I've provided some existing nodes that may be relevant to this ${sourceType}. If any of these nodes match entities in the ${sourceType}, use their 'tempId' (e.g., existing_person_1) in your 'nodes' or 'relationshipClaims' if you refer to them. DO NOT create new nodes for these if they match.
-
-<context>
-${formatNodesForPrompt(nodesForPromptFormatting)}
-</context>
-`
-    : ""
-}
-
-${openCommitmentsPromptSection}
-
-${candidateCommitmentsPromptSection}
-
-${speakerMapPromptSection}
-
-Extract the graph from the following ${sourceType}:
-
-Allowed source refs:
-${sourceRefsForPrompt}
-${contentNote ? `\n${contentNote}\n` : ""}
-<${sourceType}>
-${content}
-</${sourceType}>
 
 CRITICAL EXTRACTION RULES - READ CAREFULLY:
 
@@ -355,7 +334,7 @@ For each element, create a node with:
 	- For a notable scalar property of an entity, prefer a HAS_ATTRIBUTE attribute claim (value in objectValue) over creating a node for the value.
 	- ONLY create claims for facts explicitly stated by the ${sourceType === "document" ? "document text" : "user"}, not your own interpretations or assumptions.
 	- In the claim statement, write one concise sentence that can stand alone as the sourced assertion.
-	- Every claim must include a sourceRef copied exactly from the token after "sourceRef:" in the allowed source refs above. Do not include statedAt text.
+	- Every claim must include a sourceRef copied exactly from the token after "sourceRef:" in the allowed source refs provided with the content below. Do not include statedAt text.
 	- Emit aliases when the source uses a nickname, abbreviation, alternate spelling, or shorter name for a node.
 	- Ideally, relationship claims link to already-existing nodes. If the node isn't existing, create it.
 
@@ -387,10 +366,42 @@ ${
     : `Focus on extracting the most significant and meaningful information that the USER provided. Quality and accuracy are more important than quantity.`
 }`;
 
+  // Dynamic payload: existing-node context, commitments, speaker map, source
+  // refs and the source content itself — varies every call, so it follows the
+  // cached static prefix above as the trailing user message.
+  const userPrompt = `${
+    nodesForPromptFormatting.length > 0
+      ? `- Do NOT extract anything from the context—only from the ${sourceType} given at the end. The context is only provided to help you understand the ${sourceType} better.
+	- I've provided some existing nodes that may be relevant to this ${sourceType}. If any of these nodes match entities in the ${sourceType}, use their 'tempId' (e.g., existing_person_1) in your 'nodes' or 'relationshipClaims' if you refer to them. DO NOT create new nodes for these if they match.
+
+<context>
+${formatNodesForPrompt(nodesForPromptFormatting)}
+</context>
+`
+      : ""
+  }
+${openCommitmentsPromptSection}
+
+${candidateCommitmentsPromptSection}
+
+${speakerMapPromptSection}
+
+Extract the graph from the following ${sourceType}:
+
+Allowed source refs:
+${sourceRefsForPrompt}
+${contentNote ? `\n${contentNote}\n` : ""}
+<${sourceType}>
+${content}
+</${sourceType}>`;
+
   const completion = await parseStructuredCompletion(
     client,
     {
-      messages: [{ role: "user", content: prompt }],
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
       model: modelForTask("graph_extraction"),
       max_tokens: MODEL_MAX_OUTPUT_TOKENS,
       response_format: zodResponseFormat(llmExtractionSchema, "subgraph"),
@@ -405,7 +416,10 @@ ${
 
   if (onLlmIO) {
     try {
-      await onLlmIO({ prompt, response: parsedLlmOutput });
+      await onLlmIO({
+        prompt: `${systemPrompt}\n\n${userPrompt}`,
+        response: parsedLlmOutput,
+      });
     } catch (hookError) {
       console.error("extract-graph: onLlmIO hook threw", hookError);
     }

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -40,7 +40,7 @@ import {
 } from "~/types/graph";
 import { type TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
-import { env } from "~/utils/env";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 import { shouldSkipJobEnqueue } from "~/utils/test-overrides";
 
 type SourceRef = {
@@ -226,7 +226,9 @@ export async function extractGraph({
   const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
 
   const { createCompletionClient } = await import("./ai");
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, {
+    task: "graph_extraction",
+  });
 
   const prompt = `You are a knowledge graph extraction expert. Your task is to analyze the following ${sourceType} and extract entities, concepts, events, and their relationships to create a knowledge graph.
 
@@ -387,7 +389,8 @@ ${
 
   const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
-    model: env.MODEL_ID_GRAPH_EXTRACTION,
+    model: modelForTask("graph_extraction"),
+    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
     response_format: zodResponseFormat(llmExtractionSchema, "subgraph"),
   });
 

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -387,12 +387,16 @@ ${
     : `Focus on extracting the most significant and meaningful information that the USER provided. Quality and accuracy are more important than quantity.`
 }`;
 
-  const completion = await parseStructuredCompletion(client, {
-    messages: [{ role: "user", content: prompt }],
-    model: modelForTask("graph_extraction"),
-    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-    response_format: zodResponseFormat(llmExtractionSchema, "subgraph"),
-  });
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [{ role: "user", content: prompt }],
+      model: modelForTask("graph_extraction"),
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(llmExtractionSchema, "subgraph"),
+    },
+    { task: "graph_extraction", userId },
+  );
 
   const parsedLlmOutput = completion.choices[0]?.message.parsed;
   if (!parsedLlmOutput) {

--- a/src/lib/ingestion/extract-document-spine.ts
+++ b/src/lib/ingestion/extract-document-spine.ts
@@ -56,12 +56,16 @@ Guidance:
 ${condensed}
 </document>`;
 
-  const completion = await parseStructuredCompletion(client, {
-    messages: [{ role: "user", content: prompt }],
-    model: modelForTask("document_spine"),
-    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-    response_format: zodResponseFormat(documentSpineSchema, "document_spine"),
-  });
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [{ role: "user", content: prompt }],
+      model: modelForTask("document_spine"),
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(documentSpineSchema, "document_spine"),
+    },
+    { task: "document_spine", userId },
+  );
 
   const parsed = completion.choices[0]?.message.parsed;
   if (!parsed) throw new Error("Failed to parse document-spine response");

--- a/src/lib/ingestion/extract-document-spine.ts
+++ b/src/lib/ingestion/extract-document-spine.ts
@@ -15,7 +15,7 @@ import {
   type DocumentSpine,
   documentSpineSchema,
 } from "~/lib/schemas/document-spine";
-import { env } from "~/utils/env";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 
 // Cap how much markdown we send to the spine LLM. Most documents fit, but
 // for very long inputs we keep the head + tail + a heading outline so the
@@ -35,7 +35,9 @@ export async function extractDocumentSpine(params: {
   const { createCompletionClient, parseStructuredCompletion } = await import(
     "~/lib/ai"
   );
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, {
+    task: "document_spine",
+  });
 
   const prompt = `You are reading a document to summarize its high-level shape for a graph extractor.
 
@@ -56,7 +58,8 @@ ${condensed}
 
   const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
-    model: env.MODEL_ID_GRAPH_EXTRACTION,
+    model: modelForTask("document_spine"),
+    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
     response_format: zodResponseFormat(documentSpineSchema, "document_spine"),
   });
 

--- a/src/lib/jobs/atlas-assistant.ts
+++ b/src/lib/jobs/atlas-assistant.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns/format";
 import { DrizzleDB } from "~/db";
 import { fetchDailyConversationsList } from "~/lib/analysis/conversations";
 import { getAssistantAtlas, updateAssistantAtlas } from "~/lib/atlas";
-import { env } from "~/utils/env";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 
 /**
  * Job to process the assistant-specific Atlas:
@@ -68,9 +68,10 @@ ${convList}
 
   // 4. Call LLM
   const { createCompletionClient } = await import("../ai");
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, { task: "atlas" });
   const completion = await client.chat.completions.create({
-    model: env.MODEL_ID_GRAPH_EXTRACTION,
+    model: modelForTask("atlas"),
+    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
     messages: [
       { role: "system", content: systemMsg },
       { role: "user", content: userPrompt },

--- a/src/lib/jobs/atlas-assistant.ts
+++ b/src/lib/jobs/atlas-assistant.ts
@@ -2,7 +2,6 @@ import { format } from "date-fns/format";
 import { DrizzleDB } from "~/db";
 import { fetchDailyConversationsList } from "~/lib/analysis/conversations";
 import { getAssistantAtlas, updateAssistantAtlas } from "~/lib/atlas";
-import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 
 /**
  * Job to process the assistant-specific Atlas:
@@ -67,18 +66,15 @@ ${convList}
 `;
 
   // 4. Call LLM
-  const { createCompletionClient } = await import("../ai");
-  const client = await createCompletionClient(userId, { task: "atlas" });
-  const completion = await client.chat.completions.create({
-    model: modelForTask("atlas"),
-    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-    messages: [
-      { role: "system", content: systemMsg },
-      { role: "user", content: userPrompt },
-    ],
-  });
-
-  const updated = completion.choices[0]?.message?.content?.trim();
+  const { crateTextCompletion } = await import("../ai");
+  const updated = (
+    await crateTextCompletion({
+      userId,
+      systemPrompt: systemMsg,
+      prompt: userPrompt,
+      task: "atlas",
+    })
+  ).trim();
   if (!updated) throw new Error("Failed to generate assistant dream atlas");
 
   // 5. Persist updated assistant atlas

--- a/src/lib/jobs/atlas-user.ts
+++ b/src/lib/jobs/atlas-user.ts
@@ -386,6 +386,7 @@ export async function processAtlasJob(
       userId,
       prompt,
       schema: AtlasOutputSchema,
+      task: "atlas",
     });
     derivedAtlas = z.string().parse(parsed["atlas"]).trim();
   }

--- a/src/lib/jobs/cleanup-graph.ts
+++ b/src/lib/jobs/cleanup-graph.ts
@@ -11,6 +11,7 @@
  * cleanup pipeline, cleanup prompt builder.
  */
 import { createCompletionClient, parseStructuredCompletion } from "../ai";
+import { MODEL_MAX_OUTPUT_TOKENS } from "~/utils/models";
 import { getConversationBootstrapContext } from "../context/assemble-bootstrap-context";
 import type { ContextBundle } from "../context/types";
 import { generateAndInsertNodeEmbeddings } from "../embeddings-util";
@@ -632,7 +633,9 @@ export async function proposeGraphCleanup(
   temp: TempSubgraph,
   modelId: string,
 ): Promise<CleanupOperations> {
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, {
+    task: "graph_cleanup",
+  });
 
   // Bundle is the structured equivalent of the legacy "user atlas" string —
   // five sections (pinned, atlas, open_commitments, recent_supersessions,
@@ -644,6 +647,7 @@ export async function proposeGraphCleanup(
   const completion = await parseStructuredCompletion(client, {
     messages: [{ role: "user", content: prompt }],
     model: modelId,
+    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
     response_format: zodResponseFormat(
       CleanupOperationsSchema,
       "CleanupOperations",

--- a/src/lib/jobs/cleanup-graph.ts
+++ b/src/lib/jobs/cleanup-graph.ts
@@ -11,7 +11,6 @@
  * cleanup pipeline, cleanup prompt builder.
  */
 import { createCompletionClient, parseStructuredCompletion } from "../ai";
-import { MODEL_MAX_OUTPUT_TOKENS } from "~/utils/models";
 import { getConversationBootstrapContext } from "../context/assemble-bootstrap-context";
 import type { ContextBundle } from "../context/types";
 import { generateAndInsertNodeEmbeddings } from "../embeddings-util";
@@ -37,6 +36,7 @@ import {
 import type { AssertedByKind, NodeType, Predicate, Scope } from "~/types/graph";
 import { TypeId, typeIdSchema } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
+import { MODEL_MAX_OUTPUT_TOKENS } from "~/utils/models";
 
 export const CleanupGraphJobInputSchema = z.object({
   userId: z.string(),
@@ -644,15 +644,19 @@ export async function proposeGraphCleanup(
 
   const prompt = buildCleanupPrompt(temp, bundle);
 
-  const completion = await parseStructuredCompletion(client, {
-    messages: [{ role: "user", content: prompt }],
-    model: modelId,
-    max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-    response_format: zodResponseFormat(
-      CleanupOperationsSchema,
-      "CleanupOperations",
-    ),
-  });
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [{ role: "user", content: prompt }],
+      model: modelId,
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(
+        CleanupOperationsSchema,
+        "CleanupOperations",
+      ),
+    },
+    { task: "graph_cleanup", userId },
+  );
   const parsed = completion.choices[0]?.message.parsed;
   if (!parsed) throw new Error("Failed to parse cleanup operations");
   return parsed;

--- a/src/lib/jobs/cleanup-placeholders.ts
+++ b/src/lib/jobs/cleanup-placeholders.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { nodes, nodeMetadata } from "~/db/schema";
 import { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
-import { env } from "~/utils/env";
+import { modelForTask } from "~/utils/models";
 
 export const cleanupPlaceholdersInputSchema = z.object({
   userId: z.string().min(1),
@@ -184,7 +184,7 @@ export async function seedClaimsCleanupForPlaceholders(
       Date.now() - olderThanDays * 24 * 60 * 60 * 1000,
     ).toISOString(),
     seedIds,
-    llmModelId: env.MODEL_ID_GRAPH_EXTRACTION,
+    llmModelId: modelForTask("graph_cleanup"),
   });
 
   return { jobId: job.id ?? "", seedIds };

--- a/src/lib/jobs/deep-research.ts
+++ b/src/lib/jobs/deep-research.ts
@@ -104,6 +104,7 @@ async function generateSearchQueries(
       userId,
       systemPrompt:
         "You are an imaginative research assistant generating tangential search queries.",
+      task: "deep_research",
       prompt: `<system:info>You are processing a conversation and want to find interesting background or related topics that are not necessarily direct continuations.</system:info>
 
 <conversation>
@@ -231,6 +232,7 @@ async function refineSearchResults(
     return await performStructuredAnalysis({
       userId,
       systemPrompt: "You refine background search results.",
+      task: "deep_research",
       prompt: `<conversation>
 ${messageContext}
 </conversation>

--- a/src/lib/jobs/dream.ts
+++ b/src/lib/jobs/dream.ts
@@ -62,6 +62,7 @@ async function proposeTopics(
   const { topics } = await performStructuredAnalysis({
     userId,
     systemPrompt,
+    task: "dream",
     prompt: `<system:info>You are now in a "dream" state. This is space for you to have internal (hidden from any users) dreams, thoughts and insights. The past day is ${date}. </system:info>
 
 <context about="nodes from knowledge graph linked to today">
@@ -119,6 +120,7 @@ async function proposeQueries(
   const res = await performStructuredAnalysis({
     userId,
     systemPrompt,
+    task: "dream",
     prompt: `<system:info>You are now in a "dream" state. This is space for you to have internal (hidden from any users) dreams, thoughts and insights.</system:info>
 
 Previously, you chose the following to dream about:
@@ -162,6 +164,7 @@ async function generateDreamContent(
   return await crateTextCompletion({
     userId,
     systemPrompt,
+    task: "dream",
     prompt: `
 <system:info>
 You are now in a "dream" state. This is space for you to have internal (hidden from any users) dreams, thoughts and insights.
@@ -194,6 +197,7 @@ async function scoreDream(
   const res = await performStructuredAnalysis({
     userId,
     systemPrompt,
+    task: "dream",
     prompt: `
 <system:info>
 You are now in a "dream" state. This is space for you to have internal (hidden from any users) dreams, thoughts and insights.

--- a/src/lib/jobs/profile-synthesis.ts
+++ b/src/lib/jobs/profile-synthesis.ts
@@ -422,6 +422,7 @@ export async function runProfileSynthesis(
     userId,
     prompt,
     schema: ProfileSynthesisOutputSchema,
+    task: "profile_synthesis",
   });
 
   const description = z.string().parse(parsed["description"]).trim();

--- a/src/lib/jobs/summarize-conversation.ts
+++ b/src/lib/jobs/summarize-conversation.ts
@@ -142,24 +142,28 @@ ${formatConversationAsXml(turns)}
 
     debug(`Summarize - prompt for source ${sourceId}:`, prompt);
     try {
-      const completion = await parseStructuredCompletion(client, {
-        messages: [{ role: "user", content: prompt }],
-        model: modelForTask("conversation_summary"),
-        max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-        response_format: zodResponseFormat(
-          z.object({
-            title: z
-              .string()
-              .describe(
-                "A concise title for the summary, max length 255 characters",
-              ),
-            summary: z
-              .string()
-              .describe("A concise summary of the conversation"),
-          }),
-          "summary",
-        ),
-      });
+      const completion = await parseStructuredCompletion(
+        client,
+        {
+          messages: [{ role: "user", content: prompt }],
+          model: modelForTask("conversation_summary"),
+          max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+          response_format: zodResponseFormat(
+            z.object({
+              title: z
+                .string()
+                .describe(
+                  "A concise title for the summary, max length 255 characters",
+                ),
+              summary: z
+                .string()
+                .describe("A concise summary of the conversation"),
+            }),
+            "summary",
+          ),
+        },
+        { task: "conversation_summary", userId },
+      );
 
       const parsed = completion.choices[0]?.message.parsed;
       debug(`Summarize - parsed result for source ${sourceId}:`, parsed);

--- a/src/lib/jobs/summarize-conversation.ts
+++ b/src/lib/jobs/summarize-conversation.ts
@@ -9,7 +9,7 @@ import {
 } from "~/lib/conversation-store";
 import { debug } from "~/lib/debug-utils";
 import { formatConversationAsXml } from "~/lib/formatting";
-import { env } from "~/utils/env";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 
 // Job input schema
 export const SummarizeConversationJobInputSchema = z.object({
@@ -83,7 +83,9 @@ export async function summarizeUserConversations(
     MalformedUpstreamCompletionError,
     parseStructuredCompletion,
   } = await import("../ai");
-  const client = await createCompletionClient(userId);
+  const client = await createCompletionClient(userId, {
+    task: "conversation_summary",
+  });
 
   for (const { sourceId, conversationNodeId } of convsToSummarize) {
     // load conversation turns
@@ -142,7 +144,8 @@ ${formatConversationAsXml(turns)}
     try {
       const completion = await parseStructuredCompletion(client, {
         messages: [{ role: "user", content: prompt }],
-        model: env.MODEL_ID_GRAPH_EXTRACTION,
+        model: modelForTask("conversation_summary"),
+        max_tokens: MODEL_MAX_OUTPUT_TOKENS,
         response_format: zodResponseFormat(
           z.object({
             title: z

--- a/src/lib/queues.ts
+++ b/src/lib/queues.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 import { env } from "~/utils/env";
+import { modelForTask } from "~/utils/models";
 
 // Define connection options using environment variables
 export const redisConnection = new IORedis(env.REDIS_URL, {
@@ -288,7 +289,7 @@ const worker = new Worker<SummarizeJobData | DreamJobData>(
       } else if (job.name === "cleanup-graph") {
         const data = CleanupGraphJobInputSchema.parse({
           ...job.data,
-          llmModelId: env.MODEL_ID_GRAPH_EXTRACTION,
+          llmModelId: modelForTask("graph_cleanup"),
         });
         console.log(
           `Starting cleanup-graph job for user ${data.userId}, since ${data.since.toISOString()}`,

--- a/src/lib/transcript/segment-transcript.ts
+++ b/src/lib/transcript/segment-transcript.ts
@@ -12,7 +12,7 @@
 import { zodResponseFormat } from "openai/helpers/zod.mjs";
 import { z } from "zod";
 import { createCompletionClient, parseStructuredCompletion } from "~/lib/ai";
-import { env } from "~/utils/env";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
 
 export const segmentedUtteranceSchema = z.object({
   speakerLabel: z
@@ -71,7 +71,9 @@ export const defaultSegmentTranscriptClient: SegmentTranscriptClient = {
     rawContent,
     occurredAt,
   }: SegmentTranscriptInput): Promise<SegmentedUtterance[]> {
-    const client = await createCompletionClient(userId);
+    const client = await createCompletionClient(userId, {
+      task: "transcript_segmentation",
+    });
     const prompt = `Segment the following transcript by speaker turn.
 
 The transcript was recorded around ${occurredAt.toISOString()}. If individual utterance timestamps are visible, include them as ISO 8601; otherwise omit the timestamp field.
@@ -85,7 +87,8 @@ ${rawContent}
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      model: env.MODEL_ID_GRAPH_EXTRACTION,
+      model: modelForTask("transcript_segmentation"),
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
       response_format: zodResponseFormat(
         segmentationResponseSchema,
         "transcript_segmentation",

--- a/src/lib/transcript/segment-transcript.ts
+++ b/src/lib/transcript/segment-transcript.ts
@@ -82,18 +82,22 @@ The transcript was recorded around ${occurredAt.toISOString()}. If individual ut
 ${rawContent}
 </transcript>`;
 
-    const completion = await parseStructuredCompletion(client, {
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: prompt },
-      ],
-      model: modelForTask("transcript_segmentation"),
-      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
-      response_format: zodResponseFormat(
-        segmentationResponseSchema,
-        "transcript_segmentation",
-      ),
-    });
+    const completion = await parseStructuredCompletion(
+      client,
+      {
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: prompt },
+        ],
+        model: modelForTask("transcript_segmentation"),
+        max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+        response_format: zodResponseFormat(
+          segmentationResponseSchema,
+          "transcript_segmentation",
+        ),
+      },
+      { task: "transcript_segmentation", userId },
+    );
 
     const parsed = completion.choices[0]?.message.parsed;
     if (!parsed) {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -6,7 +6,28 @@ const envSchema = z.object({
   MEMORY_OPENAI_API_KEY: z.string().min(1),
   MEMORY_OPENAI_API_BASE_URL: z.string().min(1),
 
+  // Base model. Every other task falls back to this when its own
+  // MODEL_ID_* override is unset, so the system behaves exactly as it did
+  // before tiering until a task is deliberately pointed at another model.
   MODEL_ID_GRAPH_EXTRACTION: z.string().min(1),
+
+  // Per-task model overrides (all optional). Set any of these to route that
+  // task to a cheaper/different model on OpenRouter; leave unset to inherit
+  // MODEL_ID_GRAPH_EXTRACTION. Resolved in src/utils/models.ts.
+  MODEL_ID_DOCUMENT_SPINE: z.string().min(1).optional(),
+  MODEL_ID_TRANSCRIPT_SEGMENTATION: z.string().min(1).optional(),
+  MODEL_ID_CONVERSATION_SUMMARY: z.string().min(1).optional(),
+  MODEL_ID_GRAPH_CLEANUP: z.string().min(1).optional(),
+  MODEL_ID_ATLAS: z.string().min(1).optional(),
+  MODEL_ID_PROFILE_SYNTHESIS: z.string().min(1).optional(),
+  MODEL_ID_DREAM: z.string().min(1).optional(),
+  MODEL_ID_DEEP_RESEARCH: z.string().min(1).optional(),
+
+  // Hard ceiling on output tokens per completion. Bounds a runaway
+  // generation (providers can emit up to 128k); set well above the observed
+  // average output (~850) so it effectively never truncates real work.
+  // Per-call overrides are allowed in code.
+  MODEL_MAX_OUTPUT_TOKENS: z.coerce.number().int().positive().default(16000),
 
   JINA_API_KEY: z.string().min(1),
 
@@ -58,9 +79,14 @@ const envSchema = z.object({
     .default(false)
     .describe("Enable debug logging"),
 
-  DREAM_PROBABILITY: z.coerce.number().default(0.1),
+  // Speculative background work. Both run with no user waiting on the
+  // result and each fans out into multiple LLM calls, so they are the
+  // cheapest spend to throttle. Deep research is disabled by default
+  // (set DEEP_RESEARCH_PROBABILITY > 0 to experiment); dreams are throttled
+  // down. Override via env to tune without a deploy.
+  DREAM_PROBABILITY: z.coerce.number().default(0.05),
   DREAM_SELECTION_PROBABILITY: z.coerce.number().default(0.4),
-  DEEP_RESEARCH_PROBABILITY: z.coerce.number().default(0.5),
+  DEEP_RESEARCH_PROBABILITY: z.coerce.number().default(0),
 
   // Identity resolution (signal 3 + 4) thresholds. Defaults are intentionally
   // conservative — false-positive merges are far worse than missed merges

--- a/src/utils/llm-telemetry.ts
+++ b/src/utils/llm-telemetry.ts
@@ -1,0 +1,54 @@
+import type { ModelTask } from "./models";
+
+/**
+ * Provider-neutral accounting for one LLM call. Deliberately not tied to any
+ * observability vendor: Helicone (which we also tag via request headers) is a
+ * convenience layer that may go away, whereas this event is the durable
+ * signal we own. `task` is our own concept and only survives if we emit it
+ * ourselves — providers can only ever give us a per-model breakdown.
+ */
+export interface LlmUsageEvent {
+  task: ModelTask | "unknown";
+  model: string;
+  userId: string;
+  promptTokens?: number | undefined;
+  /** OpenRouter prompt-cache hit (prompt_tokens_details.cached_tokens). */
+  cachedTokens?: number | undefined;
+  completionTokens?: number | undefined;
+  totalTokens?: number | undefined;
+}
+
+/** The subset of the OpenAI/OpenRouter `usage` object we read. */
+interface UsageLike {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number } | null;
+}
+
+/** Flatten the provider `usage` object into {@link LlmUsageEvent} fields. */
+export function normalizeUsage(
+  usage: UsageLike | null | undefined,
+): Pick<
+  LlmUsageEvent,
+  "promptTokens" | "cachedTokens" | "completionTokens" | "totalTokens"
+> {
+  return {
+    promptTokens: usage?.prompt_tokens,
+    cachedTokens: usage?.prompt_tokens_details?.cached_tokens,
+    completionTokens: usage?.completion_tokens,
+    totalTokens: usage?.total_tokens,
+  };
+}
+
+/**
+ * Emit one LLM-call accounting event as a single structured stdout line.
+ *
+ * This is the one seam to repoint when the observability backend changes:
+ * a log drain, an OpenTelemetry collector, a Sentry breadcrumb, or a
+ * Postgres sink can all consume `type: "llm_usage"` to build per-task and
+ * per-model cost dashboards without touching any call site.
+ */
+export function recordLlmUsage(event: LlmUsageEvent): void {
+  console.log(JSON.stringify({ type: "llm_usage", ...event }));
+}

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -1,0 +1,51 @@
+import { env } from "./env";
+
+/**
+ * Logical LLM tasks the service performs. Each maps to a model id and is also
+ * emitted as the `Helicone-Property-Task` header so spend can be broken down
+ * per task in Helicone (independent of which model a task is routed to).
+ *
+ * The string values double as the Helicone property value, so keep them
+ * stable and human-readable.
+ */
+export type ModelTask =
+  | "graph_extraction"
+  | "document_spine"
+  | "transcript_segmentation"
+  | "conversation_summary"
+  | "graph_cleanup"
+  | "atlas"
+  | "profile_synthesis"
+  | "dream"
+  | "deep_research";
+
+/**
+ * Per-task overrides. An undefined entry (the default for every task) means
+ * "inherit MODEL_ID_GRAPH_EXTRACTION" — see {@link modelForTask}.
+ */
+const TASK_MODEL_OVERRIDES: Record<ModelTask, string | undefined> = {
+  graph_extraction: undefined,
+  document_spine: env.MODEL_ID_DOCUMENT_SPINE,
+  transcript_segmentation: env.MODEL_ID_TRANSCRIPT_SEGMENTATION,
+  conversation_summary: env.MODEL_ID_CONVERSATION_SUMMARY,
+  graph_cleanup: env.MODEL_ID_GRAPH_CLEANUP,
+  atlas: env.MODEL_ID_ATLAS,
+  profile_synthesis: env.MODEL_ID_PROFILE_SYNTHESIS,
+  dream: env.MODEL_ID_DREAM,
+  deep_research: env.MODEL_ID_DEEP_RESEARCH,
+};
+
+/**
+ * Resolve the model id for a task.
+ *
+ * Safe fallback: every task falls back to `MODEL_ID_GRAPH_EXTRACTION` — the
+ * single model the system used before tiering existed — so behavior is
+ * unchanged until a task's `MODEL_ID_*` override is set. Swap one task at a
+ * time and roll back by unsetting its env var.
+ */
+export function modelForTask(task: ModelTask): string {
+  return TASK_MODEL_OVERRIDES[task] ?? env.MODEL_ID_GRAPH_EXTRACTION;
+}
+
+/** Default per-completion output-token ceiling. */
+export const MODEL_MAX_OUTPUT_TOKENS = env.MODEL_MAX_OUTPUT_TOKENS;


### PR DESCRIPTION
## Summary
This PR introduces per-task model routing and structured LLM usage telemetry to enable cost tracking and optimization by task type. The system now supports routing different LLM tasks to different models via environment variables while maintaining backward compatibility.

## Key Changes

- **New telemetry infrastructure** (`src/utils/llm-telemetry.ts`):
  - Added `LlmUsageEvent` interface for provider-neutral LLM call accounting
  - Implemented `normalizeUsage()` to flatten OpenAI/OpenRouter usage objects
  - Implemented `recordLlmUsage()` to emit structured telemetry as JSON to stdout
  - Captures task, model, user, token counts, and cached token metrics

- **Per-task model routing** (`src/utils/models.ts`):
  - Defined `ModelTask` type with 9 task categories (graph_extraction, document_spine, transcript_segmentation, conversation_summary, graph_cleanup, atlas, profile_synthesis, dream, deep_research)
  - Implemented `modelForTask()` function with safe fallback to `MODEL_ID_GRAPH_EXTRACTION`
  - Allows independent model assignment per task via environment variables

- **Enhanced AI client functions** (`src/lib/ai.ts`):
  - Updated `parseStructuredCompletion()` to accept optional `task` and `userId` parameters
  - Updated `createCompletionClient()` to accept task parameter and set `Helicone-Property-Task` header for spend breakdown
  - Updated `crateTextCompletion()` and `performStructuredAnalysis()` to support task routing and telemetry recording
  - Added `max_tokens` parameter support with `MODEL_MAX_OUTPUT_TOKENS` default

- **Environment configuration** (`src/utils/env.ts`):
  - Added 8 optional per-task model override variables
  - Added `MODEL_MAX_OUTPUT_TOKENS` configuration (default 16000)
  - Adjusted default probabilities: `DREAM_PROBABILITY` (0.1 → 0.05), `DEEP_RESEARCH_PROBABILITY` (0.5 → 0)

- **Updated all LLM call sites** to pass task parameter:
  - Graph extraction (`extract-graph.ts`): Refactored prompt into static system message and dynamic user message for OpenRouter prompt caching
  - Conversation summarization (`summarize-conversation.ts`)
  - Transcript segmentation (`segment-transcript.ts`)
  - Document spine extraction (`extract-document-spine.ts`)
  - Graph cleanup (`cleanup-graph.ts`)
  - Atlas assistant (`atlas-assistant.ts`): Switched to use `crateTextCompletion()` helper
  - Dream job (`dream.ts`)
  - Deep research (`deep-research.ts`)
  - Atlas user job (`atlas-user.ts`)
  - Profile synthesis (`profile-synthesis.ts`)

- **Test updates** (`extract-graph.test.ts`): Updated mock to handle multi-message prompts by concatenating all message content

## Notable Implementation Details

- **Backward compatibility**: All task-specific model overrides are optional; undefined entries inherit `MODEL_ID_GRAPH_EXTRACTION`, preserving existing behavior until explicitly configured
- **Telemetry ownership**: Telemetry is emitted independently of vendor integrations (Helicone), ensuring cost tracking survives infrastructure changes
- **Prompt caching optimization**: Graph extraction now uses system/user message split to enable OpenRouter/OpenAI automatic prompt caching of the static instruction block
- **Helicone integration**: Task information is passed via `Helicone-Property-Task` header for vendor-side spend breakdown
- **Token accounting**: Captures both regular and cached prompt tokens to track cache hit efficiency

https://claude.ai/code/session_01NQ5oJ6eoQiKqmxk3E1NJxr