### PR TITLE
Add deterministic memory garbage collection with pruneStaleNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pruneStaleNodes` — deterministic, preview-then-apply memory garbage collection.** A new `POST /maintenance/prune-stale-nodes` endpoint (and `MemoryClient.pruneStaleNodes`) scores every entity/task node on a transparent, LLM-free weighted sum — `0.40·staleness + 0.25·isolation + 0.20·weakProvenance + 0.15·claimDecay` — and prunes the disposable tail: old, weakly-connected, assistant-inferred-only, or superseded-dominated nodes. Tune with a single `aggressiveness` knob (`[0, 1]`, higher prunes more) or pin an explicit `minScore`. `dryRun` defaults to `true` and returns the ranked candidates with per-node `reasons` plus the full `candidateCount`; re-call with the same thresholds and `dryRun: false` to delete (cascades through claims, source links, aliases, and embeddings). The sweep never touches nodes active within `minIdleDays`, nodes with a currently-open task status, the user's self-identity node(s), or — unless `includeReference` is set — reference-scope nodes. Complements the narrower `pruneOrphanNodes` (evidence-free nodes) and `dedupSweep` (exact-label duplicates).
+
 ### Fixed
 
 - **Conversation/document ingestion no longer manufactures spurious or auto-trusted tasks.** The graph-extraction prompt now explicitly forbids minting Task nodes from assistant suggestions, recaps/summaries, uncommitted planning, or the existence of the conversation itself (e.g. a "weekly check-in" task), and requires Task labels to be short imperative actions rather than conversation summaries. Additionally, **every brand-new task created during ingestion is now recorded as tentative (the candidate band) deterministically** — the model no longer decides this, so a passive background ingest can never fabricate a firm commitment. Firm commitments arise only from explicit user action: the candidate-confirmation flow (a later status claim against the existing task) or the commitment write APIs.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,45 @@ The integration only works if these are true:
 - `POST /query/day` – get a quick summary of a particular day.
 - `POST /query/recent-changes` – "what's new in memory" feed over a time range: active claims and nodes added/updated since a `since` cursor, with labels and per-source provenance.
 - `POST /digest` – consolidated daily rollup for a "Today" view (see below).
+- `POST /maintenance/prune-stale-nodes` – deterministic, preview-then-apply "garbage collect" sweep (see below).
 - `GET /sse` and `POST /messages` – MCP over HTTP using Server‑Sent Events.
+
+### Pruning stale memory
+
+Over time a graph accretes cruft: nodes from old conversations that are weakly
+connected, backed only by assistant-inferred claims, or dominated by superseded
+facts. `POST /maintenance/prune-stale-nodes` is a deterministic (no-LLM) sweep
+that scores every entity/task node and prunes the disposable tail. The score is
+a transparent weighted sum so a host (e.g. a "clean up my memory" button) can
+preview exactly what would go and why:
+
+```text
+score = 0.40·staleness + 0.25·isolation + 0.20·weakProvenance + 0.15·claimDecay
+```
+
+It is **preview-then-apply**. `dryRun` defaults to `true` and returns the ranked
+candidates with per-node `reasons` plus the full `candidateCount`; re-call with
+the same thresholds and `dryRun: false` to delete (deletion cascades through
+claims, source links, aliases, and embeddings). Tune one knob — `aggressiveness`
+in `[0, 1]`, higher prunes more — or pin an explicit `minScore`.
+
+```json
+{
+  "userId": "user_123",
+  "aggressiveness": 0.6,
+  "minIdleDays": 30,
+  "includeReference": false,
+  "dryRun": true
+}
+```
+
+The sweep never prunes nodes active within `minIdleDays`, nodes with a
+currently-open task status, the user's self-identity node(s), or — unless
+`includeReference` is set — reference-scope nodes (books, articles, imported
+documents). Page through a large backlog by re-calling while `hasMore` is true.
+For the narrower deterministic cases there are also
+`POST /maintenance/prune-orphan-nodes` (evidence-free nodes) and
+`POST /cleanup/dedup-sweep` (exact-label duplicates).
 
 ### Daily digest
 

--- a/src/lib/jobs/prune-stale-nodes.test.ts
+++ b/src/lib/jobs/prune-stale-nodes.test.ts
@@ -1,0 +1,433 @@
+/**
+ * DB-integration tests for the deterministic staleness sweep.
+ *
+ * Like prune-orphan-nodes these run against a throwaway Postgres database and
+ * skip when no server is reachable. They pin the scoring/threshold behavior and
+ * the protection rules (recency floor, open tasks, self identity, reference
+ * scope) that keep the sweep from eating live memory.
+ */
+import "dotenv/config";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId, type TypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string): string =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+type TestDb = NodePgDatabase<typeof schema>;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number): Date => new Date(Date.now() - days * DAY_MS);
+
+async function createTables(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "sources" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "type" varchar(50) NOT NULL,
+      "external_id" text NOT NULL,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "metadata" jsonb,
+      "last_ingested_at" timestamp with time zone,
+      "status" varchar(20) DEFAULT 'completed',
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "deleted_at" timestamp with time zone,
+      "content_type" varchar(100),
+      "content_length" integer,
+      UNIQUE ("user_id", "type", "external_id")
+    );
+    CREATE TABLE IF NOT EXISTS "source_links" (
+      "id" text PRIMARY KEY NOT NULL,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "specific_location" text,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      UNIQUE ("source_id", "node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "claims" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "object_value" text,
+      "predicate" varchar(80) NOT NULL,
+      "statement" text NOT NULL,
+      "description" text,
+      "metadata" jsonb,
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+      "asserted_by_kind" varchar(24) NOT NULL,
+      "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+      "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+      "stated_at" timestamp with time zone NOT NULL,
+      "valid_from" timestamp with time zone,
+      "valid_to" timestamp with time zone,
+      "status" varchar(30) DEFAULT 'active' NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "claims_object_shape_xor_ck"
+        CHECK (num_nonnulls("object_node_id", "object_value") = 1)
+    );
+    CREATE TABLE IF NOT EXISTS "aliases" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "alias_text" text NOT NULL,
+      "normalized_alias_text" text NOT NULL,
+      "canonical_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "user_profiles" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "content" text NOT NULL,
+      "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+      "last_updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+  `);
+}
+
+const USER_ID = "user_stale_sweep";
+
+async function ensureUser(client: Client): Promise<void> {
+  await client.query(
+    `INSERT INTO "users" ("id") VALUES ($1) ON CONFLICT DO NOTHING`,
+    [USER_ID],
+  );
+}
+
+async function seedNode(
+  client: Client,
+  args: {
+    id: TypeId<"node">;
+    nodeType: string;
+    label: string;
+    createdAt: Date;
+  },
+): Promise<void> {
+  await ensureUser(client);
+  await client.query(
+    `INSERT INTO "nodes" ("id", "user_id", "node_type", "created_at")
+     VALUES ($1, $2, $3, $4)`,
+    [args.id, USER_ID, args.nodeType, args.createdAt],
+  );
+  await client.query(
+    `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label")
+     VALUES ($1, $2, $3, lower($3))`,
+    [newTypeId("node_metadata"), args.id, args.label],
+  );
+}
+
+let sharedSourceId: TypeId<"source"> | null = null;
+async function seedSourceOnce(client: Client): Promise<TypeId<"source">> {
+  if (sharedSourceId) return sharedSourceId;
+  const sourceId = newTypeId("source");
+  await ensureUser(client);
+  await client.query(
+    `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "scope", "metadata")
+     VALUES ($1, $2, 'conversation', $3, 'personal', '{}'::jsonb)`,
+    [sourceId, USER_ID, `ext:${sourceId}`],
+  );
+  sharedSourceId = sourceId;
+  return sourceId;
+}
+
+async function seedClaim(
+  client: Client,
+  args: {
+    subjectNodeId: TypeId<"node">;
+    predicate: string;
+    objectValue: string;
+    statedAt: Date;
+    status?: string;
+    scope?: string;
+    assertedByKind?: string;
+  },
+): Promise<void> {
+  const sourceId = await seedSourceOnce(client);
+  await client.query(
+    `INSERT INTO "claims" (
+       "id", "user_id", "subject_node_id", "object_value", "predicate",
+       "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+    [
+      newTypeId("claim"),
+      USER_ID,
+      args.subjectNodeId,
+      args.objectValue,
+      args.predicate,
+      `${args.predicate} ${args.objectValue}`,
+      sourceId,
+      args.scope ?? "personal",
+      args.assertedByKind ?? "user",
+      args.statedAt,
+      args.status ?? "active",
+    ],
+  );
+}
+
+async function seedSelfAlias(
+  client: Client,
+  args: { nodeId: TypeId<"node">; alias: string },
+): Promise<void> {
+  await ensureUser(client);
+  await client.query(
+    `INSERT INTO "aliases" ("id", "user_id", "alias_text", "normalized_alias_text", "canonical_node_id")
+     VALUES ($1, $2, $3, $4, $5)`,
+    [
+      newTypeId("alias"),
+      USER_ID,
+      args.alias,
+      args.alias.trim().toLowerCase(),
+      args.nodeId,
+    ],
+  );
+  await client.query(
+    `INSERT INTO "user_profiles" ("id", "user_id", "content", "metadata")
+     VALUES ($1, $2, '', $3::jsonb)
+     ON CONFLICT DO NOTHING`,
+    [
+      newTypeId("user_profile"),
+      USER_ID,
+      JSON.stringify({ userSelfAliases: [args.alias] }),
+    ],
+  );
+}
+
+async function nodeCount(client: Client): Promise<number> {
+  const res = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM "nodes" WHERE "user_id" = $1`,
+    [USER_ID],
+  );
+  return Number(res.rows[0]?.count ?? "0");
+}
+
+describeIfServer("pruneStaleNodes", () => {
+  const dbName = `memory_prune_stale_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  let database: TestDb;
+  let rootClient: Client;
+
+  // Distinct node fixtures reused across cases.
+  const staleId = newTypeId("node"); // old, no evidence -> high score
+  const recentId = newTypeId("node"); // recent -> protected by recency floor
+  const strongId = newTypeId("node"); // old but well-connected -> survives
+  const openTaskId = newTypeId("node"); // old task, open -> protected
+  const selfId = newTypeId("node"); // self identity -> protected
+  const referenceId = newTypeId("node"); // reference scope -> protected by default
+
+  async function seedGraph(): Promise<void> {
+    sharedSourceId = null;
+    await seedNode(rootClient, {
+      id: staleId,
+      nodeType: "Concept",
+      label: "stale concept",
+      createdAt: daysAgo(400),
+    });
+    await seedNode(rootClient, {
+      id: recentId,
+      nodeType: "Concept",
+      label: "recent concept",
+      createdAt: daysAgo(5),
+    });
+    await seedNode(rootClient, {
+      id: strongId,
+      nodeType: "Concept",
+      label: "strong concept",
+      createdAt: daysAgo(400),
+    });
+    for (let i = 0; i < 3; i += 1) {
+      await seedClaim(rootClient, {
+        subjectNodeId: strongId,
+        predicate: "HAS_ATTRIBUTE",
+        objectValue: `attr-${i}`,
+        statedAt: daysAgo(400),
+        assertedByKind: "user",
+      });
+    }
+    await seedNode(rootClient, {
+      id: openTaskId,
+      nodeType: "Task",
+      label: "open task",
+      createdAt: daysAgo(400),
+    });
+    await seedClaim(rootClient, {
+      subjectNodeId: openTaskId,
+      predicate: "HAS_TASK_STATUS",
+      objectValue: "pending",
+      statedAt: daysAgo(400),
+      assertedByKind: "user",
+    });
+    await seedNode(rootClient, {
+      id: selfId,
+      nodeType: "Person",
+      label: "Marcel",
+      createdAt: daysAgo(400),
+    });
+    await seedSelfAlias(rootClient, { nodeId: selfId, alias: "Marcel" });
+    await seedNode(rootClient, {
+      id: referenceId,
+      nodeType: "Concept",
+      label: "reference concept",
+      createdAt: daysAgo(400),
+    });
+    await seedClaim(rootClient, {
+      subjectNodeId: referenceId,
+      predicate: "HAS_ATTRIBUTE",
+      objectValue: "from a book",
+      statedAt: daysAgo(400),
+      scope: "reference",
+      assertedByKind: "document_author",
+    });
+  }
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    rootClient = new Client({ connectionString: dsnFor(dbName) });
+    await rootClient.connect();
+    database = drizzle(rootClient, { schema, casing: "snake_case" });
+    await createTables(rootClient);
+  });
+
+  afterAll(async () => {
+    await rootClient.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  afterEach(async () => {
+    await rootClient.query(
+      `TRUNCATE "aliases", "claims", "source_links", "user_profiles",
+              "node_metadata", "nodes", "sources", "users" CASCADE`,
+    );
+  });
+
+  it("dry run scores stale nodes but protects recent/connected/task/self/reference nodes", async () => {
+    await seedGraph();
+    const { pruneStaleNodes } = await import("./prune-stale-nodes");
+
+    const result = await pruneStaleNodes({ userId: USER_ID }, database);
+
+    expect(result.dryRun).toBe(true);
+    expect(result.appliedThreshold).toBeCloseTo(0.5);
+    expect(result.scannedCount).toBe(6);
+    expect(result.candidateCount).toBe(1);
+    expect(result.deletedCount).toBe(0);
+    expect(result.candidates.map((node) => node.id)).toEqual([staleId]);
+    expect(result.candidates[0]?.score).toBe(1);
+    expect(result.candidates[0]?.reasons.join(" ")).toContain("no evidence");
+
+    // Nothing deleted on a dry run.
+    expect(await nodeCount(rootClient)).toBe(6);
+  });
+
+  it("apply deletes candidates and leaves protected nodes intact", async () => {
+    await seedGraph();
+    const { pruneStaleNodes } = await import("./prune-stale-nodes");
+
+    const result = await pruneStaleNodes(
+      { userId: USER_ID, dryRun: false },
+      database,
+    );
+
+    expect(result.dryRun).toBe(false);
+    expect(result.deletedCount).toBe(1);
+    expect(result.hasMore).toBe(false);
+
+    const remaining = await rootClient.query<{ id: string }>(
+      `SELECT "id" FROM "nodes" WHERE "user_id" = $1 ORDER BY "id"`,
+      [USER_ID],
+    );
+    const remainingIds = remaining.rows.map((row) => row.id).sort();
+    expect(remainingIds).toEqual(
+      [recentId, strongId, openTaskId, selfId, referenceId].sort(),
+    );
+  });
+
+  it("includeReference brings reference nodes into scope", async () => {
+    await seedGraph();
+    const { pruneStaleNodes } = await import("./prune-stale-nodes");
+
+    const result = await pruneStaleNodes(
+      { userId: USER_ID, includeReference: true },
+      database,
+    );
+
+    expect(result.candidateCount).toBe(2);
+    expect(result.candidates.map((node) => node.id).sort()).toEqual(
+      [staleId, referenceId].sort(),
+    );
+  });
+
+  it("higher aggressiveness lowers the threshold and catches weak-but-connected nodes", async () => {
+    await seedGraph();
+    const { pruneStaleNodes } = await import("./prune-stale-nodes");
+
+    const result = await pruneStaleNodes(
+      { userId: USER_ID, aggressiveness: 0.55 },
+      database,
+    );
+
+    expect(result.appliedThreshold).toBeCloseTo(0.45);
+    expect(result.candidates.map((node) => node.id).sort()).toEqual(
+      [staleId, strongId].sort(),
+    );
+  });
+});

--- a/src/lib/jobs/prune-stale-nodes.ts
+++ b/src/lib/jobs/prune-stale-nodes.ts
@@ -1,0 +1,382 @@
+/**
+ * Deterministic staleness-based garbage collection for accreted graph cruft.
+ *
+ * Where {@link ./prune-orphan-nodes} only removes nodes with *zero* evidence,
+ * this sweep scores every entity/task node and prunes the disposable tail:
+ * old, weakly-connected, assistant-inferred-only, or superseded-dominated
+ * nodes. The score is a transparent weighted sum of four components so a
+ * consumer can preview exactly what would go and why before applying.
+ *
+ *   score = 0.40·staleness + 0.25·isolation + 0.20·weakProvenance + 0.15·decay
+ *
+ * Protected and never pruned: nodes active within `minIdleDays`, nodes with a
+ * currently-open task status, the user's self-identity node(s), and (unless
+ * `includeReference`) reference-scope nodes. Deletion cascades through claims,
+ * source links, aliases, and embeddings by FK.
+ *
+ * Common aliases: prune stale nodes, memory garbage collection, graph GC,
+ * weed old nodes, staleness sweep, low-quality node cleanup.
+ */
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import {
+  aliases,
+  claims,
+  nodeMetadata,
+  nodes,
+  sourceLinks,
+  userProfiles,
+} from "~/db/schema";
+import { logEvent } from "~/lib/observability/log";
+import {
+  pruneStaleNodesRequestSchema,
+  type PruneStaleNodesRequest,
+  type PruneStaleNodesResponse,
+  type StaleNodeCandidate,
+} from "~/lib/schemas/prune-stale-nodes";
+import { userProfileMetadataSchema } from "~/lib/schemas/user-profile-metadata";
+import type { NodeType } from "~/types/graph";
+import type { TypeId } from "~/types/typeid";
+import { useDatabase } from "~/utils/db";
+
+const DEFAULT_PRUNABLE_NODE_TYPES = [
+  "Person",
+  "Location",
+  "Event",
+  "Object",
+  "Emotion",
+  "Concept",
+  "Media",
+  "Feedback",
+  "Idea",
+  "Task",
+] as const satisfies readonly NodeType[];
+
+const OPEN_TASK_STATUSES = ["pending", "in_progress"] as const;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Score component weights. Sum to 1 so the score stays in [0, 1].
+const W_STALENESS = 0.4;
+const W_ISOLATION = 0.25;
+const W_PROVENANCE = 0.2;
+const W_DECAY = 0.15;
+
+interface ScoredNodeRow {
+  id: TypeId<"node">;
+  nodeType: NodeType;
+  label: string | null;
+  createdAt: Date;
+  lastClaimAt: Date | null;
+  totalClaims: number;
+  activeClaims: number;
+  supersededClaims: number;
+  groundedActiveClaims: number;
+  activeReferenceClaims: number;
+  activePersonalClaims: number;
+  hasAlias: boolean;
+  hasSourceLink: boolean;
+}
+
+/**
+ * One pass over the user's nodes computing the aggregates the score needs.
+ * `count(DISTINCT claims.id)` keeps the alias/source-link presence joins from
+ * inflating claim counts via row fan-out.
+ */
+async function scoreNodeRows(
+  db: DrizzleDB,
+  params: { userId: string; nodeTypes: readonly NodeType[] },
+): Promise<ScoredNodeRow[]> {
+  if (params.nodeTypes.length === 0) return [];
+
+  const rows = await db
+    .select({
+      id: nodes.id,
+      nodeType: nodes.nodeType,
+      label: nodeMetadata.label,
+      createdAt: nodes.createdAt,
+      lastClaimAt: sql<string | null>`max(${claims.statedAt})`.as(
+        "last_claim_at",
+      ),
+      totalClaims:
+        sql<number>`cast(count(distinct ${claims.id}) as integer)`.as(
+          "total_claims",
+        ),
+      activeClaims: sql<number>`cast(count(distinct ${claims.id}) filter (
+        where ${claims.status} = 'active'
+      ) as integer)`.as("active_claims"),
+      supersededClaims: sql<number>`cast(count(distinct ${claims.id}) filter (
+        where ${claims.status} <> 'active'
+      ) as integer)`.as("superseded_claims"),
+      groundedActiveClaims:
+        sql<number>`cast(count(distinct ${claims.id}) filter (
+        where ${claims.status} = 'active'
+          and ${claims.assertedByKind} not in ('assistant_inferred', 'system')
+      ) as integer)`.as("grounded_active_claims"),
+      activeReferenceClaims:
+        sql<number>`cast(count(distinct ${claims.id}) filter (
+        where ${claims.status} = 'active' and ${claims.scope} = 'reference'
+      ) as integer)`.as("active_reference_claims"),
+      activePersonalClaims:
+        sql<number>`cast(count(distinct ${claims.id}) filter (
+        where ${claims.status} = 'active' and ${claims.scope} = 'personal'
+      ) as integer)`.as("active_personal_claims"),
+      hasAlias: sql<boolean>`bool_or(${aliases.id} is not null)`.as(
+        "has_alias",
+      ),
+      hasSourceLink: sql<boolean>`bool_or(${sourceLinks.id} is not null)`.as(
+        "has_source_link",
+      ),
+    })
+    .from(nodes)
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .leftJoin(
+      claims,
+      and(
+        eq(claims.userId, params.userId),
+        sql`(${claims.subjectNodeId} = ${nodes.id} or ${claims.objectNodeId} = ${nodes.id})`,
+      ),
+    )
+    .leftJoin(
+      aliases,
+      and(
+        eq(aliases.userId, params.userId),
+        eq(aliases.canonicalNodeId, nodes.id),
+      ),
+    )
+    .leftJoin(sourceLinks, eq(sourceLinks.nodeId, nodes.id))
+    .where(
+      and(
+        eq(nodes.userId, params.userId),
+        inArray(nodes.nodeType, [...params.nodeTypes]),
+      ),
+    )
+    .groupBy(nodes.id, nodes.nodeType, nodeMetadata.label, nodes.createdAt);
+
+  return rows.map((row) => ({
+    ...row,
+    lastClaimAt: row.lastClaimAt === null ? null : new Date(row.lastClaimAt),
+  }));
+}
+
+/**
+ * Node ids that must never be pruned regardless of score: subjects of a
+ * currently-open task status, and the user's self-identity node(s).
+ */
+async function collectProtectedNodeIds(
+  db: DrizzleDB,
+  userId: string,
+): Promise<Set<TypeId<"node">>> {
+  const protectedIds = new Set<TypeId<"node">>();
+
+  const openTaskRows = await db
+    .selectDistinct({ nodeId: claims.subjectNodeId })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.predicate, "HAS_TASK_STATUS"),
+        eq(claims.status, "active"),
+        inArray(claims.objectValue, [...OPEN_TASK_STATUSES]),
+      ),
+    );
+  for (const row of openTaskRows) protectedIds.add(row.nodeId);
+
+  const [profile] = await db
+    .select({ metadata: userProfiles.metadata })
+    .from(userProfiles)
+    .where(eq(userProfiles.userId, userId))
+    .limit(1);
+
+  const selfAliases = userProfileMetadataSchema.parse(
+    profile?.metadata ?? {},
+  ).userSelfAliases;
+  const normalizedSelfAliases = [
+    ...new Set(
+      selfAliases.map((alias) => alias.trim().toLowerCase()).filter(Boolean),
+    ),
+  ];
+
+  if (normalizedSelfAliases.length > 0) {
+    const selfRows = await db
+      .select({ nodeId: aliases.canonicalNodeId })
+      .from(aliases)
+      .where(
+        and(
+          eq(aliases.userId, userId),
+          inArray(aliases.normalizedAliasText, normalizedSelfAliases),
+        ),
+      );
+    for (const row of selfRows) protectedIds.add(row.nodeId);
+  }
+
+  return protectedIds;
+}
+
+interface ScoredCandidate {
+  candidate: StaleNodeCandidate;
+  isReference: boolean;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function scoreNode(
+  row: ScoredNodeRow,
+  opts: { now: number; stalenessHorizonDays: number },
+): ScoredCandidate {
+  const lastActivityMs = Math.max(
+    row.createdAt.getTime(),
+    row.lastClaimAt?.getTime() ?? 0,
+  );
+  const idleDays = Math.max(
+    0,
+    Math.floor((opts.now - lastActivityMs) / DAY_MS),
+  );
+
+  const staleness = clamp01(idleDays / opts.stalenessHorizonDays);
+  const isolation = row.activeClaims === 0 ? 1 : 1 / (1 + row.activeClaims);
+  const weakProvenance = row.groundedActiveClaims > 0 ? 0 : 1;
+  const decay =
+    row.totalClaims === 0 ? 1 : row.supersededClaims / row.totalClaims;
+
+  const score = round3(
+    W_STALENESS * staleness +
+      W_ISOLATION * isolation +
+      W_PROVENANCE * weakProvenance +
+      W_DECAY * decay,
+  );
+
+  const reasons: string[] = [];
+  const hasNoEvidence =
+    row.totalClaims === 0 && !row.hasAlias && !row.hasSourceLink;
+  if (hasNoEvidence) {
+    reasons.push("no evidence (no claims, sources, or aliases)");
+  }
+  reasons.push(`idle ${idleDays}d`);
+  if (row.activeClaims === 0 && !hasNoEvidence) {
+    reasons.push("no active claims");
+  } else if (row.activeClaims > 0 && row.activeClaims <= 2) {
+    reasons.push(
+      `weakly connected (${row.activeClaims} active claim${
+        row.activeClaims === 1 ? "" : "s"
+      })`,
+    );
+  }
+  if (weakProvenance === 1 && row.totalClaims > 0) {
+    reasons.push("assistant-inferred only (no grounded claims)");
+  }
+  if (decay >= 0.5 && row.supersededClaims > 0) {
+    reasons.push(`${Math.round(decay * 100)}% of claims superseded`);
+  }
+
+  return {
+    candidate: {
+      id: row.id,
+      nodeType: row.nodeType,
+      label: row.label,
+      createdAt: row.createdAt,
+      lastActivityAt: new Date(lastActivityMs),
+      idleDays,
+      score,
+      activeClaimCount: row.activeClaims,
+      totalClaimCount: row.totalClaims,
+      reasons,
+    },
+    // A node is reference-scoped iff every active scope signal is reference;
+    // any active personal claim flips it back to personal (personal wins).
+    isReference:
+      row.activeReferenceClaims > 0 && row.activePersonalClaims === 0,
+  };
+}
+
+async function deleteNodes(
+  db: DrizzleDB,
+  userId: string,
+  nodeIds: TypeId<"node">[],
+): Promise<number> {
+  if (nodeIds.length === 0) return 0;
+  const deleted = await db
+    .delete(nodes)
+    .where(and(eq(nodes.userId, userId), inArray(nodes.id, nodeIds)))
+    .returning({ id: nodes.id });
+  return deleted.length;
+}
+
+/**
+ * Score and (optionally) prune stale/low-value nodes. Dry-run returns the
+ * ranked candidate set with reasons; destructive mode deletes up to `limit`
+ * of the highest-scoring candidates.
+ */
+export async function pruneStaleNodes(
+  rawInput: PruneStaleNodesRequest,
+  dbOverride?: DrizzleDB,
+): Promise<PruneStaleNodesResponse> {
+  const input = pruneStaleNodesRequestSchema.parse(rawInput);
+  const db = dbOverride ?? (await useDatabase());
+  const nodeTypes = input.nodeTypes ?? [...DEFAULT_PRUNABLE_NODE_TYPES];
+  const threshold = input.minScore ?? 1 - input.aggressiveness;
+  const now = Date.now();
+
+  const [rows, protectedIds] = await Promise.all([
+    scoreNodeRows(db, { userId: input.userId, nodeTypes }),
+    collectProtectedNodeIds(db, input.userId),
+  ]);
+
+  const candidates = rows
+    .map((row) =>
+      scoreNode(row, {
+        now,
+        stalenessHorizonDays: input.stalenessHorizonDays,
+      }),
+    )
+    .filter(({ candidate, isReference }) => {
+      if (protectedIds.has(candidate.id)) return false;
+      if (candidate.idleDays < input.minIdleDays) return false;
+      if (isReference && !input.includeReference) return false;
+      return candidate.score >= threshold;
+    })
+    .map((scored) => scored.candidate)
+    // Highest score first; node id (k-sortable) as a stable tiebreaker.
+    .sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : 1));
+
+  const hasMore = candidates.length > input.limit;
+  const toDelete = candidates.slice(0, input.limit);
+
+  const deletedCount = input.dryRun
+    ? 0
+    : await deleteNodes(
+        db,
+        input.userId,
+        toDelete.map((candidate) => candidate.id),
+      );
+
+  const sample: StaleNodeCandidate[] = toDelete.slice(0, input.sampleLimit);
+
+  logEvent("nodes.stale.pruned", {
+    userId: input.userId,
+    dryRun: input.dryRun,
+    appliedThreshold: threshold,
+    scannedCount: rows.length,
+    candidateCount: candidates.length,
+    deletedCount,
+    hasMore,
+  });
+
+  return {
+    dryRun: input.dryRun,
+    appliedThreshold: threshold,
+    minIdleDays: input.minIdleDays,
+    scannedCount: rows.length,
+    candidateCount: candidates.length,
+    deletedCount,
+    hasMore,
+    scannedNodeTypes: nodeTypes,
+    candidates: sample,
+  };
+}

--- a/src/lib/schemas/prune-stale-nodes.ts
+++ b/src/lib/schemas/prune-stale-nodes.ts
@@ -1,0 +1,112 @@
+/**
+ * REST/SDK schemas for `POST /maintenance/prune-stale-nodes`.
+ *
+ * A deterministic "garbage collect" sweep for accreted graph cruft. Unlike
+ * {@link ./prune-orphan-nodes} — which only removes nodes with *zero* evidence
+ * — this scores every entity/task node on a staleness/weakness basis and prunes
+ * the disposable tail: nodes that are old, weakly connected, backed only by
+ * assistant-inferred claims, or dominated by superseded claims.
+ *
+ * Scoring is intentionally LLM-free so the sweep is fast, cheap, and repeatable
+ * over a large graph, and so a consumer (e.g. a chat host's "clean up my
+ * memory" button) can show a stable preview before anything is deleted.
+ *
+ * The endpoint is preview-then-apply: `dryRun: true` (the default) returns the
+ * ranked candidates with per-node `reasons`; a second call with the same
+ * thresholds and `dryRun: false` deletes them.
+ */
+import { z } from "zod";
+import { NodeTypeEnum } from "~/types/graph.js";
+import { typeIdSchema } from "~/types/typeid.js";
+
+export const pruneStaleNodesRequestSchema = z.object({
+  userId: z.string().min(1),
+  /**
+   * Single tuning knob in `[0, 1]`. Higher prunes more. Maps to the score
+   * threshold as `threshold = 1 - aggressiveness` (so `0.5` keeps everything
+   * scoring below `0.5`). Ignored when `minScore` is provided.
+   */
+  aggressiveness: z.number().min(0).max(1).default(0.5),
+  /**
+   * Explicit score threshold override in `[0, 1]`. When set, a node is a
+   * candidate iff its prunability score is `>= minScore`, bypassing the
+   * `aggressiveness` mapping. Use this for reproducible scheduled sweeps.
+   */
+  minScore: z.number().min(0).max(1).optional(),
+  /**
+   * Recency floor: never prune a node whose most recent activity (its newest
+   * claim, or its own creation when it has no claims) is within this many days.
+   * Protects freshly-created and mid-ingestion nodes.
+   */
+  minIdleDays: z.number().int().nonnegative().default(30),
+  /**
+   * Idle horizon for the staleness component: a node idle for this many days
+   * contributes the maximum staleness (1.0) to its score. Lower values make the
+   * sweep treat moderately-old nodes as fully stale.
+   */
+  stalenessHorizonDays: z.number().int().positive().default(365),
+  /**
+   * Include reference-scope nodes (books, articles, imported documents). Off by
+   * default: the reference corpus is usually curated on purpose, so only
+   * personal/conversational memory is swept unless this is set.
+   */
+  includeReference: z.boolean().default(false),
+  /** Max nodes to delete per call. Re-call to page through a larger backlog. */
+  limit: z.number().int().positive().max(10_000).default(1_000),
+  /** Max scored candidates returned in the `candidates` sample. */
+  sampleLimit: z.number().int().nonnegative().max(500).default(50),
+  /**
+   * Dry run by default because this is destructive. Set `dryRun: false` to
+   * delete after inspecting the preview.
+   */
+  dryRun: z.boolean().default(true),
+  /**
+   * Defaults to entity/task-like node types. Structural and generated node
+   * types (`Conversation`, `Document`, `Temporal`, `Atlas`, `AssistantDream`)
+   * are deliberately excluded unless a caller explicitly opts in.
+   */
+  nodeTypes: z.array(NodeTypeEnum).optional(),
+});
+
+export type PruneStaleNodesRequest = z.input<
+  typeof pruneStaleNodesRequestSchema
+>;
+
+export const staleNodeCandidateSchema = z.object({
+  id: typeIdSchema("node"),
+  nodeType: NodeTypeEnum,
+  label: z.string().nullable(),
+  createdAt: z.coerce.date(),
+  /** Newest signal of activity: max(createdAt, newest claim statedAt). */
+  lastActivityAt: z.coerce.date(),
+  idleDays: z.number().int().nonnegative(),
+  /** Prunability score in `[0, 1]`, rounded to 3 decimals. Higher = weaker. */
+  score: z.number().min(0).max(1),
+  activeClaimCount: z.number().int().nonnegative(),
+  totalClaimCount: z.number().int().nonnegative(),
+  /** Human-readable explanation of why this node scored as prunable. */
+  reasons: z.array(z.string()),
+});
+
+export const pruneStaleNodesResponseSchema = z.object({
+  dryRun: z.boolean(),
+  /** Effective score threshold actually used (after the aggressiveness map). */
+  appliedThreshold: z.number().min(0).max(1),
+  minIdleDays: z.number().int().nonnegative(),
+  /** Total nodes of the scanned types that were scored. */
+  scannedCount: z.number().int().nonnegative(),
+  /** Nodes meeting the prune criteria (may exceed `limit` and `deletedCount`). */
+  candidateCount: z.number().int().nonnegative(),
+  /** Nodes actually deleted this call (0 when `dryRun`). */
+  deletedCount: z.number().int().nonnegative(),
+  /** True when more candidates remain than this call could delete (`limit`). */
+  hasMore: z.boolean(),
+  scannedNodeTypes: z.array(NodeTypeEnum),
+  /** Highest-scoring candidates, capped at `sampleLimit`. */
+  candidates: z.array(staleNodeCandidateSchema),
+});
+
+export type StaleNodeCandidate = z.infer<typeof staleNodeCandidateSchema>;
+export type PruneStaleNodesResponse = z.infer<
+  typeof pruneStaleNodesResponseSchema
+>;

--- a/src/routes/maintenance/prune-stale-nodes.post.ts
+++ b/src/routes/maintenance/prune-stale-nodes.post.ts
@@ -1,0 +1,12 @@
+import { defineEventHandler, readBody } from "h3";
+import { pruneStaleNodes } from "~/lib/jobs/prune-stale-nodes";
+import {
+  pruneStaleNodesRequestSchema,
+  pruneStaleNodesResponseSchema,
+} from "~/lib/schemas/prune-stale-nodes";
+
+export default defineEventHandler(async (event) => {
+  const params = pruneStaleNodesRequestSchema.parse(await readBody(event));
+  const result = await pruneStaleNodes(params);
+  return pruneStaleNodesResponseSchema.parse(result);
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -28,6 +28,7 @@ export * from "../lib/schemas/cleanup.js";
 export * from "../lib/schemas/cleanup-placeholders.js";
 export * from "../lib/schemas/open-commitments.js";
 export * from "../lib/schemas/prune-orphan-nodes.js";
+export * from "../lib/schemas/prune-stale-nodes.js";
 export * from "../lib/schemas/dream.js";
 export * from "../lib/schemas/scratchpad.js";
 export * from "../lib/schemas/node.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -168,6 +168,11 @@ import {
   pruneOrphanNodesResponseSchema,
 } from "../lib/schemas/prune-orphan-nodes.js";
 import {
+  PruneStaleNodesRequest,
+  PruneStaleNodesResponse,
+  pruneStaleNodesResponseSchema,
+} from "../lib/schemas/prune-stale-nodes.js";
+import {
   QueryAtlasNodesRequest,
   QueryAtlasNodesResponse,
   queryAtlasNodesResponseSchema,
@@ -690,6 +695,32 @@ export class MemoryClient {
       "POST",
       "/maintenance/prune-orphan-nodes",
       pruneOrphanNodesResponseSchema,
+      payload,
+    );
+  }
+
+  /**
+   * Deterministic, preview-then-apply "garbage collect" sweep for accreted
+   * graph cruft. Scores every entity/task node on a staleness/weakness basis
+   * (age + connectivity + provenance + claim decay) and prunes the disposable
+   * tail. Tune aggressiveness with a single `aggressiveness` knob (0–1, higher
+   * prunes more) or pin an explicit `minScore`.
+   *
+   * Dry-run defaults to `true`: the preview returns the ranked `candidates`
+   * with per-node `reasons` and the full `candidateCount`. Re-call with the
+   * same thresholds and `dryRun: false` to delete (deletion cascades through
+   * claims, source links, aliases, and embeddings). Never prunes nodes active
+   * within `minIdleDays`, nodes with a currently-open task status, the user's
+   * self-identity node(s), or — unless `includeReference` — reference-scope
+   * nodes. Page through a large backlog by re-calling while `hasMore` is true.
+   */
+  async pruneStaleNodes(
+    payload: PruneStaleNodesRequest,
+  ): Promise<PruneStaleNodesResponse> {
+    return this._fetch(
+      "POST",
+      "/maintenance/prune-stale-nodes",
+      pruneStaleNodesResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## Summary

Introduces `pruneStaleNodes`, a deterministic, preview-then-apply garbage collection sweep for accreted graph cruft. Unlike the existing orphan pruning which only removes nodes with zero evidence, this feature scores every entity/task node on staleness, isolation, provenance quality, and claim decay—then prunes the disposable tail while protecting recent, well-connected, and identity-critical nodes.

## Key Changes

- **New job: `src/lib/jobs/prune-stale-nodes.ts`**
  - Implements a transparent scoring algorithm: `score = 0.40·staleness + 0.25·isolation + 0.20·weakProvenance + 0.15·decay`
  - Scores nodes based on age, connectivity, grounded vs. assistant-inferred claims, and superseded claim ratio
  - Protects nodes active within `minIdleDays`, nodes with open task statuses, user self-identity nodes, and (optionally) reference-scope nodes
  - Supports dry-run preview and destructive deletion modes with pagination via `limit`
  - Deletion cascades through claims, source links, aliases, and embeddings via foreign keys

- **New schema: `src/lib/schemas/prune-stale-nodes.ts`**
  - Request schema with tuning parameters: `aggressiveness` (0–1 knob), explicit `minScore`, `minIdleDays` recency floor, `stalenessHorizonDays`, `includeReference` flag, and pagination controls
  - Response schema includes `appliedThreshold`, `scannedCount`, `candidateCount`, `deletedCount`, `hasMore`, and a `candidates` sample with per-node `reasons`

- **New endpoint: `src/routes/maintenance/prune-stale-nodes.post.ts`**
  - HTTP handler for `POST /maintenance/prune-stale-nodes`

- **SDK integration: `src/sdk/memory-client.ts`**
  - Added `pruneStaleNodes()` method with full JSDoc explaining the preview-then-apply workflow

- **Comprehensive test suite: `src/lib/jobs/prune-stale-nodes.test.ts`**
  - 433-line DB integration test suite (runs against throwaway Postgres)
  - Tests dry-run scoring, protection rules (recency floor, open tasks, self identity, reference scope), aggressiveness tuning, and destructive deletion
  - Validates that stale nodes are scored correctly while protected nodes remain intact

- **Documentation: `README.md` and `CHANGELOG.md`**
  - Added section explaining the pruning feature, scoring formula, and usage example
  - Documented in CHANGELOG under "Added"

## Implementation Details

- **Scoring is LLM-free**: Fast, cheap, and repeatable over large graphs; enables stable previews before deletion
- **Protection rules are explicit**: Nodes are never pruned if they have open task status, are the user's self-identity, are too recent, or (by default) are reference-scoped
- **Deterministic ordering**: Candidates sorted by score (descending) with node ID as stable tiebreaker for reproducibility
- **Efficient aggregation**: Single SQL pass with `count(DISTINCT claims.id)` to avoid row fan-out from joins
- **Transparent reasoning**: Each candidate includes human-readable `reasons` array explaining its score components

https://claude.ai/code/session_013rPD8Yg169QChrZA4mjQXg