### PR TITLE
✨ feat(sources): add opt-in source content lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ MCP connects over `GET /sse` and `POST /messages`. Most current tool names are h
 - `search memory`: calls the same search path as `POST /query/search`.
 - `retrieve memories relevant for today`: calls the same path as `POST /query/day`.
 - `list_open_commitments`: calls `POST /commitments/open` semantics and returns currently open tasks only. The model should call it before answering about outstanding, next, pending, follow-up, completed, or abandoned work unless an `open_commitments` section was rendered for this same model call.
-- `get node` and `get node sources`: raw inspection tools.
+- `get node` and `get node sources`: raw graph and linked-source metadata inspection tools.
 - `read scratchpad`, `write scratchpad`, `edit scratchpad`: scratchpad operations.
 - `update node`, `delete node`: raw edit tools; these should be gated by the host.
 

--- a/docs/sdk-consumer-migration.md
+++ b/docs/sdk-consumer-migration.md
@@ -10,6 +10,18 @@ has the _what to change_.
 
 ---
 
+## SDK source content lookup and metadata-only node sources
+
+- `MemoryClient.getSource({ userId, sourceId, includeContent: true })` now
+  returns the source summary plus `content: { text, format } | null`.
+  `content` is omitted unless requested. The endpoint returns only memory's
+  stored textual representation; it never decodes or returns raw binary blobs.
+- `MemoryClient.getNodeSources(...)` no longer returns `content` or reads
+  source payloads. It returns linked-source metadata only. Call `getSource`
+  explicitly for the individual source whose content is needed.
+
+---
+
 ## SDK addition — commitment due-date lifecycle, write-time enums, atomic node bootstrap
 
 Driven by Petals integration feedback. Five changes; all additive, no breaking changes to existing endpoints.

--- a/src/lib/mcp/mcp-server.ts
+++ b/src/lib/mcp/mcp-server.ts
@@ -743,7 +743,7 @@ server.tool(
   },
 );
 
-// Get raw source content for a node
+// Get source metadata linked to a node
 server.tool(
   "get node sources",
   getNodeSourcesRequestSchema.shape,
@@ -751,9 +751,7 @@ server.tool(
     const result = await getNodeSources(userId, nodeId);
     if (result.sources.length === 0) {
       return {
-        content: [
-          { type: "text", text: "No source content linked to this node" },
-        ],
+        content: [{ type: "text", text: "No sources linked to this node" }],
       };
     }
     return {

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -27,7 +27,7 @@ import { ensureUser } from "~/lib/ingestion/ensure-user";
 import { normalizeLabel } from "~/lib/label";
 import { writeNodeRedirects } from "~/lib/node-redirects";
 import { getEffectiveNodeScopes } from "~/lib/node-scope";
-import { ensureSystemSource, sourceService } from "~/lib/sources";
+import { ensureSystemSource } from "~/lib/sources";
 import { ensureDayNode } from "~/lib/temporal";
 import type { AssertedByKind, NodeType, Predicate, Scope } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
@@ -170,7 +170,7 @@ export async function getNodeById(
   };
 }
 
-/** Fetch raw source content linked to a node. */
+/** Fetch source metadata linked to a node. */
 export async function getNodeSources(
   userId: string,
   nodeId: TypeId<"node">,
@@ -191,7 +191,6 @@ export async function getNodeSources(
     .select({
       sourceId: sources.id,
       type: sources.type,
-      metadata: sources.metadata,
       timestamp: sources.lastIngestedAt,
     })
     .from(sourceLinks)
@@ -200,21 +199,10 @@ export async function getNodeSources(
 
   if (linkedSources.length === 0) return { sources: [] };
 
-  // Fetch raw content for each source
-  const sourceIds = linkedSources.map((s) => s.sourceId as TypeId<"source">);
-  const rawResults = await sourceService.fetchRaw(userId, sourceIds);
-  const contentMap = new Map(
-    rawResults.map((r) => [
-      r.sourceId,
-      r.kind === "inline" ? r.content : r.buffer.toString("utf-8"),
-    ]),
-  );
-
   return {
     sources: linkedSources.map((s) => ({
       sourceId: s.sourceId,
       type: s.type,
-      content: contentMap.get(s.sourceId) ?? null,
       timestamp: s.timestamp,
     })),
   };

--- a/src/lib/schemas/node-sources.test.ts
+++ b/src/lib/schemas/node-sources.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { nodeSourceSchema } from "~/lib/schemas/node";
+import { newTypeId } from "~/types/typeid";
+
+describe("nodeSourceSchema", () => {
+  it("does not expose source content", () => {
+    const parsed = nodeSourceSchema.parse({
+      sourceId: newTypeId("source"),
+      type: "document",
+      content: "large source content",
+      timestamp: new Date("2026-06-10T08:00:00.000Z"),
+    });
+
+    expect(parsed).not.toHaveProperty("content");
+  });
+});

--- a/src/lib/schemas/node.ts
+++ b/src/lib/schemas/node.ts
@@ -85,7 +85,6 @@ export const getNodeSourcesRequestSchema = z.object({
 export const nodeSourceSchema = z.object({
   sourceId: z.string(),
   type: z.string(),
-  content: z.string().nullable(),
   timestamp: z.coerce.date().nullable(),
 });
 

--- a/src/lib/schemas/sources.ts
+++ b/src/lib/schemas/sources.ts
@@ -83,10 +83,25 @@ export type ListSourcesResponse = z.infer<typeof listSourcesResponseSchema>;
 export const getSourceRequestSchema = z.object({
   userId: z.string(),
   sourceId: typeIdSchema("source"),
+  /** Include the stored textual representation used by memory. */
+  includeContent: z.boolean().optional(),
 });
 export type GetSourceRequest = z.infer<typeof getSourceRequestSchema>;
 
+export const sourceContentSchema = z.object({
+  text: z.string(),
+  format: z.enum(["text", "markdown"]),
+});
+export type SourceContent = z.infer<typeof sourceContentSchema>;
+
 export const getSourceResponseSchema = z.object({
-  source: sourceSummarySchema,
+  source: sourceSummarySchema.extend({
+    /**
+     * Present only when `includeContent` is true. `null` means no stored
+     * textual representation is available; raw binary blobs are never
+     * decoded or returned by this endpoint.
+     */
+    content: sourceContentSchema.nullable().optional(),
+  }),
 });
 export type GetSourceResponse = z.infer<typeof getSourceResponseSchema>;

--- a/src/routes/sources/get.post.ts
+++ b/src/routes/sources/get.post.ts
@@ -3,11 +3,12 @@ import {
   getSourceRequestSchema,
   getSourceResponseSchema,
 } from "~/lib/schemas/sources";
+import { sourceService } from "~/lib/sources";
 import { getSourceSummary } from "~/lib/sources-read";
 import { useDatabase } from "~/utils/db";
 
 export default defineEventHandler(async (event) => {
-  const { userId, sourceId } = getSourceRequestSchema.parse(
+  const { userId, sourceId, includeContent } = getSourceRequestSchema.parse(
     await readBody(event),
   );
   const db = await useDatabase();
@@ -18,5 +19,21 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Source not found",
     });
   }
-  return getSourceResponseSchema.parse({ source });
+
+  if (!includeContent) {
+    return getSourceResponseSchema.parse({ source });
+  }
+
+  const [raw] = await sourceService.fetchRaw(userId, [sourceId]);
+  const content =
+    raw?.kind === "inline"
+      ? {
+          text: raw.content,
+          format: source.type === "document" ? "markdown" : "text",
+        }
+      : null;
+
+  return getSourceResponseSchema.parse({
+    source: { ...source, content },
+  });
 });

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -1128,7 +1128,8 @@ export class MemoryClient {
   /**
    * Single-source lookup. Returns the same shape as `listSources` items so
    * the host can render an attached-source chip when only the `sourceId`
-   * is known.
+   * is known. Pass `includeContent: true` to also return memory's stored
+   * textual representation. Binary blobs are never returned or decoded.
    */
   async getSource(payload: GetSourceRequest): Promise<GetSourceResponse> {
     return this._fetch(

--- a/src/sources-get-route.test.ts
+++ b/src/sources-get-route.test.ts
@@ -1,0 +1,107 @@
+import handler from "./routes/sources/get.post";
+import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SourceSummary } from "~/lib/schemas/sources";
+import { newTypeId } from "~/types/typeid";
+
+const mocks = vi.hoisted(() => ({
+  fetchRaw: vi.fn(),
+  getSourceSummary: vi.fn(),
+}));
+
+vi.mock("~/lib/sources", () => ({
+  sourceService: { fetchRaw: mocks.fetchRaw },
+}));
+
+vi.mock("~/lib/sources-read", () => ({
+  getSourceSummary: mocks.getSourceSummary,
+}));
+
+vi.mock("~/utils/db", () => ({
+  useDatabase: async (): Promise<unknown> => ({}),
+}));
+
+describe("POST /sources/get", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("does not fetch or return content by default", async () => {
+    const source = makeSourceSummary("document");
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_source",
+      sourceId: source.sourceId,
+    }));
+    mocks.getSourceSummary.mockResolvedValue(source);
+
+    const response = await handler({} as H3Event);
+
+    expect(mocks.fetchRaw).not.toHaveBeenCalled();
+    expect(response.source).toEqual(source);
+    expect(response.source).not.toHaveProperty("content");
+  });
+
+  it("returns stored document text as markdown when requested", async () => {
+    const source = makeSourceSummary("document");
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_source",
+      sourceId: source.sourceId,
+      includeContent: true,
+    }));
+    mocks.getSourceSummary.mockResolvedValue(source);
+    mocks.fetchRaw.mockResolvedValue([
+      {
+        kind: "inline",
+        sourceId: source.sourceId,
+        content: "# Stored markdown",
+      },
+    ]);
+
+    const response = await handler({} as H3Event);
+
+    expect(mocks.fetchRaw).toHaveBeenCalledWith("user_source", [
+      source.sourceId,
+    ]);
+    expect(response.source.content).toEqual({
+      text: "# Stored markdown",
+      format: "markdown",
+    });
+  });
+
+  it("returns null content instead of decoding a blob", async () => {
+    const source = makeSourceSummary("document");
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_source",
+      sourceId: source.sourceId,
+      includeContent: true,
+    }));
+    mocks.getSourceSummary.mockResolvedValue(source);
+    mocks.fetchRaw.mockResolvedValue([
+      {
+        kind: "blob",
+        sourceId: source.sourceId,
+        buffer: Buffer.from("binary"),
+        contentType: "application/pdf",
+      },
+    ]);
+
+    const response = await handler({} as H3Event);
+
+    expect(response.source.content).toBeNull();
+  });
+});
+
+function makeSourceSummary(type: SourceSummary["type"]): SourceSummary {
+  return {
+    sourceId: newTypeId("source"),
+    type,
+    title: "Source title",
+    author: null,
+    status: "completed",
+    scope: "personal",
+    ingestedAt: new Date("2026-06-10T08:00:00.000Z"),
+    receivedAt: new Date("2026-06-10T08:01:00.000Z"),
+    nodeCount: 2,
+  };
+}


### PR DESCRIPTION
## What and why

Add an explicit source-content read path to the SDK and API without loading source payloads during node-source lookup.

- Extend `MemoryClient.getSource` / `POST /sources/get` with `includeContent?: boolean`.
- Return stored textual content as `{ text, format } | null` only when requested.
- Never decode or return raw binary blobs.
- Make `getNodeSources` metadata-only and remove its eager payload reads.
- Update MCP wording and consumer migration documentation.

## Developer impact

This is a breaking cleanup for consumers of `getNodeSources`: the returned source items no longer contain `content`. Consumers that need source text should call `getSource({ userId, sourceId, includeContent: true })` explicitly.

## How to test

- `pnpm test --run` (383 tests)
- `pnpm run build:check`
- `pnpm run build-sdk`
- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`

## Checklist

- [x] Build
- [x] Tests
- [x] Lint
- [x] Prettier
- [x] SDK export verification
- [x] Breaking change documented