### PR TITLE
✨ feat(rollup): temporal rollup — day/week/month/year summary hierarchy

### DIFF
--- a/docs/superpowers/plans/2026-06-10-screenpipe-distiller.md
+++ b/docs/superpowers/plans/2026-06-10-screenpipe-distiller.md
@@ -11,6 +11,7 @@
 **Reference spec:** `~/code/assistant-memory/docs/superpowers/specs/2026-06-10-screenpipe-memory-distiller-design.md`
 
 **Ground-truth facts (verified 2026-06-10):**
+
 - Screenpipe `/search` requires `Authorization: Bearer <token>`; token via `screenpipe auth token`. Response envelope: `{ "data": [ { "type": "OCR"|"Audio"|"Input", "content": {...} } ], "pagination": {...} }`. Valid `content_type` values: `ocr | audio | input | accessibility | all`.
 - OCR `content`: `app_name, window_name, browser_url, text, timestamp, focused, frame_id, …`. Audio `content`: `transcription, text, speaker_label, timestamp, …`. Input `content`: `app_name, window_title, browser_url, text_content, event_type, timestamp, …`.
 - Petals proxy: `POST https://petals.chat/api/memory/ingest/document`, header `x-api-key: petals-…`, body `{ document: { id, content, contentType, scope, title, timestamp } }` (no `userId` — Petals injects it). Response `{ message, jobId }`. Idempotent on `document.id`.
@@ -23,6 +24,7 @@
 ### Task 1: Initialize the repo
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/package.json`
 - Create: `~/code/screenpipe-distiller/tsconfig.json`
 - Create: `~/code/screenpipe-distiller/.gitignore`
@@ -123,6 +125,7 @@ activity document and ingests it into Assistant Memory via the hosted Petals
 proxy. See the design spec in `assistant-memory/docs/superpowers/specs/`.
 
 ## Usage
+
 - `bun run distill [--date YYYY-MM-DD]` — distill a day (default: yesterday).
 - `bun run health-check` — check Screenpipe recording health; notify if down.
 
@@ -150,6 +153,7 @@ git commit -m "🔧 chore: scaffold screenpipe-distiller (bun + ts)"
 ### Task 2: Re-own `screenpipe record` via launchd
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/launchd/com.marcel.screenpipe.record.plist`
 - Create: `~/code/screenpipe-distiller/scripts/install-record-autostart.sh`
 
@@ -246,6 +250,7 @@ git commit -m "✨ feat: re-own screenpipe record autostart via launchd"
 ### Task 3: `config.ts` — validated env at the boundary
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/config.ts`
 - Test: `~/code/screenpipe-distiller/src/config.test.ts`
 
@@ -254,8 +259,8 @@ git commit -m "✨ feat: re-own screenpipe record autostart via launchd"
 `src/config.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { loadConfig } from "./config";
+import { describe, expect, test } from "bun:test";
 
 const base = {
   SCREENPIPE_API_KEY: "sp-key",
@@ -273,7 +278,9 @@ describe("loadConfig", () => {
   });
 
   test("throws when a required secret is missing", () => {
-    expect(() => loadConfig({ SCREENPIPE_API_KEY: "x", PETALS_API_KEY: "y" })).toThrow();
+    expect(() =>
+      loadConfig({ SCREENPIPE_API_KEY: "x", PETALS_API_KEY: "y" }),
+    ).toThrow();
   });
 });
 ```
@@ -304,7 +311,9 @@ const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>;
 
-export function loadConfig(env: Record<string, string | undefined> = process.env): Config {
+export function loadConfig(
+  env: Record<string, string | undefined> = process.env,
+): Config {
   return configSchema.parse(env);
 }
 ```
@@ -325,6 +334,7 @@ git commit -m "✨ feat: config loader with zod-validated env"
 ### Task 4: `date-utils.ts` — day keys + UTC day windows
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/date-utils.ts`
 - Test: `~/code/screenpipe-distiller/src/date-utils.test.ts`
 
@@ -333,17 +343,21 @@ git commit -m "✨ feat: config loader with zod-validated env"
 `src/date-utils.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { dayKeyFor, yesterdayKey, dayWindowUtc } from "./date-utils";
+import { describe, expect, test } from "bun:test";
 
 describe("date-utils", () => {
   test("dayKeyFor formats local day in tz", () => {
     // 2026-06-09T23:30:00Z is 2026-06-10 01:30 in Brussels (+02:00)
-    expect(dayKeyFor(new Date("2026-06-09T23:30:00Z"), "Europe/Brussels")).toBe("2026-06-10");
+    expect(dayKeyFor(new Date("2026-06-09T23:30:00Z"), "Europe/Brussels")).toBe(
+      "2026-06-10",
+    );
   });
 
   test("yesterdayKey is the local day before now", () => {
-    expect(yesterdayKey(new Date("2026-06-10T08:00:00Z"), "Europe/Brussels")).toBe("2026-06-09");
+    expect(
+      yesterdayKey(new Date("2026-06-10T08:00:00Z"), "Europe/Brussels"),
+    ).toBe("2026-06-09");
   });
 
   test("dayWindowUtc returns local-midnight bounds in UTC", () => {
@@ -422,7 +436,10 @@ function nextDayKey(dayKey: DayKey): DayKey {
   return next.toISOString().slice(0, 10);
 }
 
-export function dayWindowUtc(dayKey: DayKey, timeZone: string): { startIso: string; endIso: string } {
+export function dayWindowUtc(
+  dayKey: DayKey,
+  timeZone: string,
+): { startIso: string; endIso: string } {
   return {
     startIso: localMidnightUtcIso(dayKey, timeZone),
     endIso: localMidnightUtcIso(nextDayKey(dayKey), timeZone),
@@ -446,6 +463,7 @@ git commit -m "✨ feat: tz-aware day keys and utc day windows"
 ### Task 5: `types.ts` — shared digest/doc types
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/types.ts`
 
 - [ ] **Step 1: Write `src/types.ts`** (no test — pure type declarations)
@@ -497,6 +515,7 @@ git commit -m "✨ feat: shared digest and document types"
 ### Task 6: `screenpipe.ts` — REST client (search + pagination)
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/screenpipe.ts`
 - Test: `~/code/screenpipe-distiller/src/screenpipe.client.test.ts`
 
@@ -505,31 +524,57 @@ git commit -m "✨ feat: shared digest and document types"
 `src/screenpipe.client.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { ScreenpipeClient, ScreenpipeError } from "./screenpipe";
+import { describe, expect, test } from "bun:test";
 
 function fakeFetch(pages: unknown[][]): typeof fetch {
   let i = 0;
   return (async () => {
     const data = pages[i++] ?? [];
-    return new Response(JSON.stringify({ data, pagination: { total: 0 } }), { status: 200 });
+    return new Response(JSON.stringify({ data, pagination: { total: 0 } }), {
+      status: 200,
+    });
   }) as unknown as typeof fetch;
 }
 
 describe("ScreenpipeClient", () => {
   test("parses items and stops when a page is short", async () => {
-    const item = { type: "OCR", content: { text: "hello", app_name: "Chrome", timestamp: "2026-06-09T10:00:00Z" } };
-    const client = new ScreenpipeClient("http://localhost:3030", "tok", fakeFetch([[item]]));
-    const items = await client.searchAll({ contentType: "ocr", startIso: "a", endIso: "b" });
+    const item = {
+      type: "OCR",
+      content: {
+        text: "hello",
+        app_name: "Chrome",
+        timestamp: "2026-06-09T10:00:00Z",
+      },
+    };
+    const client = new ScreenpipeClient(
+      "http://localhost:3030",
+      "tok",
+      fakeFetch([[item]]),
+    );
+    const items = await client.searchAll({
+      contentType: "ocr",
+      startIso: "a",
+      endIso: "b",
+    });
     expect(items.length).toBe(1);
     expect(items[0]?.type).toBe("OCR");
     expect(items[0]?.content.app_name).toBe("Chrome");
   });
 
   test("throws ScreenpipeError on non-200", async () => {
-    const f = (async () => new Response("nope", { status: 401 })) as unknown as typeof fetch;
+    const f = (async () =>
+      new Response("nope", { status: 401 })) as unknown as typeof fetch;
     const client = new ScreenpipeClient("http://localhost:3030", "tok", f);
-    await expect(client.search({ contentType: "ocr", startIso: "a", endIso: "b", limit: 10, offset: 0 })).rejects.toBeInstanceOf(ScreenpipeError);
+    await expect(
+      client.search({
+        contentType: "ocr",
+        startIso: "a",
+        endIso: "b",
+        limit: 10,
+        offset: 0,
+      }),
+    ).rejects.toBeInstanceOf(ScreenpipeError);
   });
 });
 ```
@@ -546,9 +591,9 @@ Expected: FAIL — cannot find module `./screenpipe`.
  * Screenpipe local REST client + day condenser.
  * Aliases: screenpipe search, activity digest, /search client.
  */
-import { z } from "zod";
-import type { DayDigest } from "./types";
 import { dayWindowUtc } from "./date-utils";
+import type { DayDigest } from "./types";
+import { z } from "zod";
 
 export class ScreenpipeError extends Error {}
 
@@ -600,16 +645,23 @@ export class ScreenpipeClient {
     url.searchParams.set("end_time", params.endIso);
     url.searchParams.set("limit", String(params.limit));
     url.searchParams.set("offset", String(params.offset));
-    if (params.minLength != null) url.searchParams.set("min_length", String(params.minLength));
+    if (params.minLength != null)
+      url.searchParams.set("min_length", String(params.minLength));
 
-    const res = await this.fetchImpl(url, { headers: { Authorization: `Bearer ${this.apiKey}` } });
+    const res = await this.fetchImpl(url, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
     if (!res.ok) {
-      throw new ScreenpipeError(`screenpipe /search ${params.contentType} failed: ${res.status} ${await res.text()}`);
+      throw new ScreenpipeError(
+        `screenpipe /search ${params.contentType} failed: ${res.status} ${await res.text()}`,
+      );
     }
     return searchResponseSchema.parse(await res.json()).data;
   }
 
-  async searchAll(params: Omit<SearchParams, "limit" | "offset">): Promise<SearchItem[]> {
+  async searchAll(
+    params: Omit<SearchParams, "limit" | "offset">,
+  ): Promise<SearchItem[]> {
     const limit = 500;
     const out: SearchItem[] = [];
     for (let offset = 0; offset <= 20_000; offset += limit) {
@@ -638,6 +690,7 @@ git commit -m "✨ feat: screenpipe search client with pagination"
 ### Task 7: condenser — `condenseItems()` (the deterministic heart)
 
 **Files:**
+
 - Modify: `~/code/screenpipe-distiller/src/screenpipe.ts` (append)
 - Test: `~/code/screenpipe-distiller/src/screenpipe.condense.test.ts`
 
@@ -646,28 +699,67 @@ git commit -m "✨ feat: screenpipe search client with pagination"
 `src/screenpipe.condense.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { condenseItems, type SearchItem } from "./screenpipe";
+import { describe, expect, test } from "bun:test";
 
-const ocr = (app: string, text: string, ts: string, url?: string, window?: string): SearchItem => ({
+const ocr = (
+  app: string,
+  text: string,
+  ts: string,
+  url?: string,
+  window?: string,
+): SearchItem => ({
   type: "OCR",
-  content: { app_name: app, text, timestamp: ts, browser_url: url, window_name: window },
+  content: {
+    app_name: app,
+    text,
+    timestamp: ts,
+    browser_url: url,
+    window_name: window,
+  },
 });
 
 describe("condenseItems", () => {
   test("groups by app, dedupes windows/urls/text, counts frames", () => {
     const items: SearchItem[] = [
-      ocr("Chrome", "GitHub - foo/bar", "2026-06-09T09:00:00Z", "https://github.com/foo/bar", "foo/bar"),
-      ocr("Chrome", "GitHub - foo/bar", "2026-06-09T09:01:00Z", "https://github.com/foo/bar", "foo/bar"),
-      ocr("Chrome", "Pull requests", "2026-06-09T09:05:00Z", "https://github.com/foo/bar/pulls", "foo/bar"),
-      ocr("Ghostty", "$ bun test", "2026-06-09T10:00:00Z", undefined, "marcel — zsh"),
+      ocr(
+        "Chrome",
+        "GitHub - foo/bar",
+        "2026-06-09T09:00:00Z",
+        "https://github.com/foo/bar",
+        "foo/bar",
+      ),
+      ocr(
+        "Chrome",
+        "GitHub - foo/bar",
+        "2026-06-09T09:01:00Z",
+        "https://github.com/foo/bar",
+        "foo/bar",
+      ),
+      ocr(
+        "Chrome",
+        "Pull requests",
+        "2026-06-09T09:05:00Z",
+        "https://github.com/foo/bar/pulls",
+        "foo/bar",
+      ),
+      ocr(
+        "Ghostty",
+        "$ bun test",
+        "2026-06-09T10:00:00Z",
+        undefined,
+        "marcel — zsh",
+      ),
     ];
     const digest = condenseItems(items, "2026-06-09");
     expect(digest.isEmpty).toBe(false);
     expect(digest.totalFrames).toBe(4);
     const chrome = digest.apps.find((a) => a.app === "Chrome");
     expect(chrome?.frames).toBe(3);
-    expect(chrome?.urls).toEqual(["https://github.com/foo/bar", "https://github.com/foo/bar/pulls"]);
+    expect(chrome?.urls).toEqual([
+      "https://github.com/foo/bar",
+      "https://github.com/foo/bar/pulls",
+    ]);
     expect(chrome?.windows).toEqual(["foo/bar"]);
     expect(chrome?.sampleText).toContain("GitHub - foo/bar");
     expect(chrome?.firstSeen).toBe("2026-06-09T09:00:00Z");
@@ -678,12 +770,30 @@ describe("condenseItems", () => {
 
   test("maps audio to snippets and ignores empty transcriptions", () => {
     const items: SearchItem[] = [
-      { type: "Audio", content: { transcription: "let's ship it", speaker_label: "Marcel", timestamp: "2026-06-09T11:00:00Z" } },
-      { type: "Audio", content: { transcription: "", speaker_label: "Marcel", timestamp: "2026-06-09T11:01:00Z" } },
+      {
+        type: "Audio",
+        content: {
+          transcription: "let's ship it",
+          speaker_label: "Marcel",
+          timestamp: "2026-06-09T11:00:00Z",
+        },
+      },
+      {
+        type: "Audio",
+        content: {
+          transcription: "",
+          speaker_label: "Marcel",
+          timestamp: "2026-06-09T11:01:00Z",
+        },
+      },
     ];
     const digest = condenseItems(items, "2026-06-09");
     expect(digest.audio.length).toBe(1);
-    expect(digest.audio[0]).toEqual({ speaker: "Marcel", text: "let's ship it", timestamp: "2026-06-09T11:00:00Z" });
+    expect(digest.audio[0]).toEqual({
+      speaker: "Marcel",
+      text: "let's ship it",
+      timestamp: "2026-06-09T11:00:00Z",
+    });
   });
 
   test("empty input yields isEmpty digest", () => {
@@ -727,7 +837,12 @@ export function condenseItems(items: SearchItem[], dayKey: string): DayDigest {
     const c = item.content;
     if (item.type === "Audio") {
       const text = (c.transcription ?? c.text ?? "").trim();
-      if (text) audio.push({ speaker: c.speaker_label ?? null, text, timestamp: c.timestamp });
+      if (text)
+        audio.push({
+          speaker: c.speaker_label ?? null,
+          text,
+          timestamp: c.timestamp,
+        });
       continue;
     }
     const app = (c.app_name ?? "Unknown").trim() || "Unknown";
@@ -740,11 +855,16 @@ export function condenseItems(items: SearchItem[], dayKey: string): DayDigest {
     const text = c.text ?? c.text_content;
     if (text && text.trim()) {
       const snippet = truncate(text, MAX_TEXT_LEN);
-      if (snippet && acc.sampleText.length < MAX_SAMPLE_TEXT_PER_APP && !acc.sampleText.includes(snippet)) {
+      if (
+        snippet &&
+        acc.sampleText.length < MAX_SAMPLE_TEXT_PER_APP &&
+        !acc.sampleText.includes(snippet)
+      ) {
         acc.sampleText.push(snippet);
       }
     }
-    if (!acc.firstSeen || c.timestamp < acc.firstSeen) acc.firstSeen = c.timestamp;
+    if (!acc.firstSeen || c.timestamp < acc.firstSeen)
+      acc.firstSeen = c.timestamp;
     if (!acc.lastSeen || c.timestamp > acc.lastSeen) acc.lastSeen = c.timestamp;
   }
 
@@ -761,7 +881,13 @@ export function condenseItems(items: SearchItem[], dayKey: string): DayDigest {
     .sort((x, y) => y.frames - x.frames)
     .slice(0, MAX_APPS);
 
-  return { dayKey, apps, audio, totalFrames, isEmpty: apps.length === 0 && audio.length === 0 };
+  return {
+    dayKey,
+    apps,
+    audio,
+    totalFrames,
+    isEmpty: apps.length === 0 && audio.length === 0,
+  };
 }
 
 interface AppActivityAcc {
@@ -774,7 +900,14 @@ interface AppActivityAcc {
 }
 
 function newAcc(): AppActivityAcc {
-  return { windows: [], urls: [], sampleText: [], firstSeen: null, lastSeen: null, frames: 0 };
+  return {
+    windows: [],
+    urls: [],
+    sampleText: [],
+    firstSeen: null,
+    lastSeen: null,
+    frames: 0,
+  };
 }
 ```
 
@@ -800,6 +933,7 @@ git commit -m "✨ feat: deterministic day condenser"
 ### Task 8: `fetchDayActivity()` — wire client + condenser
 
 **Files:**
+
 - Modify: `~/code/screenpipe-distiller/src/screenpipe.ts` (append)
 - Test: `~/code/screenpipe-distiller/src/screenpipe.fetch.test.ts`
 
@@ -808,8 +942,8 @@ git commit -m "✨ feat: deterministic day condenser"
 `src/screenpipe.fetch.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { fetchDayActivity, ScreenpipeClient } from "./screenpipe";
+import { describe, expect, test } from "bun:test";
 
 describe("fetchDayActivity", () => {
   test("queries the three content types over the day window and condenses", async () => {
@@ -819,13 +953,28 @@ describe("fetchDayActivity", () => {
       seen.push(ct);
       const data =
         ct === "ocr"
-          ? [{ type: "OCR", content: { app_name: "Chrome", text: "hi", timestamp: "2026-06-09T10:00:00Z" } }]
+          ? [
+              {
+                type: "OCR",
+                content: {
+                  app_name: "Chrome",
+                  text: "hi",
+                  timestamp: "2026-06-09T10:00:00Z",
+                },
+              },
+            ]
           : [];
-      return new Response(JSON.stringify({ data, pagination: {} }), { status: 200 });
+      return new Response(JSON.stringify({ data, pagination: {} }), {
+        status: 200,
+      });
     }) as unknown as typeof fetch;
 
     const client = new ScreenpipeClient("http://localhost:3030", "tok", f);
-    const digest = await fetchDayActivity(client, "2026-06-09", "Europe/Brussels");
+    const digest = await fetchDayActivity(
+      client,
+      "2026-06-09",
+      "Europe/Brussels",
+    );
     expect(seen.sort()).toEqual(["audio", "input", "ocr"]);
     expect(digest.apps[0]?.app).toBe("Chrome");
   });
@@ -875,6 +1024,7 @@ git commit -m "✨ feat: fetchDayActivity orchestration"
 ### Task 9: `curation-prompt.ts` — the contract + user-prompt renderer
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/curation-prompt.ts`
 - Test: `~/code/screenpipe-distiller/src/curation-prompt.test.ts`
 
@@ -883,14 +1033,30 @@ git commit -m "✨ feat: fetchDayActivity orchestration"
 `src/curation-prompt.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { CURATION_SYSTEM_PROMPT, buildUserPrompt } from "./curation-prompt";
 import type { DayDigest } from "./types";
+import { describe, expect, test } from "bun:test";
 
 const digest: DayDigest = {
   dayKey: "2026-06-09",
-  apps: [{ app: "Ghostty", windows: ["zsh"], urls: [], sampleText: ["$ bun test"], firstSeen: "2026-06-09T10:00:00Z", lastSeen: "2026-06-09T11:00:00Z", frames: 12 }],
-  audio: [{ speaker: "Marcel", text: "let's ship it", timestamp: "2026-06-09T11:00:00Z" }],
+  apps: [
+    {
+      app: "Ghostty",
+      windows: ["zsh"],
+      urls: [],
+      sampleText: ["$ bun test"],
+      firstSeen: "2026-06-09T10:00:00Z",
+      lastSeen: "2026-06-09T11:00:00Z",
+      frames: 12,
+    },
+  ],
+  audio: [
+    {
+      speaker: "Marcel",
+      text: "let's ship it",
+      timestamp: "2026-06-09T11:00:00Z",
+    },
+  ],
   totalFrames: 12,
   isEmpty: false,
 };
@@ -948,16 +1114,25 @@ Output ONLY the Markdown document, using exactly these section headers (omit a s
 ## Notes`;
 
 export function buildUserPrompt(digest: DayDigest): string {
-  const lines: string[] = [`Date: ${digest.dayKey}`, `Total screen frames: ${digest.totalFrames}`, "", "## Apps"];
+  const lines: string[] = [
+    `Date: ${digest.dayKey}`,
+    `Total screen frames: ${digest.totalFrames}`,
+    "",
+    "## Apps",
+  ];
   for (const a of digest.apps) {
-    lines.push(`### ${a.app} (${a.frames} frames, ${a.firstSeen.slice(11, 16)}–${a.lastSeen.slice(11, 16)} UTC)`);
-    if (a.windows.length) lines.push(`- windows: ${a.windows.slice(0, 6).join(" | ")}`);
+    lines.push(
+      `### ${a.app} (${a.frames} frames, ${a.firstSeen.slice(11, 16)}–${a.lastSeen.slice(11, 16)} UTC)`,
+    );
+    if (a.windows.length)
+      lines.push(`- windows: ${a.windows.slice(0, 6).join(" | ")}`);
     if (a.urls.length) lines.push(`- urls: ${a.urls.slice(0, 10).join(" , ")}`);
     for (const t of a.sampleText) lines.push(`- text: ${t}`);
   }
   if (digest.audio.length) {
     lines.push("", "## Audio");
-    for (const s of digest.audio) lines.push(`- ${s.speaker ?? "?"}: ${s.text}`);
+    for (const s of digest.audio)
+      lines.push(`- ${s.speaker ?? "?"}: ${s.text}`);
   }
   return lines.join("\n");
 }
@@ -979,6 +1154,7 @@ git commit -m "✨ feat: curation contract prompt + digest renderer"
 ### Task 10: `curate.ts` — OpenRouter call (LLM mocked in tests)
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/curate.ts`
 - Test: `~/code/screenpipe-distiller/src/curate.test.ts`
 
@@ -987,16 +1163,29 @@ git commit -m "✨ feat: curation contract prompt + digest renderer"
 `src/curate.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
-import { curateDigest, type ChatClient } from "./curate";
 import type { Config } from "./config";
+import { curateDigest, type ChatClient } from "./curate";
 import type { DayDigest } from "./types";
+import { describe, expect, test } from "bun:test";
 
-const config = { CURATION_MODEL: "test/model", OPENROUTER_API_KEY: "k" } as Config;
+const config = {
+  CURATION_MODEL: "test/model",
+  OPENROUTER_API_KEY: "k",
+} as Config;
 
 const nonEmpty: DayDigest = {
   dayKey: "2026-06-09",
-  apps: [{ app: "Ghostty", windows: [], urls: [], sampleText: ["x"], firstSeen: "2026-06-09T10:00:00Z", lastSeen: "2026-06-09T11:00:00Z", frames: 3 }],
+  apps: [
+    {
+      app: "Ghostty",
+      windows: [],
+      urls: [],
+      sampleText: ["x"],
+      firstSeen: "2026-06-09T10:00:00Z",
+      lastSeen: "2026-06-09T11:00:00Z",
+      frames: 3,
+    },
+  ],
   audio: [],
   totalFrames: 3,
   isEmpty: false,
@@ -1005,8 +1194,19 @@ const nonEmpty: DayDigest = {
 describe("curateDigest", () => {
   test("short-circuits an empty day without calling the LLM", async () => {
     let called = false;
-    const client: ChatClient = { create: async () => { called = true; return { content: "x" }; } };
-    const empty: DayDigest = { dayKey: "2026-06-09", apps: [], audio: [], totalFrames: 0, isEmpty: true };
+    const client: ChatClient = {
+      create: async () => {
+        called = true;
+        return { content: "x" };
+      },
+    };
+    const empty: DayDigest = {
+      dayKey: "2026-06-09",
+      apps: [],
+      audio: [],
+      totalFrames: 0,
+      isEmpty: true,
+    };
     const doc = await curateDigest(empty, config, client);
     expect(called).toBe(false);
     expect(doc.isEmptyDay).toBe(true);
@@ -1017,8 +1217,15 @@ describe("curateDigest", () => {
     let captured: { model: string; system: string; user: string } | null = null;
     const client: ChatClient = {
       create: async ({ model, messages }) => {
-        captured = { model, system: messages[0]!.content, user: messages[1]!.content };
-        return { content: "# Computer activity — 2026-06-09\n\n## What I worked on\n- stuff" };
+        captured = {
+          model,
+          system: messages[0]!.content,
+          user: messages[1]!.content,
+        };
+        return {
+          content:
+            "# Computer activity — 2026-06-09\n\n## What I worked on\n- stuff",
+        };
       },
     };
     const doc = await curateDigest(nonEmpty, config, client);
@@ -1043,10 +1250,10 @@ Expected: FAIL — cannot find module `./curate`.
  * Curates a day digest into a Markdown activity document via OpenRouter.
  * The OpenAI client is injectable so tests mock only the external AI.
  */
-import OpenAI from "openai";
 import type { Config } from "./config";
-import type { CuratedDoc, DayDigest } from "./types";
 import { CURATION_SYSTEM_PROMPT, buildUserPrompt } from "./curation-prompt";
+import type { CuratedDoc, DayDigest } from "./types";
+import OpenAI from "openai";
 
 export class CurationError extends Error {}
 
@@ -1057,14 +1264,24 @@ export interface ChatMessage {
 
 /** Minimal seam over the OpenAI chat API so tests can inject a fake. */
 export interface ChatClient {
-  create(args: { model: string; messages: ChatMessage[] }): Promise<{ content: string | null }>;
+  create(args: {
+    model: string;
+    messages: ChatMessage[];
+  }): Promise<{ content: string | null }>;
 }
 
 function openRouterClient(config: Config): ChatClient {
-  const openai = new OpenAI({ baseURL: "https://openrouter.ai/api/v1", apiKey: config.OPENROUTER_API_KEY });
+  const openai = new OpenAI({
+    baseURL: "https://openrouter.ai/api/v1",
+    apiKey: config.OPENROUTER_API_KEY,
+  });
   return {
     create: async ({ model, messages }) => {
-      const completion = await openai.chat.completions.create({ model, messages, temperature: 0.2 });
+      const completion = await openai.chat.completions.create({
+        model,
+        messages,
+        temperature: 0.2,
+      });
       return { content: completion.choices[0]?.message?.content ?? null };
     },
   };
@@ -1074,8 +1291,13 @@ function emptyDayMarkdown(dayKey: string): string {
   return `# Computer activity — ${dayKey}\n\n## Notes\nMinimal or no recorded computer activity for this day.`;
 }
 
-export async function curateDigest(digest: DayDigest, config: Config, client?: ChatClient): Promise<CuratedDoc> {
-  if (digest.isEmpty) return { markdown: emptyDayMarkdown(digest.dayKey), isEmptyDay: true };
+export async function curateDigest(
+  digest: DayDigest,
+  config: Config,
+  client?: ChatClient,
+): Promise<CuratedDoc> {
+  if (digest.isEmpty)
+    return { markdown: emptyDayMarkdown(digest.dayKey), isEmptyDay: true };
   const chat = client ?? openRouterClient(config);
   const { content } = await chat.create({
     model: config.CURATION_MODEL,
@@ -1110,6 +1332,7 @@ git commit -m "✨ feat: curate day digest via openrouter (injectable client)"
 ### Task 11: `upload.ts` — Petals document ingest with retry
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/upload.ts`
 - Test: `~/code/screenpipe-distiller/src/upload.test.ts`
 
@@ -1118,12 +1341,20 @@ git commit -m "✨ feat: curate day digest via openrouter (injectable client)"
 `src/upload.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
-import { buildDocumentBody, uploadDocument, UploadError } from "./upload";
 import type { Config } from "./config";
+import { buildDocumentBody, uploadDocument, UploadError } from "./upload";
+import { describe, expect, test } from "bun:test";
 
-const config = { PETALS_BASE_URL: "https://petals.chat", PETALS_API_KEY: "petals-k" } as Config;
-const doc = { id: "screenpipe-activity-2026-06-09", content: "# x", title: "Computer activity — 2026-06-09", timestampIso: "2026-06-09T12:00:00Z" };
+const config = {
+  PETALS_BASE_URL: "https://petals.chat",
+  PETALS_API_KEY: "petals-k",
+} as Config;
+const doc = {
+  id: "screenpipe-activity-2026-06-09",
+  content: "# x",
+  title: "Computer activity — 2026-06-09",
+  timestampIso: "2026-06-09T12:00:00Z",
+};
 
 describe("upload", () => {
   test("buildDocumentBody produces a personal-scope markdown document", () => {
@@ -1138,17 +1369,27 @@ describe("upload", () => {
     let headerSeen = "";
     const f = (async (_url: string, init: RequestInit) => {
       headerSeen = new Headers(init.headers).get("x-api-key") ?? "";
-      return new Response(JSON.stringify({ message: "ok", jobId: "job_1" }), { status: 200 });
+      return new Response(JSON.stringify({ message: "ok", jobId: "job_1" }), {
+        status: 200,
+      });
     }) as unknown as typeof fetch;
-    const res = await uploadDocument(doc, config, { fetchImpl: f, sleep: async () => {} });
+    const res = await uploadDocument(doc, config, {
+      fetchImpl: f,
+      sleep: async () => {},
+    });
     expect(res.jobId).toBe("job_1");
     expect(headerSeen).toBe("petals-k");
   });
 
   test("throws UploadError on 4xx without retrying", async () => {
     let calls = 0;
-    const f = (async () => { calls++; return new Response("bad", { status: 400 }); }) as unknown as typeof fetch;
-    await expect(uploadDocument(doc, config, { fetchImpl: f, sleep: async () => {} })).rejects.toBeInstanceOf(UploadError);
+    const f = (async () => {
+      calls++;
+      return new Response("bad", { status: 400 });
+    }) as unknown as typeof fetch;
+    await expect(
+      uploadDocument(doc, config, { fetchImpl: f, sleep: async () => {} }),
+    ).rejects.toBeInstanceOf(UploadError);
     expect(calls).toBe(1);
   });
 
@@ -1156,9 +1397,16 @@ describe("upload", () => {
     let calls = 0;
     const f = (async () => {
       calls++;
-      return calls < 2 ? new Response("err", { status: 503 }) : new Response(JSON.stringify({ message: "ok", jobId: "job_2" }), { status: 200 });
+      return calls < 2
+        ? new Response("err", { status: 503 })
+        : new Response(JSON.stringify({ message: "ok", jobId: "job_2" }), {
+            status: 200,
+          });
     }) as unknown as typeof fetch;
-    const res = await uploadDocument(doc, config, { fetchImpl: f, sleep: async () => {} });
+    const res = await uploadDocument(doc, config, {
+      fetchImpl: f,
+      sleep: async () => {},
+    });
     expect(res.jobId).toBe("job_2");
     expect(calls).toBe(2);
   });
@@ -1177,8 +1425,8 @@ Expected: FAIL — cannot find module `./upload`.
  * Uploads a curated activity document to Assistant Memory via the hosted
  * Petals proxy. Idempotent on document.id; retries network/5xx with backoff.
  */
-import { z } from "zod";
 import type { Config } from "./config";
+import { z } from "zod";
 
 export class UploadError extends Error {}
 
@@ -1189,7 +1437,9 @@ export interface DocPayload {
   timestampIso: string;
 }
 
-const uploadResponseSchema = z.object({ message: z.string(), jobId: z.string() }).passthrough();
+const uploadResponseSchema = z
+  .object({ message: z.string(), jobId: z.string() })
+  .passthrough();
 
 export function buildDocumentBody(p: DocPayload) {
   return {
@@ -1209,13 +1459,20 @@ interface UploadDeps {
   sleep?: (ms: number) => Promise<void>;
 }
 
-export async function uploadDocument(p: DocPayload, config: Config, deps: UploadDeps = {}): Promise<{ jobId: string }> {
+export async function uploadDocument(
+  p: DocPayload,
+  config: Config,
+  deps: UploadDeps = {},
+): Promise<{ jobId: string }> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
   const url = `${config.PETALS_BASE_URL}/api/memory/ingest/document`;
   const init: RequestInit = {
     method: "POST",
-    headers: { "Content-Type": "application/json", "x-api-key": config.PETALS_API_KEY },
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": config.PETALS_API_KEY,
+    },
     body: JSON.stringify(buildDocumentBody(p)),
   };
 
@@ -1229,7 +1486,8 @@ export async function uploadDocument(p: DocPayload, config: Config, deps: Upload
       lastErr = e; // network error → retry
     }
     if (res) {
-      if (res.ok) return { jobId: uploadResponseSchema.parse(await res.json()).jobId };
+      if (res.ok)
+        return { jobId: uploadResponseSchema.parse(await res.json()).jobId };
       const text = await res.text();
       if (res.status >= 400 && res.status < 500) {
         throw new UploadError(`Petals rejected upload ${res.status}: ${text}`);
@@ -1238,7 +1496,9 @@ export async function uploadDocument(p: DocPayload, config: Config, deps: Upload
     }
     if (attempt < maxAttempts) await sleep(250 * 2 ** attempt);
   }
-  throw lastErr instanceof Error ? lastErr : new UploadError("upload failed after retries");
+  throw lastErr instanceof Error
+    ? lastErr
+    : new UploadError("upload failed after retries");
 }
 ```
 
@@ -1262,6 +1522,7 @@ git commit -m "✨ feat: petals document upload with retry/backoff"
 ### Task 12: `distill.ts` — `runDistill()` wiring
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/distill.ts`
 - Test: `~/code/screenpipe-distiller/src/distill.test.ts`
 
@@ -1270,21 +1531,40 @@ git commit -m "✨ feat: petals document upload with retry/backoff"
 `src/distill.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
-import { runDistill, type DistillDeps } from "./distill";
 import type { Config } from "./config";
+import { runDistill, type DistillDeps } from "./distill";
 import type { DayDigest } from "./types";
+import { describe, expect, test } from "bun:test";
 
 const config = { USER_TIMEZONE: "Europe/Brussels" } as Config;
 
 describe("runDistill", () => {
   test("fetch → curate → upload, returning the jobId", async () => {
-    const digest: DayDigest = { dayKey: "2026-06-09", apps: [{ app: "Ghostty", windows: [], urls: [], sampleText: [], firstSeen: "", lastSeen: "", frames: 1 }], audio: [], totalFrames: 1, isEmpty: false };
+    const digest: DayDigest = {
+      dayKey: "2026-06-09",
+      apps: [
+        {
+          app: "Ghostty",
+          windows: [],
+          urls: [],
+          sampleText: [],
+          firstSeen: "",
+          lastSeen: "",
+          frames: 1,
+        },
+      ],
+      audio: [],
+      totalFrames: 1,
+      isEmpty: false,
+    };
     let uploadedId = "";
     const deps: DistillDeps = {
       fetchDay: async () => digest,
       curate: async () => ({ markdown: "# doc", isEmptyDay: false }),
-      upload: async (p) => { uploadedId = p.id; return { jobId: "job_9" }; },
+      upload: async (p) => {
+        uploadedId = p.id;
+        return { jobId: "job_9" };
+      },
     };
     const res = await runDistill("2026-06-09", config, deps);
     expect(res.jobId).toBe("job_9");
@@ -1306,9 +1586,9 @@ Expected: FAIL — cannot find module `./distill`.
  * Seams are injectable for testing; defaults wire the real implementations.
  */
 import type { Config } from "./config";
-import type { CuratedDoc, DayDigest } from "./types";
-import { ScreenpipeClient, fetchDayActivity } from "./screenpipe";
 import { curateDigest } from "./curate";
+import { ScreenpipeClient, fetchDayActivity } from "./screenpipe";
+import type { CuratedDoc, DayDigest } from "./types";
 import { uploadDocument, type DocPayload } from "./upload";
 
 export interface DistillDeps {
@@ -1318,9 +1598,13 @@ export interface DistillDeps {
 }
 
 function defaultDeps(config: Config): DistillDeps {
-  const client = new ScreenpipeClient(config.SCREENPIPE_API_URL, config.SCREENPIPE_API_KEY);
+  const client = new ScreenpipeClient(
+    config.SCREENPIPE_API_URL,
+    config.SCREENPIPE_API_KEY,
+  );
   return {
-    fetchDay: (dayKey) => fetchDayActivity(client, dayKey, config.USER_TIMEZONE),
+    fetchDay: (dayKey) =>
+      fetchDayActivity(client, dayKey, config.USER_TIMEZONE),
     curate: (digest) => curateDigest(digest, config),
     upload: (p) => uploadDocument(p, config),
   };
@@ -1359,6 +1643,7 @@ git commit -m "✨ feat: runDistill orchestrator"
 ### Task 13: `main.ts` — CLI entry
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/main.ts`
 
 - [ ] **Step 1: Write `src/main.ts`** (thin entry; logic is tested in distill.test.ts)
@@ -1366,14 +1651,15 @@ git commit -m "✨ feat: runDistill orchestrator"
 ```ts
 /** CLI: `bun run distill [--date YYYY-MM-DD]` (default: yesterday). */
 import { loadConfig } from "./config";
-import { runDistill } from "./distill";
 import { yesterdayKey } from "./date-utils";
+import { runDistill } from "./distill";
 
 function parseDateArg(argv: string[], timeZone: string): string {
   const idx = argv.indexOf("--date");
   if (idx !== -1) {
     const value = argv[idx + 1];
-    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error("--date must be YYYY-MM-DD");
+    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value))
+      throw new Error("--date must be YYYY-MM-DD");
     return value;
   }
   return yesterdayKey(new Date(), timeZone);
@@ -1384,7 +1670,9 @@ async function main(): Promise<void> {
   const dayKey = parseDateArg(process.argv.slice(2), config.USER_TIMEZONE);
   console.log(`[distill] day=${dayKey} tz=${config.USER_TIMEZONE}`);
   const { jobId, isEmptyDay } = await runDistill(dayKey, config);
-  console.log(`[distill] uploaded day=${dayKey} jobId=${jobId} emptyDay=${isEmptyDay}`);
+  console.log(
+    `[distill] uploaded day=${dayKey} jobId=${jobId} emptyDay=${isEmptyDay}`,
+  );
 }
 
 main().catch((err) => {
@@ -1418,6 +1706,7 @@ git commit -m "✨ feat: distill CLI entry"
 ### Task 14: `health.ts` — recording-health nudge
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/src/health.ts`
 - Test: `~/code/screenpipe-distiller/src/health.test.ts`
 
@@ -1426,8 +1715,8 @@ git commit -m "✨ feat: distill CLI entry"
 `src/health.test.ts`:
 
 ```ts
-import { describe, expect, test } from "bun:test";
 import { evaluateHealth } from "./health";
+import { describe, expect, test } from "bun:test";
 
 describe("evaluateHealth", () => {
   test("flags audio stall and frame staleness", () => {
@@ -1444,7 +1733,11 @@ describe("evaluateHealth", () => {
 
   test("healthy when recording fresh and audio fine", () => {
     const now = new Date("2026-06-10T12:00:00Z");
-    const r = evaluateHealth({ status: "healthy", audio_db_write_stalled: false }, "2026-06-10T11:58:00Z", now);
+    const r = evaluateHealth(
+      { status: "healthy", audio_db_write_stalled: false },
+      "2026-06-10T11:58:00Z",
+      now,
+    );
     expect(r.ok).toBe(true);
     expect(r.problems).toEqual([]);
   });
@@ -1463,14 +1756,17 @@ Expected: FAIL — cannot find module `./health`.
  * Checks Screenpipe recording health and notifies (macOS) when it is down,
  * stale, or audio transcription has stalled. Read-only; no memory writes.
  */
-import { z } from "zod";
 import { loadConfig, type Config } from "./config";
 import { ScreenpipeClient } from "./screenpipe";
+import { z } from "zod";
 
 const STALE_FRAMES_MINUTES = 30;
 
 const healthSchema = z
-  .object({ status: z.string().nullish(), audio_db_write_stalled: z.boolean().nullish() })
+  .object({
+    status: z.string().nullish(),
+    audio_db_write_stalled: z.boolean().nullish(),
+  })
   .passthrough();
 
 export interface HealthResult {
@@ -1484,20 +1780,33 @@ export function evaluateHealth(
   now: Date,
 ): HealthResult {
   const problems: string[] = [];
-  if (health.status && health.status !== "healthy") problems.push(`recording status: ${health.status}`);
-  if (health.audio_db_write_stalled) problems.push("audio transcription stalled");
+  if (health.status && health.status !== "healthy")
+    problems.push(`recording status: ${health.status}`);
+  if (health.audio_db_write_stalled)
+    problems.push("audio transcription stalled");
   if (!newestFrameIso) {
     problems.push("no recent frames found");
   } else {
-    const ageMin = (now.getTime() - new Date(newestFrameIso).getTime()) / 60_000;
-    if (ageMin > STALE_FRAMES_MINUTES) problems.push(`screen capture stale (${Math.round(ageMin)}m old)`);
+    const ageMin =
+      (now.getTime() - new Date(newestFrameIso).getTime()) / 60_000;
+    if (ageMin > STALE_FRAMES_MINUTES)
+      problems.push(`screen capture stale (${Math.round(ageMin)}m old)`);
   }
   return { ok: problems.length === 0, problems };
 }
 
-async function newestFrameIso(client: ScreenpipeClient, now: Date): Promise<string | null> {
+async function newestFrameIso(
+  client: ScreenpipeClient,
+  now: Date,
+): Promise<string | null> {
   const since = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString();
-  const items = await client.search({ contentType: "ocr", startIso: since, endIso: now.toISOString(), limit: 1, offset: 0 });
+  const items = await client.search({
+    contentType: "ocr",
+    startIso: since,
+    endIso: now.toISOString(),
+    limit: 1,
+    offset: 0,
+  });
   return items[0]?.content.timestamp ?? null;
 }
 
@@ -1511,7 +1820,10 @@ async function main(): Promise<void> {
   const now = new Date();
   const res = await fetch(`${config.SCREENPIPE_API_URL}/health`);
   const health = healthSchema.parse(await res.json());
-  const client = new ScreenpipeClient(config.SCREENPIPE_API_URL, config.SCREENPIPE_API_KEY);
+  const client = new ScreenpipeClient(
+    config.SCREENPIPE_API_URL,
+    config.SCREENPIPE_API_KEY,
+  );
   const newest = await newestFrameIso(client, now).catch(() => null);
   const result = evaluateHealth(health, newest, now);
   if (!result.ok) {
@@ -1550,6 +1862,7 @@ git commit -m "✨ feat: screenpipe recording health-check + macos notify"
 ### Task 15: launchd plists, install script, and a real distill run
 
 **Files:**
+
 - Create: `~/code/screenpipe-distiller/launchd/com.marcel.screenpipe-distiller.daily.plist`
 - Create: `~/code/screenpipe-distiller/launchd/com.marcel.screenpipe-distiller.health.plist`
 - Create: `~/code/screenpipe-distiller/scripts/install-schedules.sh`
@@ -1591,7 +1904,7 @@ git commit -m "✨ feat: screenpipe recording health-check + macos notify"
 </plist>
 ```
 
-Note: Bun auto-loads `.env` from `WorkingDirectory`, so secrets stay in the gitignored `.env`, not the plist. Targeting *yesterday* + idempotent `document.id` makes the exact fire time irrelevant; launchd also runs a missed 08:00 job once on the next wake/boot.
+Note: Bun auto-loads `.env` from `WorkingDirectory`, so secrets stay in the gitignored `.env`, not the plist. Targeting _yesterday_ + idempotent `document.id` makes the exact fire time irrelevant; launchd also runs a missed 08:00 job once on the next wake/boot.
 
 - [ ] **Step 2: Write the health-check plist** (twice daily: 12:00 and 20:00)
 
@@ -1661,6 +1974,7 @@ cp -n .env.example .env
 # Then run a recent, data-rich day (2026-06-05 had ~2700 frames):
 bun run distill --date 2026-06-05
 ```
+
 Expected: logs `[distill] uploaded day=2026-06-05 jobId=… emptyDay=false`. If the day is empty, try `2026-06-05`/`2026-06-06`.
 
 - [ ] **Step 5: Verify the document landed in memory and reads cleanly**

--- a/docs/superpowers/plans/2026-06-12-temporal-rollup.md
+++ b/docs/superpowers/plans/2026-06-12-temporal-rollup.md
@@ -1,0 +1,2975 @@
+# Temporal Rollup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** SDK-triggered catch-up sweep that builds a recursive summary hierarchy over Temporal nodes: day (`2026-06-08`) → week (`2026-W24`) → month (`2026-06`) → year (`2026`), with watermark+fingerprint staleness tracking, a per-sweep LLM-call budget, and a `startDate` history floor.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-temporal-rollup-design.md` (read it first).
+
+**Architecture:** Pure period math (`src/lib/rollup/period.ts`) feeds a deterministic input collector (`src/lib/rollup/collect.ts`); `summarize-period.ts` makes exactly one structured LLM call per stale period and writes the summary onto the Temporal node's `nodeMetadata.description`; the sweep job (`src/lib/jobs/rollup.ts`) discovers stale periods via a per-user claim-timestamp watermark + `pendingPeriods` set stored in a new `rollup_state` table. Triggered by `POST /rollup` → BullMQ, never scheduled internally.
+
+**Tech Stack:** Nitro/h3, Drizzle + Postgres, BullMQ, OpenAI SDK (`parseStructuredCompletion` + `zodResponseFormat`), date-fns, Zod v4, vitest (test Postgres on port **5431**; CI does NOT run vitest — run tests locally).
+
+**Conventions that apply to every task:**
+- Package manager: `pnpm`. Run `pnpm run test -- <file> --run` (vitest), `pnpm run build:check` (tsc + structured-output check), `pnpm run lint`, `pnpm run format`.
+- Commit messages: `<emoji> <type>(<scope>): <subject>` (✨ feat, ✅ test, ♻️ refactor, 📚 docs). Stage explicit paths only — never `git add -A` or `.`.
+- Imports use the `~` alias for `src` (e.g. `~/db/schema`). Within `src/lib/**`, relative imports of siblings are the norm (see existing files).
+- No `any`, no casts; `satisfies`/explicit types. External input through Zod.
+- DB tests follow the ephemeral-database pattern from `src/lib/node.test.ts`: create a uniquely-named database in `beforeAll`, raw-SQL `CREATE TABLE` only the tables the test needs, drop in `afterAll`, skip the suite when no server is reachable.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/lib/rollup/period.ts` (+ `.test.ts`) | Pure period-key math: levels, parents/children, completeness, ordering |
+| `src/lib/rollup/collect.ts` (+ `.test.ts`) | Deterministic input assembly + compaction (pure builders), sha256 fingerprint, defensive `additionalData.rollup` reader, thin DB fetchers |
+| `src/lib/rollup/source.ts` (+ `.test.ts`) | Per-user synthetic `"rollup"` source (for `PART_OF` claims' NOT NULL `sourceId`) |
+| `src/lib/rollup/summarize-period.ts` (+ `.test.ts`) | One period: collect → ensure node → ensure `PART_OF` claims → fingerprint check → one LLM call → write description + re-embed |
+| `src/lib/jobs/rollup.ts` (+ `.test.ts`) | The sweep: discovery, work-set expansion, startDate/completeness filtering, budgeted bottom-up processing, state commit |
+| `src/lib/temporal.ts` | Generalize: add `ensurePeriodNode`, make `ensureDayNode` delegate |
+| `src/lib/schemas/rollup.ts` | Request/response Zod schemas |
+| `src/routes/rollup.post.ts` (+ `src/rollup-route.test.ts`) | HTTP trigger w/ jobId dedup |
+| `src/db/schema.ts` + `drizzle/` migration | `rollup_state` table |
+| `src/types/graph.ts` | Add `"rollup"` to `SourceType` |
+| `src/utils/models.ts`, `src/utils/env.ts` | `temporal_summary` ModelTask + `MODEL_ID_TEMPORAL_SUMMARY` |
+| `src/lib/queues.ts` | `ROLLUP_JOB_OPTIONS` + `"rollup"` worker branch |
+| `src/sdk/memory-client.ts`, `src/sdk/index.ts` | `rollup()` method + schema export |
+
+---
+
+### Task 1: Period math module (pure)
+
+**Files:**
+- Create: `src/lib/rollup/period.ts`
+- Test: `src/lib/rollup/period.test.ts`
+
+Background you need: day labels are `yyyy-MM-dd` (see `ensureDayNode` in `src/lib/temporal.ts`). Weeks are ISO weeks (Monday start) keyed by ISO week-numbering year: `2026-W24`. 2026-01-01 is a Thursday, so 2026 has 53 ISO weeks and ISO W01 of 2026 runs 2025-12-29 → 2026-01-04. ISO weeks do NOT nest in months — a week can overlap two months, and the month layer consumes every overlapping week.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/rollup/period.test.ts`:
+
+```typescript
+import {
+  ancestorKeysForDay,
+  isPeriodComplete,
+  monthKeyForDay,
+  monthKeysForWeek,
+  monthKeysOfYear,
+  periodEndDayKey,
+  periodLevelOf,
+  sortForProcessing,
+  weekDayKeys,
+  weekKeyForDay,
+  weeksOverlappingMonth,
+  yearKeyForMonth,
+} from "./period";
+import { describe, expect, it } from "vitest";
+
+describe("periodLevelOf", () => {
+  it("classifies keys by shape", () => {
+    expect(periodLevelOf("2026-06-08")).toBe("day");
+    expect(periodLevelOf("2026-W24")).toBe("week");
+    expect(periodLevelOf("2026-06")).toBe("month");
+    expect(periodLevelOf("2026")).toBe("year");
+  });
+
+  it("throws on malformed keys", () => {
+    expect(() => periodLevelOf("2026-6-8")).toThrow();
+    expect(() => periodLevelOf("W24")).toThrow();
+    expect(() => periodLevelOf("")).toThrow();
+  });
+});
+
+describe("weekKeyForDay", () => {
+  it("maps a mid-year Monday to its ISO week", () => {
+    // 2026-06-08 is a Monday in ISO week 24 of 2026.
+    expect(weekKeyForDay("2026-06-08")).toBe("2026-W24");
+    expect(weekKeyForDay("2026-06-14")).toBe("2026-W24"); // its Sunday
+  });
+
+  it("assigns early-January days to the correct ISO week-numbering year", () => {
+    // 2026 W01 spans 2025-12-29 .. 2026-01-04.
+    expect(weekKeyForDay("2025-12-29")).toBe("2026-W01");
+    expect(weekKeyForDay("2026-01-01")).toBe("2026-W01");
+    // 2026 has 53 ISO weeks; W53 spans 2026-12-28 .. 2027-01-03.
+    expect(weekKeyForDay("2027-01-01")).toBe("2026-W53");
+  });
+});
+
+describe("weekDayKeys", () => {
+  it("returns Monday..Sunday day keys", () => {
+    expect(weekDayKeys("2026-W24")).toEqual([
+      "2026-06-08",
+      "2026-06-09",
+      "2026-06-10",
+      "2026-06-11",
+      "2026-06-12",
+      "2026-06-13",
+      "2026-06-14",
+    ]);
+  });
+
+  it("handles a year-straddling week", () => {
+    expect(weekDayKeys("2026-W53")[0]).toBe("2026-12-28");
+    expect(weekDayKeys("2026-W53")[6]).toBe("2027-01-03");
+  });
+});
+
+describe("month/year containment", () => {
+  it("maps days and months upward by prefix", () => {
+    expect(monthKeyForDay("2026-06-08")).toBe("2026-06");
+    expect(yearKeyForMonth("2026-06")).toBe("2026");
+    expect(monthKeysOfYear("2026")).toHaveLength(12);
+    expect(monthKeysOfYear("2026")[0]).toBe("2026-01");
+    expect(monthKeysOfYear("2026")[11]).toBe("2026-12");
+  });
+
+  it("finds the month(s) a week overlaps", () => {
+    expect(monthKeysForWeek("2026-W24")).toEqual(["2026-06"]);
+    // W53 2026 straddles December 2026 and January 2027.
+    expect(monthKeysForWeek("2026-W53")).toEqual(["2026-12", "2027-01"]);
+  });
+});
+
+describe("weeksOverlappingMonth", () => {
+  it("lists every overlapping ISO week with its in-month days", () => {
+    // June 2026: Jun 1 is a Monday (W23); Jun 29-30 fall in W27.
+    const weeks = weeksOverlappingMonth("2026-06");
+    expect(weeks.map((w) => w.weekKey)).toEqual([
+      "2026-W23",
+      "2026-W24",
+      "2026-W25",
+      "2026-W26",
+      "2026-W27",
+    ]);
+    const last = weeks[4]!;
+    expect(last.dayKeysInMonth).toEqual(["2026-06-29", "2026-06-30"]);
+    const first = weeks[0]!;
+    expect(first.dayKeysInMonth).toHaveLength(7);
+  });
+});
+
+describe("ancestorKeysForDay", () => {
+  it("returns week, overlapping months, and their years", () => {
+    expect(ancestorKeysForDay("2026-06-08")).toEqual([
+      "2026-W24",
+      "2026-06",
+      "2026",
+    ]);
+  });
+
+  it("includes both straddled months and years at a boundary", () => {
+    expect(ancestorKeysForDay("2027-01-01")).toEqual([
+      "2026-W53",
+      "2026-12",
+      "2027-01",
+      "2026",
+      "2027",
+    ]);
+  });
+});
+
+describe("periodEndDayKey / isPeriodComplete", () => {
+  it("computes the period's final day", () => {
+    expect(periodEndDayKey("2026-06-08")).toBe("2026-06-08");
+    expect(periodEndDayKey("2026-W24")).toBe("2026-06-14");
+    expect(periodEndDayKey("2026-06")).toBe("2026-06-30");
+    expect(periodEndDayKey("2026-02")).toBe("2026-02-28");
+    expect(periodEndDayKey("2026")).toBe("2026-12-31");
+  });
+
+  it("a period is complete only when its last day is strictly before today", () => {
+    expect(isPeriodComplete("2026-W24", "2026-06-14")).toBe(false);
+    expect(isPeriodComplete("2026-W24", "2026-06-15")).toBe(true);
+    expect(isPeriodComplete("2026-06-14", "2026-06-15")).toBe(true);
+    expect(isPeriodComplete("2026", "2026-12-31")).toBe(false);
+    expect(isPeriodComplete("2026", "2027-01-01")).toBe(true);
+  });
+});
+
+describe("sortForProcessing", () => {
+  it("orders bottom-up by level, then oldest-first within a level", () => {
+    expect(
+      sortForProcessing([
+        "2026",
+        "2026-06",
+        "2026-W24",
+        "2026-06-09",
+        "2026-06-08",
+        "2026-W23",
+      ]),
+    ).toEqual([
+      "2026-06-08",
+      "2026-06-09",
+      "2026-W23",
+      "2026-W24",
+      "2026-06",
+      "2026",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/rollup/period.test.ts --run`
+Expected: FAIL — cannot resolve `./period`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/rollup/period.ts`:
+
+```typescript
+/**
+ * Pure period-key math for the temporal rollup hierarchy.
+ *
+ * Period keys (all derived from the day-label convention used by
+ * `ensureDayNode`): day `yyyy-MM-dd`, ISO week `yyyy-Www` (ISO
+ * week-numbering year), month `yyyy-MM`, year `yyyy`. All functions are
+ * pure and timezone-stable: day keys are parsed and re-formatted with
+ * date-fns in local time, so round-trips never shift dates.
+ *
+ * Aliases for search: period keys, temporal hierarchy, ISO week math,
+ * rollup periods.
+ */
+import {
+  addDays,
+  format,
+  getISOWeek,
+  getISOWeekYear,
+  lastDayOfMonth,
+  parse,
+  setISOWeek,
+  setISOWeekYear,
+  startOfISOWeek,
+} from "date-fns";
+
+export type PeriodLevel = "day" | "week" | "month" | "year";
+
+const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const WEEK_KEY_RE = /^(\d{4})-W(\d{2})$/;
+const MONTH_KEY_RE = /^\d{4}-\d{2}$/;
+const YEAR_KEY_RE = /^\d{4}$/;
+
+const REFERENCE_DATE = new Date(2000, 0, 1);
+
+export function periodLevelOf(key: string): PeriodLevel {
+  if (DAY_KEY_RE.test(key)) return "day";
+  if (WEEK_KEY_RE.test(key)) return "week";
+  if (MONTH_KEY_RE.test(key)) return "month";
+  if (YEAR_KEY_RE.test(key)) return "year";
+  throw new Error(`Malformed period key: "${key}"`);
+}
+
+export function isDayKey(key: string): boolean {
+  return DAY_KEY_RE.test(key);
+}
+
+function dayDate(dayKey: string): Date {
+  return parse(dayKey, "yyyy-MM-dd", REFERENCE_DATE);
+}
+
+export function dayKeyOf(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+export function weekKeyForDay(dayKey: string): string {
+  const d = dayDate(dayKey);
+  const isoYear = String(getISOWeekYear(d)).padStart(4, "0");
+  const isoWeek = String(getISOWeek(d)).padStart(2, "0");
+  return `${isoYear}-W${isoWeek}`;
+}
+
+function mondayOfWeek(weekKey: string): Date {
+  const match = WEEK_KEY_RE.exec(weekKey);
+  if (!match) throw new Error(`Malformed week key: "${weekKey}"`);
+  const isoYear = Number(match[1]);
+  const isoWeek = Number(match[2]);
+  // Anchor mid-year so week 26 always exists before the ISO fields are set.
+  let d = new Date(2000, 6, 1);
+  d = setISOWeekYear(d, isoYear);
+  d = setISOWeek(d, isoWeek);
+  return startOfISOWeek(d);
+}
+
+export function weekDayKeys(weekKey: string): string[] {
+  const monday = mondayOfWeek(weekKey);
+  return Array.from({ length: 7 }, (_, i) => dayKeyOf(addDays(monday, i)));
+}
+
+export function monthKeyForDay(dayKey: string): string {
+  if (!DAY_KEY_RE.test(dayKey)) {
+    throw new Error(`Malformed day key: "${dayKey}"`);
+  }
+  return dayKey.slice(0, 7);
+}
+
+export function monthKeysForWeek(weekKey: string): string[] {
+  const days = weekDayKeys(weekKey);
+  return [...new Set(days.map(monthKeyForDay))];
+}
+
+export function yearKeyForMonth(monthKey: string): string {
+  if (!MONTH_KEY_RE.test(monthKey)) {
+    throw new Error(`Malformed month key: "${monthKey}"`);
+  }
+  return monthKey.slice(0, 4);
+}
+
+export function monthKeysOfYear(yearKey: string): string[] {
+  if (!YEAR_KEY_RE.test(yearKey)) {
+    throw new Error(`Malformed year key: "${yearKey}"`);
+  }
+  return Array.from(
+    { length: 12 },
+    (_, i) => `${yearKey}-${String(i + 1).padStart(2, "0")}`,
+  );
+}
+
+export interface WeekInMonth {
+  weekKey: string;
+  /** The subset of this week's 7 days that fall inside the month. */
+  dayKeysInMonth: string[];
+}
+
+export function weeksOverlappingMonth(monthKey: string): WeekInMonth[] {
+  if (!MONTH_KEY_RE.test(monthKey)) {
+    throw new Error(`Malformed month key: "${monthKey}"`);
+  }
+  const firstDayKey = `${monthKey}-01`;
+  const lastDayKey = dayKeyOf(lastDayOfMonth(dayDate(firstDayKey)));
+  const result: WeekInMonth[] = [];
+  let weekKey = weekKeyForDay(firstDayKey);
+  for (;;) {
+    const days = weekDayKeys(weekKey);
+    const dayKeysInMonth = days.filter(
+      (d) => monthKeyForDay(d) === monthKey,
+    );
+    result.push({ weekKey, dayKeysInMonth });
+    const sunday = days[6]!;
+    if (sunday >= lastDayKey) break;
+    weekKey = weekKeyForDay(dayKeyOf(addDays(dayDate(sunday), 1)));
+  }
+  return result;
+}
+
+/**
+ * Every period whose summary input can change when this day's summary
+ * changes: the day's ISO week, every month that week overlaps (a
+ * boundary week feeds two month summaries), and those months' years.
+ */
+export function ancestorKeysForDay(dayKey: string): string[] {
+  const weekKey = weekKeyForDay(dayKey);
+  const monthKeys = monthKeysForWeek(weekKey);
+  const yearKeys = [...new Set(monthKeys.map(yearKeyForMonth))];
+  return [weekKey, ...monthKeys, ...yearKeys];
+}
+
+export function periodEndDayKey(key: string): string {
+  const level = periodLevelOf(key);
+  switch (level) {
+    case "day":
+      return key;
+    case "week":
+      return weekDayKeys(key)[6]!;
+    case "month":
+      return dayKeyOf(lastDayOfMonth(dayDate(`${key}-01`)));
+    case "year":
+      return `${key}-12-31`;
+  }
+}
+
+/** A period is complete once its final day is strictly before today. */
+export function isPeriodComplete(key: string, todayDayKey: string): boolean {
+  return periodEndDayKey(key) < todayDayKey;
+}
+
+const LEVEL_ORDER: Record<PeriodLevel, number> = {
+  day: 0,
+  week: 1,
+  month: 2,
+  year: 3,
+};
+
+/** Bottom-up (day→week→month→year), oldest-first within each level. */
+export function sortForProcessing(keys: string[]): string[] {
+  return [...keys].sort((a, b) => {
+    const levelDiff = LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
+    if (levelDiff !== 0) return levelDiff;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/lib/rollup/period.test.ts --run`
+Expected: PASS (all describes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rollup/period.ts src/lib/rollup/period.test.ts
+git commit -m "✨ feat(rollup): pure period-key math for temporal hierarchy"
+```
+
+### Task 2: Schema groundwork — `rollup_state` table, `"rollup"` SourceType, `temporal_summary` ModelTask
+
+**Files:**
+- Modify: `src/db/schema.ts` (append after the `scratchpads` table + its relations)
+- Modify: `src/types/graph.ts` (the `SourceType` union)
+- Modify: `src/utils/models.ts` (ModelTask union + overrides map)
+- Modify: `src/utils/env.ts` (env schema, next to the other `MODEL_ID_*` entries)
+- Create: generated migration under `drizzle/` (via drizzle-kit)
+
+Declarative schema/type changes — no behavior to TDD; the build check and migration diff are the verification.
+
+- [ ] **Step 1: Add the `rollup_state` table to `src/db/schema.ts`**
+
+The file uses drizzle `casing: "snake_case"` — bare property names map to snake_case columns automatically. Append after `scratchpadsRelations`:
+
+```typescript
+/**
+ * Per-user temporal-rollup sweep state (see
+ * docs/superpowers/specs/2026-06-12-temporal-rollup-design.md).
+ *
+ * `watermark`: max `claims.createdAt` whose OCCURRED_ON claims have been
+ * incorporated into the work set. Always advances; deferred work is
+ * carried by `pendingPeriods`, never by holding the watermark back.
+ * `pendingPeriods`: period keys (day/week/month/year) awaiting
+ * summarization — incomplete periods, over-budget leftovers, failures.
+ */
+export const rollupState = pgTable("rollup_state", {
+  userId: text()
+    .primaryKey()
+    .notNull()
+    .references(() => users.id),
+  watermark: timestamp({ withTimezone: true }),
+  pendingPeriods: jsonb().$type<string[]>().notNull().default([]),
+  updatedAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+});
+
+export const rollupStateRelations = relations(rollupState, ({ one }) => ({
+  user: one(users, {
+    fields: [rollupState.userId],
+    references: [users.id],
+  }),
+}));
+```
+
+- [ ] **Step 2: Add `"rollup"` to the `SourceType` union in `src/types/graph.ts`**
+
+```typescript
+export type SourceType =
+  | "conversation"
+  | "conversation_message"
+  | "document"
+  | "legacy_migration"
+  | "manual"
+  | "meeting_transcript"
+  | "external_conversation"
+  | "metric_push"
+  | "metric_manual"
+  | "rollup";
+```
+
+(`sources.type` is a plain `varchar(50)` — no DB change needed for this.)
+
+- [ ] **Step 3: Add the `temporal_summary` ModelTask**
+
+In `src/utils/models.ts`, extend the union and the overrides map:
+
+```typescript
+export type ModelTask =
+  | "graph_extraction"
+  | "document_spine"
+  | "transcript_segmentation"
+  | "conversation_summary"
+  | "graph_cleanup"
+  | "atlas"
+  | "profile_synthesis"
+  | "dream"
+  | "deep_research"
+  | "temporal_summary";
+```
+
+```typescript
+const TASK_MODEL_OVERRIDES: Record<ModelTask, string | undefined> = {
+  graph_extraction: undefined,
+  document_spine: env.MODEL_ID_DOCUMENT_SPINE,
+  transcript_segmentation: env.MODEL_ID_TRANSCRIPT_SEGMENTATION,
+  conversation_summary: env.MODEL_ID_CONVERSATION_SUMMARY,
+  graph_cleanup: env.MODEL_ID_GRAPH_CLEANUP,
+  atlas: env.MODEL_ID_ATLAS,
+  profile_synthesis: env.MODEL_ID_PROFILE_SYNTHESIS,
+  dream: env.MODEL_ID_DREAM,
+  deep_research: env.MODEL_ID_DEEP_RESEARCH,
+  temporal_summary: env.MODEL_ID_TEMPORAL_SUMMARY,
+};
+```
+
+In `src/utils/env.ts`, add directly under `MODEL_ID_DEEP_RESEARCH`:
+
+```typescript
+  MODEL_ID_TEMPORAL_SUMMARY: z.string().min(1).optional(),
+```
+
+- [ ] **Step 4: Generate the migration**
+
+Run: `pnpm run drizzle:generate`
+Expected: a new file `drizzle/00XX_<name>.sql` containing `CREATE TABLE "rollup_state"` with columns `user_id` (text, PK, FK → users), `watermark` (timestamptz, nullable), `pending_periods` (jsonb, not null, default `'[]'`), `updated_at` (timestamptz, not null, default now). Inspect the SQL — it must contain ONLY the new table (no unrelated diffs). If unrelated statements appear, STOP and report BLOCKED.
+
+- [ ] **Step 5: Build check**
+
+Run: `pnpm run build:check`
+Expected: clean exit (tsc + structured-output check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/db/schema.ts src/types/graph.ts src/utils/models.ts src/utils/env.ts drizzle/
+git commit -m "✨ feat(rollup): rollup_state table, rollup source type, temporal_summary task"
+```
+
+---
+
+### Task 3: Per-user synthetic rollup source
+
+**Files:**
+- Create: `src/lib/rollup/source.ts`
+- Test: `src/lib/rollup/source.test.ts`
+
+`claims.sourceId` is NOT NULL, so the `PART_OF` containment claims need a source. One idempotent synthetic source per user, modeled on `src/lib/metrics/sources.ts` (which relies on the existing `sources` unique constraint on `(user_id, type, external_id)`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/rollup/source.test.ts`:
+
+```typescript
+import { ensureRollupSource } from "./source";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("ensureRollupSource", () => {
+  const dbName = `memory_rollup_source_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(`
+      CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE "sources" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "type" varchar(50) NOT NULL,
+        "external_id" text NOT NULL,
+        "parent_source" text,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "metadata" jsonb,
+        "last_ingested_at" timestamp with time zone,
+        "status" varchar(20) DEFAULT 'pending',
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "deleted_at" timestamp with time zone,
+        "content_type" varchar(100),
+        "content_length" integer,
+        CONSTRAINT "sources_user_type_external_unique"
+          UNIQUE ("user_id", "type", "external_id")
+      );
+    `);
+    await client.query(`INSERT INTO "users" ("id") VALUES ('user_rollup')`);
+  });
+
+  afterAll(async () => {
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("creates the source once and returns the same id thereafter", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    const first = await ensureRollupSource(db, "user_rollup");
+    const second = await ensureRollupSource(db, "user_rollup");
+    expect(second).toBe(first);
+
+    const rows = await client.query(
+      `SELECT "type", "external_id", "status" FROM "sources" WHERE "user_id" = 'user_rollup'`,
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0]).toMatchObject({
+      type: "rollup",
+      external_id: "rollup",
+      status: "completed",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/rollup/source.test.ts --run`
+Expected: FAIL — cannot resolve `./source`. (If it reports the whole suite skipped, the test Postgres on :5431 isn't running — start it with `docker compose up -d` first.)
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/rollup/source.ts`:
+
+```typescript
+/**
+ * Synthetic per-user source backing rollup-generated PART_OF claims
+ * (`claims.sourceId` is NOT NULL and containment claims have no natural
+ * ingestion source). Mirrors the metric-source pattern in
+ * `src/lib/metrics/sources.ts`.
+ */
+import { and, eq } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { sources } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+
+const ROLLUP_EXTERNAL_ID = "rollup";
+
+export async function ensureRollupSource(
+  db: DrizzleDB,
+  userId: string,
+): Promise<TypeId<"source">> {
+  const [inserted] = await db
+    .insert(sources)
+    .values({
+      userId,
+      type: "rollup",
+      externalId: ROLLUP_EXTERNAL_ID,
+      scope: "personal",
+      status: "completed",
+    })
+    .onConflictDoNothing()
+    .returning({ id: sources.id });
+  if (inserted) return inserted.id;
+
+  const [existing] = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(
+      and(
+        eq(sources.userId, userId),
+        eq(sources.type, "rollup"),
+        eq(sources.externalId, ROLLUP_EXTERNAL_ID),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error(`Failed to ensure rollup source for user ${userId}`);
+  }
+  return existing.id;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/lib/rollup/source.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rollup/source.ts src/lib/rollup/source.test.ts
+git commit -m "✨ feat(rollup): per-user synthetic rollup source"
+```
+
+### Task 4: `ensurePeriodNode` (generalize `ensureDayNode`)
+
+**Files:**
+- Modify: `src/lib/temporal.ts`
+- Test: `src/lib/temporal.test.ts` (new)
+
+`ensureDayNode` (currently in `src/lib/temporal.ts`) finds/creates a `Temporal` node by `nodeMetadata.label`. Generalize it: `ensurePeriodNode(db, userId, periodKey)` handles all four levels; `ensureDayNode` becomes a thin delegate so all existing callers keep working unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/temporal.test.ts`:
+
+```typescript
+import { ensureDayNode, ensurePeriodNode } from "./temporal";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import {
+  resetTestOverrides,
+  setSkipEmbeddingPersistence,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("ensurePeriodNode", () => {
+  const dbName = `memory_temporal_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(`
+      CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE "nodes" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "node_type" varchar(50) NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+      CREATE TABLE "node_metadata" (
+        "id" text PRIMARY KEY NOT NULL,
+        "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "label" text,
+        "canonical_label" text,
+        "description" text,
+        "additional_data" jsonb,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+      );
+    `);
+    await client.query(`INSERT INTO "users" ("id") VALUES ('user_t')`);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("creates a Temporal node per period key and is idempotent", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    const weekId = await ensurePeriodNode(db, "user_t", "2026-W24");
+    const weekIdAgain = await ensurePeriodNode(db, "user_t", "2026-W24");
+    expect(weekIdAgain).toBe(weekId);
+
+    const monthId = await ensurePeriodNode(db, "user_t", "2026-06");
+    const yearId = await ensurePeriodNode(db, "user_t", "2026");
+    expect(new Set([weekId, monthId, yearId]).size).toBe(3);
+
+    const rows = await client.query(
+      `SELECT m."label", m."description", n."node_type"
+       FROM "node_metadata" m JOIN "nodes" n ON n."id" = m."node_id"
+       WHERE n."user_id" = 'user_t' ORDER BY m."label"`,
+    );
+    expect(rows.rows).toEqual([
+      {
+        label: "2026",
+        description: "Represents the year 2026",
+        node_type: "Temporal",
+      },
+      {
+        label: "2026-06",
+        description: "Represents the month 2026-06",
+        node_type: "Temporal",
+      },
+      {
+        label: "2026-W24",
+        description: "Represents the week 2026-W24",
+        node_type: "Temporal",
+      },
+    ]);
+  });
+
+  it("ensureDayNode delegates and stays label-compatible", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const viaDate = await ensureDayNode(db, "user_t", new Date(2026, 5, 8));
+    const viaKey = await ensurePeriodNode(db, "user_t", "2026-06-08");
+    expect(viaKey).toBe(viaDate);
+  });
+
+  it("rejects malformed period keys", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    await expect(ensurePeriodNode(db, "user_t", "junk")).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/temporal.test.ts --run`
+Expected: FAIL — `ensurePeriodNode` is not exported.
+
+- [ ] **Step 3: Refactor `src/lib/temporal.ts`**
+
+Replace the whole file body (keeping the existing imports, adding `periodLevelOf`/`PeriodLevel` from the rollup period module):
+
+```typescript
+import { generateEmbeddings } from "./embeddings";
+import { periodLevelOf, type PeriodLevel } from "./rollup/period";
+import { format } from "date-fns";
+import { and, eq } from "drizzle-orm";
+import { type NodePgDatabase } from "drizzle-orm/node-postgres";
+import * as schema from "~/db/schema";
+import { nodeEmbeddings, nodeMetadata, nodes } from "~/db/schema";
+import { NodeTypeEnum } from "~/types/graph";
+import { type TypeId } from "~/types/typeid";
+import { shouldSkipEmbeddingPersistence } from "~/utils/test-overrides";
+
+type Database = NodePgDatabase<typeof schema>;
+
+const PERIOD_DESCRIPTION: Record<PeriodLevel, (key: string) => string> = {
+  day: (key) => `Represents the day ${key}`,
+  week: (key) => `Represents the week ${key}`,
+  month: (key) => `Represents the month ${key}`,
+  year: (key) => `Represents the year ${key}`,
+};
+
+/**
+ * Ensures a Temporal node representing the given date exists for the user,
+ * creating one if necessary.
+ *
+ * @returns The TypeId of the existing or newly created day node.
+ */
+export async function ensureDayNode(
+  db: Database,
+  userId: string,
+  targetDate: Date = new Date(),
+): Promise<TypeId<"node">> {
+  return ensurePeriodNode(db, userId, format(targetDate, "yyyy-MM-dd"));
+}
+
+/**
+ * Ensures a Temporal node for any rollup period key (day `yyyy-MM-dd`,
+ * week `yyyy-Www`, month `yyyy-MM`, year `yyyy`) exists for the user.
+ * Lookup is by `nodeMetadata.label` — the period key IS the label.
+ *
+ * @throws Error on a malformed key, embedding failure, or insert failure.
+ */
+export async function ensurePeriodNode(
+  db: Database,
+  userId: string,
+  periodKey: string,
+): Promise<TypeId<"node">> {
+  const level = periodLevelOf(periodKey);
+
+  const [existingNode] = await db
+    .select({ id: nodes.id })
+    .from(nodes)
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(nodes.userId, userId),
+        eq(nodes.nodeType, NodeTypeEnum.enum.Temporal),
+        eq(nodeMetadata.label, periodKey),
+      ),
+    )
+    .limit(1);
+
+  if (existingNode) {
+    return existingNode.id;
+  }
+
+  const nodeDescription = PERIOD_DESCRIPTION[level](periodKey);
+  const skipEmbedding = shouldSkipEmbeddingPersistence();
+
+  const nodeEmbedding = skipEmbedding
+    ? null
+    : await generatePeriodNodeEmbedding(periodKey, nodeDescription);
+
+  try {
+    const [insertedNode] = await db
+      .insert(nodes)
+      .values({
+        userId,
+        nodeType: NodeTypeEnum.enum.Temporal,
+      })
+      .returning({ id: nodes.id });
+
+    if (!insertedNode) {
+      throw new Error(
+        `Failed to retrieve ID after inserting period node: ${periodKey}`,
+      );
+    }
+
+    const actualNodeId = insertedNode.id;
+
+    await db.transaction(async (tx) => {
+      await tx.insert(nodeMetadata).values({
+        nodeId: actualNodeId,
+        label: periodKey,
+        description: nodeDescription,
+      });
+      if (nodeEmbedding) {
+        await tx.insert(nodeEmbeddings).values({
+          nodeId: actualNodeId,
+          embedding: nodeEmbedding,
+          modelName: "jina-embeddings-v3",
+        });
+      }
+    });
+
+    return actualNodeId;
+  } catch (error) {
+    console.error(`Failed to create period node ${periodKey}:`, error);
+    throw new Error(`Database operation failed for period node ${periodKey}`);
+  }
+}
+
+async function generatePeriodNodeEmbedding(
+  periodKey: string,
+  nodeDescription: string,
+): Promise<number[]> {
+  const embeddingContent = `${periodKey}: ${nodeDescription}`;
+  const embeddingsResult = await generateEmbeddings({
+    input: [embeddingContent],
+    model: "jina-embeddings-v3",
+    truncate: true,
+  });
+
+  const embedding = embeddingsResult?.data?.[0]?.embedding;
+  if (!embedding) {
+    throw new Error(
+      `Failed to generate valid embedding for period node: ${periodKey}`,
+    );
+  }
+  return embedding;
+}
+```
+
+Note: the old `generateDayNodeEmbedding` is renamed to `generatePeriodNodeEmbedding`; behavior for day nodes is byte-identical (same lookup, same description text, same embedding content).
+
+- [ ] **Step 4: Run tests — new file AND existing suites that exercise `ensureDayNode`**
+
+Run: `pnpm run test -- src/lib/temporal.test.ts src/lib/node.test.ts --run`
+Expected: PASS. Then `pnpm run build:check` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/temporal.ts src/lib/temporal.test.ts
+git commit -m "♻️ refactor(temporal): generalize ensureDayNode into ensurePeriodNode"
+```
+
+---
+
+### Task 5: Input builders, compaction, fingerprint (pure) + DB fetchers
+
+**Files:**
+- Create: `src/lib/rollup/collect.ts`
+- Test: `src/lib/rollup/collect.test.ts` (pure builders only — the DB fetchers are exercised by Tasks 6–7's integration tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/rollup/collect.test.ts`:
+
+```typescript
+import {
+  DAY_ENTRY_MAX_CHARS,
+  DAY_INPUT_MAX_CHARS,
+  buildDayInputText,
+  buildMonthInputText,
+  buildWeekInputText,
+  buildYearInputText,
+  fingerprintOf,
+  readRollupMeta,
+} from "./collect";
+import { describe, expect, it } from "vitest";
+
+describe("fingerprintOf", () => {
+  it("is a stable sha256 hex of the input", () => {
+    expect(fingerprintOf("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect(fingerprintOf("abc")).toBe(fingerprintOf("abc"));
+    expect(fingerprintOf("abc")).not.toBe(fingerprintOf("abd"));
+  });
+});
+
+describe("readRollupMeta", () => {
+  it("reads a valid rollup marker", () => {
+    expect(
+      readRollupMeta({ rollup: { fingerprint: "f1", summarizedAt: "t1" } }),
+    ).toEqual({ fingerprint: "f1", summarizedAt: "t1" });
+  });
+
+  it("returns null for anything else", () => {
+    expect(readRollupMeta(null)).toBeNull();
+    expect(readRollupMeta(undefined)).toBeNull();
+    expect(readRollupMeta({})).toBeNull();
+    expect(readRollupMeta({ rollup: { fingerprint: 42 } })).toBeNull();
+    expect(readRollupMeta([])).toBeNull();
+    expect(readRollupMeta("rollup")).toBeNull();
+  });
+});
+
+describe("buildDayInputText", () => {
+  const entry = (label: string, description: string | null) => ({
+    nodeType: "Conversation",
+    label,
+    description,
+    createdAt: new Date("2026-06-08T10:00:00Z"),
+  });
+
+  it("returns null when there are no usable entries", () => {
+    expect(buildDayInputText("2026-06-08", [])).toBeNull();
+    expect(
+      buildDayInputText("2026-06-08", [
+        { nodeType: "Event", label: null, description: null, createdAt: new Date(0) },
+      ]),
+    ).toBeNull();
+  });
+
+  it("renders one capped line per entry, chronologically", () => {
+    const text = buildDayInputText("2026-06-08", [
+      entry("Standup", "Discussed the rollout plan with Sam."),
+      entry("Gym session", null),
+    ]);
+    expect(text).toContain("Day: 2026-06-08");
+    expect(text).toContain(
+      "- [Conversation] Standup: Discussed the rollout plan with Sam.",
+    );
+    expect(text).toContain("- [Conversation] Gym session");
+  });
+
+  it("truncates an oversize entry to the per-entry cap", () => {
+    const text = buildDayInputText("2026-06-08", [
+      entry("Long", "x".repeat(DAY_ENTRY_MAX_CHARS * 2)),
+    ]);
+    const line = text!.split("\n").find((l) => l.startsWith("- "));
+    expect(line!.length).toBeLessThanOrEqual(DAY_ENTRY_MAX_CHARS);
+  });
+
+  it("drops oldest entries beyond the total cap and says so", () => {
+    const entries = Array.from({ length: 100 }, (_, i) => ({
+      nodeType: "Document",
+      label: `Doc ${String(i).padStart(3, "0")}`,
+      description: "y".repeat(500),
+      createdAt: new Date(2026, 5, 8, 0, i),
+    }));
+    const text = buildDayInputText("2026-06-08", entries);
+    expect(text!.length).toBeLessThanOrEqual(DAY_INPUT_MAX_CHARS + 200);
+    expect(text).toContain("older entries omitted");
+    // newest entry survives, oldest is dropped
+    expect(text).toContain("Doc 099");
+    expect(text).not.toContain("Doc 000");
+  });
+});
+
+describe("buildWeekInputText", () => {
+  it("returns null when no day has a summary", () => {
+    expect(
+      buildWeekInputText("2026-W24", [
+        { key: "2026-06-08", summary: null },
+        { key: "2026-06-09", summary: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it("lists each day with its summary or a no-activity marker", () => {
+    const text = buildWeekInputText("2026-W24", [
+      { key: "2026-06-08", summary: "Shipped the rollup spec." },
+      { key: "2026-06-09", summary: null },
+    ]);
+    expect(text).toContain("Week: 2026-W24");
+    expect(text).toContain("2026-06-08: Shipped the rollup spec.");
+    expect(text).toContain("2026-06-09: (no summarized activity)");
+  });
+});
+
+describe("buildMonthInputText", () => {
+  it("annotates boundary weeks with their in-month days", () => {
+    const text = buildMonthInputText("2026-06", [
+      {
+        weekKey: "2026-W23",
+        summary: "Full week in June.",
+        dayKeysInMonth: [
+          "2026-06-01",
+          "2026-06-02",
+          "2026-06-03",
+          "2026-06-04",
+          "2026-06-05",
+          "2026-06-06",
+          "2026-06-07",
+        ],
+      },
+      {
+        weekKey: "2026-W27",
+        summary: "Straddles into July.",
+        dayKeysInMonth: ["2026-06-29", "2026-06-30"],
+      },
+    ]);
+    expect(text).toContain("Month: 2026-06");
+    expect(text).toContain("2026-W23: Full week in June.");
+    expect(text).toContain(
+      "2026-W27 (only 2026-06-29 to 2026-06-30 fall in this month): Straddles into July.",
+    );
+  });
+
+  it("returns null when no week has a summary", () => {
+    expect(
+      buildMonthInputText("2026-06", [
+        { weekKey: "2026-W23", summary: null, dayKeysInMonth: [] },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("buildYearInputText", () => {
+  it("lists months with summaries or markers, null when empty", () => {
+    expect(
+      buildYearInputText("2026", [{ key: "2026-01", summary: null }]),
+    ).toBeNull();
+    const text = buildYearInputText("2026", [
+      { key: "2026-01", summary: "January arc." },
+      { key: "2026-02", summary: null },
+    ]);
+    expect(text).toContain("Year: 2026");
+    expect(text).toContain("2026-01: January arc.");
+    expect(text).toContain("2026-02: (no summarized activity)");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/rollup/collect.test.ts --run`
+Expected: FAIL — cannot resolve `./collect`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/rollup/collect.ts`:
+
+```typescript
+/**
+ * Deterministic input assembly for temporal rollup summaries.
+ *
+ * Pure builders turn child rows into the exact prompt-input text; the
+ * sha256 of that text is the period's staleness fingerprint (input
+ * unchanged → fingerprint match → no LLM call). Thin DB fetchers load
+ * the child rows. No LLM calls happen here.
+ *
+ * Aliases for search: rollup input collection, compaction, period
+ * fingerprint, day entries.
+ */
+import {
+  monthKeysOfYear,
+  weekDayKeys,
+  weeksOverlappingMonth,
+} from "./period";
+import { and, eq, inArray } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+
+/** Initial caps — tunable. Bounds even heavy days (e.g. screenpipe docs). */
+export const DAY_ENTRY_MAX_CHARS = 600;
+export const DAY_INPUT_MAX_CHARS = 24_000;
+
+export function fingerprintOf(inputText: string): string {
+  return createHash("sha256").update(inputText, "utf8").digest("hex");
+}
+
+export interface RollupMeta {
+  fingerprint: string;
+  summarizedAt: string;
+}
+
+/** Defensive read of `nodeMetadata.additionalData.rollup`. */
+export function readRollupMeta(additionalData: unknown): RollupMeta | null {
+  if (
+    !additionalData ||
+    typeof additionalData !== "object" ||
+    Array.isArray(additionalData)
+  ) {
+    return null;
+  }
+  const rollup = (additionalData as Record<string, unknown>)["rollup"];
+  if (!rollup || typeof rollup !== "object" || Array.isArray(rollup)) {
+    return null;
+  }
+  const { fingerprint, summarizedAt } = rollup as Record<string, unknown>;
+  if (typeof fingerprint !== "string" || typeof summarizedAt !== "string") {
+    return null;
+  }
+  return { fingerprint, summarizedAt };
+}
+
+// --- Pure builders ---
+
+export interface DayEntry {
+  nodeType: string;
+  label: string | null;
+  description: string | null;
+  createdAt: Date;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+export function buildDayInputText(
+  dayKey: string,
+  entries: DayEntry[],
+): string | null {
+  const usable = entries
+    .filter((e) => e.label !== null || e.description !== null)
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  if (usable.length === 0) return null;
+
+  const lines = usable.map((e) =>
+    truncate(
+      `- [${e.nodeType}] ${e.label ?? "(unlabeled)"}${
+        e.description ? `: ${e.description}` : ""
+      }`,
+      DAY_ENTRY_MAX_CHARS,
+    ),
+  );
+
+  // Keep the newest lines under the total cap; render chronologically.
+  const kept: string[] = [];
+  let total = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!;
+    if (total + line.length + 1 > DAY_INPUT_MAX_CHARS) break;
+    kept.unshift(line);
+    total += line.length + 1;
+  }
+  const dropped = lines.length - kept.length;
+
+  return [
+    `Day: ${dayKey}`,
+    ...(dropped > 0 ? [`(${dropped} older entries omitted for length)`] : []),
+    ...kept,
+  ].join("\n");
+}
+
+export interface ChildSummary {
+  key: string;
+  summary: string | null;
+}
+
+export function buildWeekInputText(
+  weekKey: string,
+  days: ChildSummary[],
+): string | null {
+  if (days.every((d) => d.summary === null)) return null;
+  const lines = days.map(
+    (d) => `${d.key}: ${d.summary ?? "(no summarized activity)"}`,
+  );
+  return [`Week: ${weekKey}`, ...lines].join("\n\n");
+}
+
+export interface WeekSummaryInMonth {
+  weekKey: string;
+  summary: string | null;
+  dayKeysInMonth: string[];
+}
+
+export function buildMonthInputText(
+  monthKey: string,
+  weeks: WeekSummaryInMonth[],
+): string | null {
+  if (weeks.every((w) => w.summary === null)) return null;
+  const lines = weeks.map((w) => {
+    const partial =
+      w.dayKeysInMonth.length > 0 && w.dayKeysInMonth.length < 7
+        ? ` (only ${w.dayKeysInMonth[0]} to ${w.dayKeysInMonth[w.dayKeysInMonth.length - 1]} fall in this month)`
+        : "";
+    return `${w.weekKey}${partial}: ${w.summary ?? "(no summarized activity)"}`;
+  });
+  return [`Month: ${monthKey}`, ...lines].join("\n\n");
+}
+
+export function buildYearInputText(
+  yearKey: string,
+  months: ChildSummary[],
+): string | null {
+  if (months.every((m) => m.summary === null)) return null;
+  const lines = months.map(
+    (m) => `${m.key}: ${m.summary ?? "(no summarized activity)"}`,
+  );
+  return [`Year: ${yearKey}`, ...lines].join("\n\n");
+}
+
+// --- DB fetchers (exercised by the summarize-period and rollup job tests) ---
+
+export interface TemporalNodeRow {
+  nodeId: TypeId<"node">;
+  label: string;
+  description: string | null;
+  additionalData: unknown;
+}
+
+/** Fetch the user's Temporal nodes for the given period-key labels. */
+export async function fetchTemporalNodesByLabels(
+  db: DrizzleDB,
+  userId: string,
+  labels: string[],
+): Promise<Map<string, TemporalNodeRow>> {
+  if (labels.length === 0) return new Map();
+  const rows = await db
+    .select({
+      nodeId: nodes.id,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      additionalData: nodeMetadata.additionalData,
+    })
+    .from(nodes)
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(nodes.userId, userId),
+        eq(nodes.nodeType, "Temporal"),
+        inArray(nodeMetadata.label, labels),
+      ),
+    );
+  return new Map(
+    rows
+      .filter((r): r is typeof r & { label: string } => r.label !== null)
+      .map((r) => [r.label, r]),
+  );
+}
+
+/**
+ * A child period's summary counts only when the rollup marker is present —
+ * `description` alone may be the "Represents the …" boilerplate.
+ */
+function summarizedDescriptionOf(row: TemporalNodeRow | undefined): string | null {
+  if (!row) return null;
+  return readRollupMeta(row.additionalData) ? row.description : null;
+}
+
+/** Content entries linked to a day node via active OCCURRED_ON claims. */
+export async function fetchDayEntries(
+  db: DrizzleDB,
+  userId: string,
+  dayNodeId: TypeId<"node">,
+): Promise<DayEntry[]> {
+  return db
+    .select({
+      nodeType: nodes.nodeType,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      createdAt: nodes.createdAt,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.objectNodeId, dayNodeId),
+        eq(claims.predicate, "OCCURRED_ON"),
+        eq(claims.status, "active"),
+      ),
+    );
+}
+
+export interface CollectedInput {
+  inputText: string;
+  /** Existing child period nodes — used to ensure PART_OF claims. */
+  childNodeIds: TypeId<"node">[];
+}
+
+/**
+ * Assemble the full prompt input for a period. Returns null when there is
+ * nothing to summarize (no content for a day; no summarized children for
+ * week/month/year).
+ */
+export async function collectPeriodInput(
+  db: DrizzleDB,
+  userId: string,
+  periodKey: string,
+  level: "day" | "week" | "month" | "year",
+): Promise<CollectedInput | null> {
+  if (level === "day") {
+    const dayNode = (
+      await fetchTemporalNodesByLabels(db, userId, [periodKey])
+    ).get(periodKey);
+    if (!dayNode) return null;
+    const entries = await fetchDayEntries(db, userId, dayNode.nodeId);
+    const inputText = buildDayInputText(periodKey, entries);
+    return inputText ? { inputText, childNodeIds: [] } : null;
+  }
+
+  if (level === "week") {
+    const dayKeys = weekDayKeys(periodKey);
+    const dayNodes = await fetchTemporalNodesByLabels(db, userId, dayKeys);
+    const inputText = buildWeekInputText(
+      periodKey,
+      dayKeys.map((key) => ({
+        key,
+        summary: summarizedDescriptionOf(dayNodes.get(key)),
+      })),
+    );
+    if (!inputText) return null;
+    return {
+      inputText,
+      childNodeIds: dayKeys
+        .map((key) => dayNodes.get(key)?.nodeId)
+        .filter((id): id is TypeId<"node"> => id !== undefined),
+    };
+  }
+
+  if (level === "month") {
+    const weeks = weeksOverlappingMonth(periodKey);
+    const weekNodes = await fetchTemporalNodesByLabels(
+      db,
+      userId,
+      weeks.map((w) => w.weekKey),
+    );
+    const inputText = buildMonthInputText(
+      periodKey,
+      weeks.map((w) => ({
+        weekKey: w.weekKey,
+        summary: summarizedDescriptionOf(weekNodes.get(w.weekKey)),
+        dayKeysInMonth: w.dayKeysInMonth,
+      })),
+    );
+    if (!inputText) return null;
+    return {
+      inputText,
+      childNodeIds: weeks
+        .map((w) => weekNodes.get(w.weekKey)?.nodeId)
+        .filter((id): id is TypeId<"node"> => id !== undefined),
+    };
+  }
+
+  const monthKeys = monthKeysOfYear(periodKey);
+  const monthNodes = await fetchTemporalNodesByLabels(db, userId, monthKeys);
+  const inputText = buildYearInputText(
+    periodKey,
+    monthKeys.map((key) => ({
+      key,
+      summary: summarizedDescriptionOf(monthNodes.get(key)),
+    })),
+  );
+  if (!inputText) return null;
+  return {
+    inputText,
+    childNodeIds: monthKeys
+      .map((key) => monthNodes.get(key)?.nodeId)
+      .filter((id): id is TypeId<"node"> => id !== undefined),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/lib/rollup/collect.test.ts --run`
+Expected: PASS. Then `pnpm run build:check` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rollup/collect.ts src/lib/rollup/collect.test.ts
+git commit -m "✨ feat(rollup): deterministic input builders, compaction, fingerprint"
+```
+
+### Task 6: `summarizePeriod` — one period, one LLM call
+
+**Files:**
+- Create: `src/lib/rollup/summarize-period.ts`
+- Test: `src/lib/rollup/summarize-period.test.ts`
+
+Flow per period: collect input → ensure period node → ensure `PART_OF` claims for existing children (before the fingerprint gate, so re-runs repair missing edges) → fingerprint match? skip : one `parseStructuredCompletion` call → write `description` + `additionalData.rollup` → re-embed (unless `shouldSkipEmbeddingPersistence()`).
+
+LLM mocking uses the existing production seam: `createCompletionClient` returns `getExtractionClientOverride()` when set (see `src/lib/ai.ts` / `src/utils/test-overrides.ts`) — no vitest module mocks needed.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/rollup/summarize-period.test.ts`:
+
+```typescript
+import { ensureRollupSource } from "./source";
+import { summarizePeriod } from "./summarize-period";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { createCompletionClient } from "~/lib/ai";
+import { ensurePeriodNode } from "~/lib/temporal";
+import { newTypeId } from "~/types/typeid";
+import {
+  resetTestOverrides,
+  setExtractionClientOverride,
+  setSkipEmbeddingPersistence,
+  type StubCompletionClient,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+/** All tables the rollup write path touches (embeddings are skipped). */
+export const ROLLUP_TEST_TABLES_SQL = `
+  CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+  CREATE TABLE "nodes" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "node_type" varchar(50) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "node_metadata" (
+    "id" text PRIMARY KEY NOT NULL,
+    "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "label" text,
+    "canonical_label" text,
+    "description" text,
+    "additional_data" jsonb,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+  );
+  CREATE TABLE "sources" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "type" varchar(50) NOT NULL,
+    "external_id" text NOT NULL,
+    "parent_source" text,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "metadata" jsonb,
+    "last_ingested_at" timestamp with time zone,
+    "status" varchar(20) DEFAULT 'pending',
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "deleted_at" timestamp with time zone,
+    "content_type" varchar(100),
+    "content_length" integer,
+    CONSTRAINT "sources_user_type_external_unique"
+      UNIQUE ("user_id", "type", "external_id")
+  );
+  CREATE TABLE "claims" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_value" text,
+    "predicate" varchar(80) NOT NULL,
+    "statement" text NOT NULL,
+    "description" text,
+    "metadata" jsonb,
+    "object_instant" timestamp with time zone,
+    "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "asserted_by_kind" varchar(24) NOT NULL,
+    "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+    "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "stated_at" timestamp with time zone NOT NULL,
+    "valid_from" timestamp with time zone,
+    "valid_to" timestamp with time zone,
+    "status" varchar(30) DEFAULT 'active' NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "rollup_state" (
+    "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id"),
+    "watermark" timestamp with time zone,
+    "pending_periods" jsonb DEFAULT '[]' NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+`;
+
+/** Stub LLM client that records prompts and returns canned summaries. */
+export function stubLlm(): {
+  client: StubCompletionClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const client = {
+    chat: {
+      completions: {
+        parse: async (body: {
+          messages: Array<{ content: string }>;
+        }) => {
+          const prompt = body.messages.map((m) => m.content).join("\n");
+          calls.push(prompt);
+          return {
+            choices: [
+              {
+                message: {
+                  parsed: { summary: `LLM summary #${calls.length}` },
+                },
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+        },
+      },
+    },
+  } as unknown as StubCompletionClient;
+  return { client, calls };
+}
+
+describeIfServer("summarizePeriod", () => {
+  const dbName = `memory_summarize_period_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  const userId = "user_sp";
+  let client: Client;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(ROLLUP_TEST_TABLES_SQL);
+    await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("skips a day with no linked content", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    const outcome = await summarizePeriod({
+      db,
+      userId,
+      periodKey: "2026-01-05",
+      client: openai,
+      rollupSourceId,
+    });
+    expect(outcome).toBe("skipped-empty");
+  });
+
+  it("summarizes a day with content, then fingerprint-skips a re-run", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    // Seed: a day node + one content node linked via OCCURRED_ON.
+    const dayNodeId = await ensurePeriodNode(db, userId, "2026-01-06");
+    const contentNodeId = newTypeId("node");
+    const contentSourceId = newTypeId("source");
+    await client.query(
+      `INSERT INTO "sources" ("id", "user_id", "type", "external_id")
+       VALUES ($1, $2, 'conversation', 'conv-1')`,
+      [contentSourceId, userId],
+    );
+    await client.query(
+      `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Conversation')`,
+      [contentNodeId, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata" ("id", "node_id", "label", "description")
+       VALUES ($1, $2, 'Standup', 'Talked about rollups with Sam.')`,
+      [newTypeId("node_metadata"), contentNodeId],
+    );
+    await client.query(
+      `INSERT INTO "claims" (
+        "id", "user_id", "subject_node_id", "object_node_id", "predicate",
+        "statement", "source_id", "asserted_by_kind", "stated_at"
+      ) VALUES ($1, $2, $3, $4, 'OCCURRED_ON', 'occurred', $5, 'system', now())`,
+      [newTypeId("claim"), userId, contentNodeId, dayNodeId, contentSourceId],
+    );
+
+    const params = {
+      db,
+      userId,
+      periodKey: "2026-01-06",
+      client: openai,
+      rollupSourceId,
+    };
+    expect(await summarizePeriod(params)).toBe("summarized");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("Standup");
+
+    const meta = await client.query(
+      `SELECT m."description", m."additional_data" FROM "node_metadata" m
+       WHERE m."node_id" = $1`,
+      [dayNodeId],
+    );
+    expect(meta.rows[0].description).toBe("LLM summary #1");
+    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+
+    // Unchanged input → no second LLM call.
+    expect(await summarizePeriod(params)).toBe("skipped-unchanged");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("summarizes a week from day summaries and ensures PART_OF claims idempotently", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    // 2026-01-06 already has a summarized day node from the previous test.
+    const params = {
+      db,
+      userId,
+      periodKey: "2026-W02", // Jan 5–11 2026
+      client: openai,
+      rollupSourceId,
+    };
+    expect(await summarizePeriod(params)).toBe("summarized");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("2026-01-06: LLM summary");
+    expect(calls[0]).toContain("(no summarized activity)");
+
+    const partOf = await client.query(
+      `SELECT c."statement" FROM "claims" c WHERE c."predicate" = 'PART_OF' AND c."user_id" = $1`,
+      [userId],
+    );
+    // Only the existing day node gets an edge (the other 6 days have no node).
+    expect(partOf.rowCount).toBe(1);
+    expect(partOf.rows[0].statement).toBe("2026-01-06 is part of 2026-W02");
+
+    // Re-run: fingerprint-skips, and does not duplicate the claim.
+    expect(await summarizePeriod(params)).toBe("skipped-unchanged");
+    const partOfAgain = await client.query(
+      `SELECT count(*)::int AS n FROM "claims" WHERE "predicate" = 'PART_OF' AND "user_id" = $1`,
+      [userId],
+    );
+    expect(partOfAgain.rows[0].n).toBe(1);
+  });
+
+  it("skips a week whose days have no summaries", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    expect(
+      await summarizePeriod({
+        db,
+        userId,
+        periodKey: "2026-W30",
+        client: openai,
+        rollupSourceId,
+      }),
+    ).toBe("skipped-empty");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/rollup/summarize-period.test.ts --run`
+Expected: FAIL — cannot resolve `./summarize-period`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/rollup/summarize-period.ts`:
+
+```typescript
+/**
+ * Summarize a single rollup period: deterministic input → fingerprint
+ * gate → one structured LLM completion → summary written to the period
+ * node's `nodeMetadata.description` (+ `additionalData.rollup` marker) →
+ * embedding refresh → idempotent PART_OF containment claims.
+ */
+import {
+  collectPeriodInput,
+  fingerprintOf,
+  readRollupMeta,
+} from "./collect";
+import { periodLevelOf, type PeriodLevel } from "./period";
+import { and, eq, inArray } from "drizzle-orm";
+import type OpenAI from "openai";
+import { zodResponseFormat } from "openai/helpers/zod.mjs";
+import { z } from "zod";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeEmbeddings, nodeMetadata } from "~/db/schema";
+import { parseStructuredCompletion } from "~/lib/ai";
+import { generateEmbeddings } from "~/lib/embeddings";
+import { ensurePeriodNode } from "~/lib/temporal";
+import type { TypeId } from "~/types/typeid";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
+import { shouldSkipEmbeddingPersistence } from "~/utils/test-overrides";
+
+const LEVEL_PROMPT_INTRO: Record<PeriodLevel, string> = {
+  day: `You are summarizing one day of a person's life from entries in their personal memory graph (conversations, documents, events).
+
+Write a concise narrative summary of the day. Be concrete and specific: name the people, projects, places, decisions, and outcomes involved. Use past tense. Skip meta-commentary and filler; if entries are sparse, keep the summary proportionally short.`,
+  week: `You are summarizing one week of a person's life from their daily summaries.
+
+Write a narrative summary of the week's arc: key events, recurring themes, progress on projects, notable people, decisions, and changes. Synthesize across days rather than listing day-by-day. Use past tense; be concrete and specific. Days marked "(no summarized activity)" simply have no recorded data — don't speculate about them.`,
+  month: `You are summarizing one month of a person's life from weekly summaries. Boundary weeks may only partially overlap the month — weigh only the overlapping days.
+
+Write a narrative summary of the month: dominant themes, milestones, project progress, important relationships, and notable shifts. Use past tense; be concrete and specific.`,
+  year: `You are summarizing one year of a person's life from monthly summaries.
+
+Write a narrative summary of the year: major arcs, milestones, turning points, recurring themes, and how things changed from beginning to end. Use past tense; be concrete and specific.`,
+};
+
+const periodSummarySchema = z.object({
+  summary: z
+    .string()
+    .describe(
+      "Narrative summary of the period; concrete, specific, past tense",
+    ),
+});
+
+export type SummarizePeriodOutcome =
+  | "summarized"
+  | "skipped-unchanged"
+  | "skipped-empty";
+
+export interface SummarizePeriodParams {
+  db: DrizzleDB;
+  userId: string;
+  periodKey: string;
+  /** Completion client created once per sweep (task: temporal_summary). */
+  client: OpenAI;
+  /** Per-user synthetic rollup source backing PART_OF claims. */
+  rollupSourceId: TypeId<"source">;
+}
+
+export async function summarizePeriod({
+  db,
+  userId,
+  periodKey,
+  client,
+  rollupSourceId,
+}: SummarizePeriodParams): Promise<SummarizePeriodOutcome> {
+  const level = periodLevelOf(periodKey);
+
+  const collected = await collectPeriodInput(db, userId, periodKey, level);
+  if (!collected) return "skipped-empty";
+
+  const nodeId = await ensurePeriodNode(db, userId, periodKey);
+
+  // Containment edges first (and on every run) so a previously interrupted
+  // run is repaired even when the summary itself fingerprint-skips.
+  await ensurePartOfClaims(
+    db,
+    userId,
+    collected.childNodeIds,
+    nodeId,
+    periodKey,
+    rollupSourceId,
+  );
+
+  const fingerprint = fingerprintOf(collected.inputText);
+  const [meta] = await db
+    .select({
+      description: nodeMetadata.description,
+      additionalData: nodeMetadata.additionalData,
+    })
+    .from(nodeMetadata)
+    .where(eq(nodeMetadata.nodeId, nodeId))
+    .limit(1);
+  if (!meta) {
+    throw new Error(`Period node ${periodKey} (${nodeId}) has no metadata row`);
+  }
+  if (readRollupMeta(meta.additionalData)?.fingerprint === fingerprint) {
+    return "skipped-unchanged";
+  }
+
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [
+        {
+          role: "user",
+          content: `${LEVEL_PROMPT_INTRO[level]}\n\n${collected.inputText}`,
+        },
+      ],
+      model: modelForTask("temporal_summary"),
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(periodSummarySchema, "period_summary"),
+    },
+    { task: "temporal_summary", userId },
+  );
+  const parsed = completion.choices[0]?.message.parsed;
+  if (!parsed) {
+    throw new Error(`Failed to parse period summary for ${periodKey}`);
+  }
+
+  const existingData =
+    meta.additionalData &&
+    typeof meta.additionalData === "object" &&
+    !Array.isArray(meta.additionalData)
+      ? (meta.additionalData as Record<string, unknown>)
+      : {};
+  await db
+    .update(nodeMetadata)
+    .set({
+      description: parsed.summary,
+      additionalData: {
+        ...existingData,
+        rollup: { fingerprint, summarizedAt: new Date().toISOString() },
+      },
+    })
+    .where(eq(nodeMetadata.nodeId, nodeId));
+
+  if (!shouldSkipEmbeddingPersistence()) {
+    const embText = `${periodKey}: ${parsed.summary}`;
+    const embResponse = await generateEmbeddings({
+      model: "jina-embeddings-v3",
+      task: "retrieval.passage",
+      input: [embText],
+      truncate: true,
+    });
+    const embedding = embResponse.data[0]?.embedding;
+    if (embedding) {
+      await db.delete(nodeEmbeddings).where(eq(nodeEmbeddings.nodeId, nodeId));
+      await db.insert(nodeEmbeddings).values({
+        nodeId,
+        embedding,
+        modelName: "jina-embeddings-v3",
+      });
+    }
+  }
+
+  return "summarized";
+}
+
+/** Child PART_OF parent claims for every existing child node, idempotent. */
+async function ensurePartOfClaims(
+  db: DrizzleDB,
+  userId: string,
+  childNodeIds: TypeId<"node">[],
+  parentNodeId: TypeId<"node">,
+  parentKey: string,
+  rollupSourceId: TypeId<"source">,
+): Promise<void> {
+  if (childNodeIds.length === 0) return;
+
+  const existing = await db
+    .select({ subjectNodeId: claims.subjectNodeId })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.objectNodeId, parentNodeId),
+        eq(claims.predicate, "PART_OF"),
+        eq(claims.status, "active"),
+        inArray(claims.subjectNodeId, childNodeIds),
+      ),
+    );
+  const linked = new Set(existing.map((c) => c.subjectNodeId));
+  const missing = childNodeIds.filter((id) => !linked.has(id));
+  if (missing.length === 0) return;
+
+  const labels = await db
+    .select({ nodeId: nodeMetadata.nodeId, label: nodeMetadata.label })
+    .from(nodeMetadata)
+    .where(inArray(nodeMetadata.nodeId, missing));
+  const labelOf = new Map(labels.map((l) => [l.nodeId, l.label]));
+
+  await db.insert(claims).values(
+    missing.map((childNodeId) => ({
+      userId,
+      predicate: "PART_OF" as const,
+      subjectNodeId: childNodeId,
+      objectNodeId: parentNodeId,
+      statement: `${labelOf.get(childNodeId) ?? childNodeId} is part of ${parentKey}`,
+      sourceId: rollupSourceId,
+      scope: "personal" as const,
+      assertedByKind: "system" as const,
+      statedAt: new Date(),
+      status: "active" as const,
+    })),
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm run test -- src/lib/rollup/summarize-period.test.ts --run`
+Expected: PASS (4 tests). Then `pnpm run build:check` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/rollup/summarize-period.ts src/lib/rollup/summarize-period.test.ts
+git commit -m "✨ feat(rollup): per-period summarization with fingerprint gate and PART_OF claims"
+```
+
+### Task 7: The sweep job (`runRollup`)
+
+**Files:**
+- Create: `src/lib/jobs/rollup.ts`
+- Create: `src/lib/schemas/rollup.ts`
+- Test: `src/lib/jobs/rollup.test.ts`
+
+The sweep: discover stale days from `OCCURRED_ON` claims past the watermark → expand to ancestors ∪ `pendingPeriods` → apply `startDate` floor (exclude + purge) and completeness filter (defer) → process bottom-up within the LLM-call budget → commit watermark + pending. The watermark ALWAYS advances to the max claim `createdAt` seen; deferred/failed work is carried only by `pendingPeriods`.
+
+- [ ] **Step 1: Write the request/response schemas**
+
+Create `src/lib/schemas/rollup.ts`:
+
+```typescript
+import { z } from "zod";
+
+export const rollupRequestSchema = z.object({
+  userId: z.string().min(1),
+  /** Hard cap on LLM calls this sweep; leftovers resume on the next call. */
+  maxLlmCalls: z.number().int().positive().max(500).default(50),
+  /**
+   * History floor (yyyy-MM-dd). Periods ending before this are excluded
+   * outright — never summarized, purged from pending. Prevents a first
+   * sweep over a backlogged account from paying for ancient history.
+   */
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "startDate must be yyyy-MM-dd")
+    .optional(),
+});
+
+export type RollupRequest = z.infer<typeof rollupRequestSchema>;
+
+export const rollupResponseSchema = z.object({
+  message: z.string(),
+  enqueued: z.boolean(),
+});
+
+export type RollupResponse = z.infer<typeof rollupResponseSchema>;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/lib/jobs/rollup.test.ts`. It reuses the table SQL + LLM stub exported from `src/lib/rollup/summarize-period.test.ts` (`ROLLUP_TEST_TABLES_SQL`, `stubLlm`):
+
+```typescript
+import { runRollup } from "./rollup";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { ensurePeriodNode } from "~/lib/temporal";
+import {
+  ROLLUP_TEST_TABLES_SQL,
+  stubLlm,
+} from "~/lib/rollup/summarize-period.test";
+import { newTypeId } from "~/types/typeid";
+import {
+  resetTestOverrides,
+  setExtractionClientOverride,
+  setSkipEmbeddingPersistence,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+const TODAY = "2026-06-15";
+
+describeIfServer("runRollup", () => {
+  const dbName = `memory_rollup_job_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+  let db: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(ROLLUP_TEST_TABLES_SQL);
+    db = drizzle(client, { schema, casing: "snake_case" });
+  });
+
+  afterEach(() => {
+    resetTestOverrides();
+    setSkipEmbeddingPersistence(true);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  async function seedUser(userId: string): Promise<void> {
+    await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+  }
+
+  /** A content node OCCURRED_ON the given day (creates the day node too). */
+  async function seedContent(
+    userId: string,
+    dayKey: string,
+    label: string,
+  ): Promise<void> {
+    const dayNodeId = await ensurePeriodNode(db, userId, dayKey);
+    const contentNodeId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    await client.query(
+      `INSERT INTO "sources" ("id", "user_id", "type", "external_id")
+       VALUES ($1, $2, 'conversation', $3)`,
+      [sourceId, userId, `conv-${label}`],
+    );
+    await client.query(
+      `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Conversation')`,
+      [contentNodeId, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata" ("id", "node_id", "label", "description")
+       VALUES ($1, $2, $3, 'Some details.')`,
+      [newTypeId("node_metadata"), contentNodeId, label],
+    );
+    await client.query(
+      `INSERT INTO "claims" (
+        "id", "user_id", "subject_node_id", "object_node_id", "predicate",
+        "statement", "source_id", "asserted_by_kind", "stated_at"
+      ) VALUES ($1, $2, $3, $4, 'OCCURRED_ON', 'occurred', $5, 'system', now())`,
+      [newTypeId("claim"), userId, contentNodeId, dayNodeId, sourceId],
+    );
+  }
+
+  async function pendingOf(userId: string): Promise<string[]> {
+    const rows = await client.query(
+      `SELECT "pending_periods" FROM "rollup_state" WHERE "user_id" = $1`,
+      [userId],
+    );
+    return rows.rows[0]?.pending_periods ?? [];
+  }
+
+  async function summaryOf(userId: string, label: string): Promise<string | null> {
+    const rows = await client.query(
+      `SELECT m."description" FROM "node_metadata" m
+       JOIN "nodes" n ON n."id" = m."node_id"
+       WHERE n."user_id" = $1 AND m."label" = $2 AND m."additional_data" -> 'rollup' IS NOT NULL`,
+      [userId, label],
+    );
+    return rows.rows[0]?.description ?? null;
+  }
+
+  it("builds the full hierarchy bottom-up and defers the open year", async () => {
+    const userId = "u_full";
+    await seedUser(userId);
+    // W02 2026 = Jan 5–11; W03 = Jan 12–18.
+    await seedContent(userId, "2026-01-05", "Kickoff");
+    await seedContent(userId, "2026-01-07", "Design review");
+    await seedContent(userId, "2026-01-13", "Retro");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+
+    // 3 days + 2 weeks + 1 month = 6; year 2026 is still open.
+    expect(result).toMatchObject({ summarized: 6, failed: 0 });
+    expect(calls).toHaveLength(6);
+    expect(await summaryOf(userId, "2026-01-05")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-W02")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-W03")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-01")).toMatch(/^LLM summary/);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+
+    // PART_OF: 3 day→week + 2 week→month (only existing week nodes link).
+    const partOf = await client.query(
+      `SELECT count(*)::int AS n FROM "claims" WHERE "user_id" = $1 AND "predicate" = 'PART_OF'`,
+      [userId],
+    );
+    expect(partOf.rows[0].n).toBe(5);
+
+    const state = await client.query(
+      `SELECT "watermark" FROM "rollup_state" WHERE "user_id" = $1`,
+      [userId],
+    );
+    expect(state.rows[0].watermark).not.toBeNull();
+  });
+
+  it("costs zero LLM calls when nothing changed", async () => {
+    const userId = "u_full";
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    expect(result.summarized).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("summarizes a completed year", async () => {
+    const userId = "u_year";
+    await seedUser(userId);
+    await seedContent(userId, "2025-03-10", "Spring planning");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // day + week (2025-W11) + month (2025-03) + year (2025) = 4.
+    expect(result.summarized).toBe(4);
+    expect(calls).toHaveLength(4);
+    expect(await summaryOf(userId, "2025")).toMatch(/^LLM summary/);
+    expect(await pendingOf(userId)).toEqual([]);
+  });
+
+  it("re-summarizes the cascade when old content is backfilled", async () => {
+    const userId = "u_full";
+    // New claim (createdAt = now > watermark) pointing at the old day.
+    await seedContent(userId, "2026-01-07", "Backfilled memo");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // Day 2026-01-07 + week W02 + month 2026-01 re-run; W03 untouched.
+    expect(result.summarized).toBe(3);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("defers over-budget work to pending and resumes on the next sweep", async () => {
+    const userId = "u_budget";
+    await seedUser(userId);
+    await seedContent(userId, "2026-01-05", "A");
+    await seedContent(userId, "2026-01-06", "B");
+    await seedContent(userId, "2026-01-07", "C");
+    await seedContent(userId, "2026-01-08", "D");
+    await seedContent(userId, "2026-01-12", "E");
+
+    const { client: llm1, calls: calls1 } = stubLlm();
+    setExtractionClientOverride(llm1);
+    const first = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 3,
+      todayKey: TODAY,
+    });
+    expect(first.summarized).toBe(3);
+    expect(calls1).toHaveLength(3);
+    const pendingAfterFirst = await pendingOf(userId);
+    expect(pendingAfterFirst).toContain("2026-01-08");
+    expect(pendingAfterFirst).toContain("2026-W02");
+
+    const { client: llm2, calls: calls2 } = stubLlm();
+    setExtractionClientOverride(llm2);
+    const second = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // Remaining: days 01-08, 01-12 + weeks W02, W03 + month 2026-01 = 5.
+    expect(second.summarized).toBe(5);
+    expect(calls2).toHaveLength(5);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("startDate excludes pre-floor periods and purges them from pending", async () => {
+    const userId = "u_floor";
+    await seedUser(userId);
+    await seedContent(userId, "2025-12-15", "Old era");
+    await seedContent(userId, "2026-01-06", "New era");
+
+    // First sweep with a zero budget: everything ready lands in pending.
+    const { client: llm0 } = stubLlm();
+    setExtractionClientOverride(llm0);
+    const zero = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 0,
+      todayKey: TODAY,
+    });
+    expect(zero.summarized).toBe(0);
+    expect(await pendingOf(userId)).toContain("2025-12-15");
+
+    // Second sweep with the floor: 2025 periods are gone for good.
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      startDate: "2026-01-01",
+      todayKey: TODAY,
+    });
+    // 2026-01-06 + W02 + 2026-01 = 3 (W02 ends 2026-01-11 ≥ floor).
+    expect(result.summarized).toBe(3);
+    expect(calls).toHaveLength(3);
+    expect(await summaryOf(userId, "2025-12-15")).toBeNull();
+    expect(await summaryOf(userId, "2025-12")).toBeNull();
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm run test -- src/lib/jobs/rollup.test.ts --run`
+Expected: FAIL — cannot resolve `./rollup`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/lib/jobs/rollup.ts`:
+
+```typescript
+/**
+ * Temporal rollup sweep (see
+ * docs/superpowers/specs/2026-06-12-temporal-rollup-design.md).
+ *
+ * Catch-up semantics: discover days touched by OCCURRED_ON claims since
+ * the per-user watermark, expand to ancestor periods, union the pending
+ * set, then summarize completed periods bottom-up within an LLM-call
+ * budget. Never scheduled internally — triggered via POST /rollup.
+ */
+import {
+  ancestorKeysForDay,
+  dayKeyOf,
+  isDayKey,
+  isPeriodComplete,
+  periodEndDayKey,
+  sortForProcessing,
+} from "../rollup/period";
+import { ensureRollupSource } from "../rollup/source";
+import { summarizePeriod } from "../rollup/summarize-period";
+import { and, eq, gt, type SQL } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes, rollupState } from "~/db/schema";
+import { createCompletionClient } from "~/lib/ai";
+
+export interface RunRollupParams {
+  db: DrizzleDB;
+  userId: string;
+  /** Hard cap on LLM calls this sweep (fingerprint skips are free). */
+  maxLlmCalls: number;
+  /** History floor: periods ending before this day key are excluded. */
+  startDate?: string | undefined;
+  /** Test seam for completeness checks; defaults to the real today. */
+  todayKey?: string | undefined;
+}
+
+export interface RollupJobResult {
+  summarized: number;
+  skippedUnchanged: number;
+  skippedEmpty: number;
+  failed: number;
+  /** Periods left in pendingPeriods (incomplete, over budget, or failed). */
+  deferred: number;
+}
+
+export async function runRollup({
+  db,
+  userId,
+  maxLlmCalls,
+  startDate,
+  todayKey = dayKeyOf(new Date()),
+}: RunRollupParams): Promise<RollupJobResult> {
+  const [state] = await db
+    .select()
+    .from(rollupState)
+    .where(eq(rollupState.userId, userId))
+    .limit(1);
+
+  // 1. Discover: day labels touched by active OCCURRED_ON claims since
+  //    the watermark (all claims on the first sweep).
+  const conditions: SQL[] = [
+    eq(claims.userId, userId),
+    eq(claims.predicate, "OCCURRED_ON"),
+    eq(claims.status, "active"),
+    eq(nodes.nodeType, "Temporal"),
+  ];
+  if (state?.watermark) {
+    conditions.push(gt(claims.createdAt, state.watermark));
+  }
+  const touched = await db
+    .select({
+      dayLabel: nodeMetadata.label,
+      claimCreatedAt: claims.createdAt,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.objectNodeId))
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(and(...conditions));
+
+  let watermark = state?.watermark ?? null;
+  const touchedDayKeys = new Set<string>();
+  for (const row of touched) {
+    if (!watermark || row.claimCreatedAt > watermark) {
+      watermark = row.claimCreatedAt;
+    }
+    if (row.dayLabel && isDayKey(row.dayLabel)) {
+      touchedDayKeys.add(row.dayLabel);
+    }
+  }
+
+  // 2. Expand to ancestors; union the carried-over pending set.
+  const workSet = new Set<string>(state?.pendingPeriods ?? []);
+  for (const dayKey of touchedDayKeys) {
+    workSet.add(dayKey);
+    for (const ancestor of ancestorKeysForDay(dayKey)) {
+      workSet.add(ancestor);
+    }
+  }
+
+  // 3. Filter: startDate floor excludes outright (incl. purging pending);
+  //    incomplete periods are deferred until they end.
+  const pending = new Set<string>();
+  const ready: string[] = [];
+  for (const key of workSet) {
+    if (startDate !== undefined && periodEndDayKey(key) < startDate) continue;
+    if (!isPeriodComplete(key, todayKey)) {
+      pending.add(key);
+      continue;
+    }
+    ready.push(key);
+  }
+
+  // 4. Process bottom-up, oldest first, within budget. A failing period
+  //    is logged, left pending, and must not block the rest.
+  const result: RollupJobResult = {
+    summarized: 0,
+    skippedUnchanged: 0,
+    skippedEmpty: 0,
+    failed: 0,
+    deferred: 0,
+  };
+  let budget = maxLlmCalls;
+  const client = await createCompletionClient(userId, {
+    task: "temporal_summary",
+  });
+  const rollupSourceId = await ensureRollupSource(db, userId);
+
+  for (const periodKey of sortForProcessing(ready)) {
+    if (budget <= 0) {
+      pending.add(periodKey);
+      continue;
+    }
+    try {
+      const outcome = await summarizePeriod({
+        db,
+        userId,
+        periodKey,
+        client,
+        rollupSourceId,
+      });
+      if (outcome === "summarized") {
+        budget -= 1;
+        result.summarized += 1;
+      } else if (outcome === "skipped-unchanged") {
+        result.skippedUnchanged += 1;
+      } else {
+        result.skippedEmpty += 1;
+      }
+    } catch (error) {
+      console.error(
+        `Rollup: failed to summarize ${periodKey} for user ${userId}:`,
+        error,
+      );
+      pending.add(periodKey);
+      result.failed += 1;
+    }
+  }
+  result.deferred = pending.size;
+
+  // 5. Commit state. The watermark always advances; pending carries the
+  //    deferred work.
+  const pendingPeriods = [...pending].sort();
+  await db
+    .insert(rollupState)
+    .values({
+      userId,
+      watermark,
+      pendingPeriods,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: rollupState.userId,
+      set: { watermark, pendingPeriods, updatedAt: new Date() },
+    });
+
+  return result;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm run test -- src/lib/jobs/rollup.test.ts --run`
+Expected: PASS (6 tests). Then `pnpm run build:check` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/jobs/rollup.ts src/lib/jobs/rollup.test.ts src/lib/schemas/rollup.ts
+git commit -m "✨ feat(rollup): catch-up sweep job with watermark, budget, and startDate floor"
+```
+
+### Task 8: Queue registration + `POST /rollup` route
+
+**Files:**
+- Modify: `src/lib/queues.ts`
+- Create: `src/routes/rollup.post.ts`
+- Test: `src/rollup-route.test.ts` (route tests live at `src/` top level, e.g. `src/query-recent-changes-route.test.ts`)
+
+- [ ] **Step 1: Register the job in `src/lib/queues.ts`**
+
+Add to the imports at the top:
+
+```typescript
+import { rollupRequestSchema } from "./schemas/rollup";
+```
+
+Add directly below `SUMMARIZE_JOB_OPTIONS`:
+
+```typescript
+/**
+ * Retry profile for the temporal-rollup sweep. The sweep is idempotent
+ * (watermark + per-period fingerprints), so a BullMQ retry after a partial
+ * failure only re-pays for periods that were never written. `removeOnFail`
+ * keeps a short failure history without blocking the deterministic
+ * `rollup:<userId>` jobId from being re-enqueued later (the route removes
+ * finished/failed jobs before re-adding).
+ */
+export const ROLLUP_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: { type: "exponential", delay: 1_000 },
+  removeOnComplete: true,
+  removeOnFail: 100,
+} as const;
+```
+
+Add a worker branch directly after the `"summarize"` branch (before `} else if (job.name === "dream")`):
+
+```typescript
+      } else if (job.name === "rollup") {
+        const { userId, maxLlmCalls, startDate } = rollupRequestSchema.parse(
+          job.data,
+        );
+        console.log(`Starting rollup job for user ${userId}`);
+        const { runRollup } = await import("./jobs/rollup");
+        const result = await runRollup({
+          db,
+          userId,
+          maxLlmCalls,
+          ...(startDate !== undefined ? { startDate } : {}),
+        });
+        console.log(
+          `Rollup for user ${userId}: ${result.summarized} summarized, ${result.skippedUnchanged} unchanged, ${result.skippedEmpty} empty, ${result.failed} failed, ${result.deferred} deferred.`,
+        );
+```
+
+- [ ] **Step 2: Write the failing route test**
+
+Create `src/rollup-route.test.ts`:
+
+```typescript
+import handler from "./routes/rollup.post";
+import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const queueMocks = vi.hoisted(() => ({
+  getJob: vi.fn(),
+  add: vi.fn(),
+}));
+
+vi.mock("~/lib/queues", () => ({
+  batchQueue: { getJob: queueMocks.getJob, add: queueMocks.add },
+  ROLLUP_JOB_OPTIONS: {
+    attempts: 3,
+    backoff: { type: "exponential", delay: 1_000 },
+    removeOnComplete: true,
+    removeOnFail: 100,
+  },
+}));
+
+describe("POST /rollup", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("applies defaults and enqueues with a deterministic jobId", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    queueMocks.getJob.mockResolvedValue(undefined);
+    queueMocks.add.mockResolvedValue({});
+
+    const response = await handler({} as H3Event);
+
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      "rollup",
+      { userId: "user_r", maxLlmCalls: 50 },
+      expect.objectContaining({ jobId: "rollup:user_r", attempts: 3 }),
+    );
+    expect(response).toMatchObject({ enqueued: true });
+  });
+
+  it("passes startDate and maxLlmCalls through", async () => {
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_r",
+      maxLlmCalls: 10,
+      startDate: "2026-01-01",
+    }));
+    queueMocks.getJob.mockResolvedValue(undefined);
+    queueMocks.add.mockResolvedValue({});
+
+    await handler({} as H3Event);
+
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      "rollup",
+      { userId: "user_r", maxLlmCalls: 10, startDate: "2026-01-01" },
+      expect.objectContaining({ jobId: "rollup:user_r" }),
+    );
+  });
+
+  it("does not double-enqueue while a sweep is queued or running", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    queueMocks.getJob.mockResolvedValue({
+      getState: async () => "waiting",
+      remove: vi.fn(),
+    });
+
+    const response = await handler({} as H3Event);
+
+    expect(queueMocks.add).not.toHaveBeenCalled();
+    expect(response).toMatchObject({ enqueued: false });
+  });
+
+  it("removes a finished job with the same id, then re-enqueues", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    const remove = vi.fn();
+    queueMocks.getJob.mockResolvedValue({
+      getState: async () => "failed",
+      remove,
+    });
+    queueMocks.add.mockResolvedValue({});
+
+    const response = await handler({} as H3Event);
+
+    expect(remove).toHaveBeenCalled();
+    expect(queueMocks.add).toHaveBeenCalled();
+    expect(response).toMatchObject({ enqueued: true });
+  });
+
+  it("rejects a malformed startDate before enqueueing", async () => {
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_r",
+      startDate: "Jan 1",
+    }));
+
+    await expect(handler({} as H3Event)).rejects.toThrow();
+    expect(queueMocks.add).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm run test -- src/rollup-route.test.ts --run`
+Expected: FAIL — cannot resolve `./routes/rollup.post`.
+
+- [ ] **Step 4: Write the route**
+
+Create `src/routes/rollup.post.ts`:
+
+```typescript
+/**
+ * `POST /rollup` — enqueue a temporal-rollup catch-up sweep for a user.
+ *
+ * Fire-and-forget: the sweep runs as a BullMQ job. A deterministic
+ * `rollup:<userId>` jobId collapses concurrent triggers for the same user
+ * into one queued sweep. Cost control belongs to the caller: `maxLlmCalls`
+ * caps this sweep, `startDate` floors how far back history is summarized.
+ */
+// `readBody` is deliberately NOT imported: Nitro auto-imports it globally
+// (same as src/routes/digest.post.ts), which is what lets the route test
+// stub it via vi.stubGlobal.
+import { defineEventHandler } from "h3";
+import { batchQueue, ROLLUP_JOB_OPTIONS } from "~/lib/queues";
+import {
+  rollupRequestSchema,
+  rollupResponseSchema,
+} from "~/lib/schemas/rollup";
+
+export default defineEventHandler(async (event) => {
+  const params = rollupRequestSchema.parse(await readBody(event));
+  const jobId = `rollup:${params.userId}`;
+
+  const existing = await batchQueue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state === "active" || state === "waiting" || state === "delayed") {
+      return rollupResponseSchema.parse({
+        message: `Rollup already queued for user ${params.userId}.`,
+        enqueued: false,
+      });
+    }
+    // Completed/failed leftovers block re-use of the deterministic jobId.
+    await existing.remove();
+  }
+
+  await batchQueue.add("rollup", params, { ...ROLLUP_JOB_OPTIONS, jobId });
+  console.log(`Enqueued 'rollup' job for user: ${params.userId}`);
+
+  return rollupResponseSchema.parse({
+    message: `Rollup job for user ${params.userId} enqueued successfully.`,
+    enqueued: true,
+  });
+});
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm run test -- src/rollup-route.test.ts --run`
+Expected: PASS (5 tests). Then `pnpm run build:check` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/queues.ts src/routes/rollup.post.ts src/rollup-route.test.ts
+git commit -m "✨ feat(rollup): POST /rollup route and BullMQ job registration"
+```
+
+---
+
+### Task 9: SDK method
+
+**Files:**
+- Modify: `src/sdk/memory-client.ts`
+- Modify: `src/sdk/index.ts`
+
+- [ ] **Step 1: Add the `rollup` method to `MemoryClient`**
+
+In `src/sdk/memory-client.ts`, add to the schema imports (match the existing `.js`-suffixed import style, alphabetical placement among the other `../lib/schemas/*` imports):
+
+```typescript
+import {
+  rollupResponseSchema,
+  type RollupRequest,
+  type RollupResponse,
+} from "../lib/schemas/rollup.js";
+```
+
+Add the method directly after the existing `summarize` method:
+
+```typescript
+  /**
+   * Trigger a temporal-rollup catch-up sweep (day/week/month/year summary
+   * nodes). Fire-and-forget; `maxLlmCalls` caps the sweep's LLM spend and
+   * `startDate` floors how far back history is summarized.
+   */
+  async rollup(payload: RollupRequest): Promise<RollupResponse> {
+    return this._fetch("POST", "/rollup", rollupResponseSchema, payload);
+  }
+```
+
+- [ ] **Step 2: Export the schemas from the SDK**
+
+In `src/sdk/index.ts`, add (next to the `summarize.js` export line):
+
+```typescript
+export * from "../lib/schemas/rollup.js";
+```
+
+- [ ] **Step 3: Verify the SDK builds**
+
+Run: `pnpm run build:check && pnpm run build-sdk`
+Expected: both clean (tsc, structured-output check, SDK build + verify script).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/sdk/memory-client.ts src/sdk/index.ts
+git commit -m "✨ feat(sdk): rollup() trigger for temporal summarization"
+```
+
+---
+
+### Task 10: Final validation
+
+- [ ] **Step 1: Full verification gates**
+
+Run, in order, expecting every one clean:
+
+```bash
+pnpm run build:check
+pnpm run lint
+pnpm run format
+pnpm run test -- --run
+```
+
+If `pnpm run format` fails, run `pnpm run format:fix` and re-check. If any test outside this feature fails, STOP and report BLOCKED — do not "fix" unrelated tests.
+
+- [ ] **Step 2: Mark the spec as implemented**
+
+In `docs/superpowers/specs/2026-06-12-temporal-rollup-design.md`, change the Status line to:
+
+```markdown
+**Status:** Implemented — plan at docs/superpowers/plans/2026-06-12-temporal-rollup.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-12-temporal-rollup-design.md docs/superpowers/plans/2026-06-12-temporal-rollup.md
+git commit -m "📚 docs(rollup): mark temporal rollup spec implemented"
+```
+
+---
+
+## Notes for the executor
+
+- **Test DB**: integration suites self-skip when Postgres on :5431 is unreachable — a "pass" with everything skipped is NOT a pass. Start services with `docker compose up -d` first and confirm the suites actually ran.
+- **No internal scheduling**: do not add cron/intervals anywhere; the only trigger is `POST /rollup`.
+- **Don't touch** `pendingPeriods` semantics casually: the watermark always advances; pending is the only carrier of deferred work. Both tests in Task 7 encode this.
+- **`runRollup` accepts `maxLlmCalls: 0`** at the function level (used by tests to force-defer); the HTTP schema floor is 1 — that difference is intentional.
+- The `summarize-period.test.ts` file deliberately exports `ROLLUP_TEST_TABLES_SQL` and `stubLlm` for reuse by `rollup.test.ts`.
+
+
+
+
+

--- a/docs/superpowers/plans/2026-06-12-temporal-rollup.md
+++ b/docs/superpowers/plans/2026-06-12-temporal-rollup.md
@@ -11,6 +11,7 @@
 **Tech Stack:** Nitro/h3, Drizzle + Postgres, BullMQ, OpenAI SDK (`parseStructuredCompletion` + `zodResponseFormat`), date-fns, Zod v4, vitest (test Postgres on port **5431**; CI does NOT run vitest — run tests locally).
 
 **Conventions that apply to every task:**
+
 - Package manager: `pnpm`. Run `pnpm run test -- <file> --run` (vitest), `pnpm run build:check` (tsc + structured-output check), `pnpm run lint`, `pnpm run format`.
 - Commit messages: `<emoji> <type>(<scope>): <subject>` (✨ feat, ✅ test, ♻️ refactor, 📚 docs). Stage explicit paths only — never `git add -A` or `.`.
 - Imports use the `~` alias for `src` (e.g. `~/db/schema`). Within `src/lib/**`, relative imports of siblings are the norm (see existing files).
@@ -19,27 +20,28 @@
 
 ## File structure
 
-| File | Responsibility |
-| --- | --- |
-| `src/lib/rollup/period.ts` (+ `.test.ts`) | Pure period-key math: levels, parents/children, completeness, ordering |
-| `src/lib/rollup/collect.ts` (+ `.test.ts`) | Deterministic input assembly + compaction (pure builders), sha256 fingerprint, defensive `additionalData.rollup` reader, thin DB fetchers |
-| `src/lib/rollup/source.ts` (+ `.test.ts`) | Per-user synthetic `"rollup"` source (for `PART_OF` claims' NOT NULL `sourceId`) |
-| `src/lib/rollup/summarize-period.ts` (+ `.test.ts`) | One period: collect → ensure node → ensure `PART_OF` claims → fingerprint check → one LLM call → write description + re-embed |
-| `src/lib/jobs/rollup.ts` (+ `.test.ts`) | The sweep: discovery, work-set expansion, startDate/completeness filtering, budgeted bottom-up processing, state commit |
-| `src/lib/temporal.ts` | Generalize: add `ensurePeriodNode`, make `ensureDayNode` delegate |
-| `src/lib/schemas/rollup.ts` | Request/response Zod schemas |
-| `src/routes/rollup.post.ts` (+ `src/rollup-route.test.ts`) | HTTP trigger w/ jobId dedup |
-| `src/db/schema.ts` + `drizzle/` migration | `rollup_state` table |
-| `src/types/graph.ts` | Add `"rollup"` to `SourceType` |
-| `src/utils/models.ts`, `src/utils/env.ts` | `temporal_summary` ModelTask + `MODEL_ID_TEMPORAL_SUMMARY` |
-| `src/lib/queues.ts` | `ROLLUP_JOB_OPTIONS` + `"rollup"` worker branch |
-| `src/sdk/memory-client.ts`, `src/sdk/index.ts` | `rollup()` method + schema export |
+| File                                                       | Responsibility                                                                                                                            |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/rollup/period.ts` (+ `.test.ts`)                  | Pure period-key math: levels, parents/children, completeness, ordering                                                                    |
+| `src/lib/rollup/collect.ts` (+ `.test.ts`)                 | Deterministic input assembly + compaction (pure builders), sha256 fingerprint, defensive `additionalData.rollup` reader, thin DB fetchers |
+| `src/lib/rollup/source.ts` (+ `.test.ts`)                  | Per-user synthetic `"rollup"` source (for `PART_OF` claims' NOT NULL `sourceId`)                                                          |
+| `src/lib/rollup/summarize-period.ts` (+ `.test.ts`)        | One period: collect → ensure node → ensure `PART_OF` claims → fingerprint check → one LLM call → write description + re-embed             |
+| `src/lib/jobs/rollup.ts` (+ `.test.ts`)                    | The sweep: discovery, work-set expansion, startDate/completeness filtering, budgeted bottom-up processing, state commit                   |
+| `src/lib/temporal.ts`                                      | Generalize: add `ensurePeriodNode`, make `ensureDayNode` delegate                                                                         |
+| `src/lib/schemas/rollup.ts`                                | Request/response Zod schemas                                                                                                              |
+| `src/routes/rollup.post.ts` (+ `src/rollup-route.test.ts`) | HTTP trigger w/ jobId dedup                                                                                                               |
+| `src/db/schema.ts` + `drizzle/` migration                  | `rollup_state` table                                                                                                                      |
+| `src/types/graph.ts`                                       | Add `"rollup"` to `SourceType`                                                                                                            |
+| `src/utils/models.ts`, `src/utils/env.ts`                  | `temporal_summary` ModelTask + `MODEL_ID_TEMPORAL_SUMMARY`                                                                                |
+| `src/lib/queues.ts`                                        | `ROLLUP_JOB_OPTIONS` + `"rollup"` worker branch                                                                                           |
+| `src/sdk/memory-client.ts`, `src/sdk/index.ts`             | `rollup()` method + schema export                                                                                                         |
 
 ---
 
 ### Task 1: Period math module (pure)
 
 **Files:**
+
 - Create: `src/lib/rollup/period.ts`
 - Test: `src/lib/rollup/period.test.ts`
 
@@ -343,9 +345,7 @@ export function weeksOverlappingMonth(monthKey: string): WeekInMonth[] {
   let weekKey = weekKeyForDay(firstDayKey);
   for (;;) {
     const days = weekDayKeys(weekKey);
-    const dayKeysInMonth = days.filter(
-      (d) => monthKeyForDay(d) === monthKey,
-    );
+    const dayKeysInMonth = days.filter((d) => monthKeyForDay(d) === monthKey);
     result.push({ weekKey, dayKeysInMonth });
     const sunday = days[6]!;
     if (sunday >= lastDayKey) break;
@@ -395,7 +395,8 @@ const LEVEL_ORDER: Record<PeriodLevel, number> = {
 /** Bottom-up (day→week→month→year), oldest-first within each level. */
 export function sortForProcessing(keys: string[]): string[] {
   return [...keys].sort((a, b) => {
-    const levelDiff = LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
+    const levelDiff =
+      LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
     if (levelDiff !== 0) return levelDiff;
     return a < b ? -1 : a > b ? 1 : 0;
   });
@@ -417,6 +418,7 @@ git commit -m "✨ feat(rollup): pure period-key math for temporal hierarchy"
 ### Task 2: Schema groundwork — `rollup_state` table, `"rollup"` SourceType, `temporal_summary` ModelTask
 
 **Files:**
+
 - Modify: `src/db/schema.ts` (append after the `scratchpads` table + its relations)
 - Modify: `src/types/graph.ts` (the `SourceType` union)
 - Modify: `src/utils/models.ts` (ModelTask union + overrides map)
@@ -537,6 +539,7 @@ git commit -m "✨ feat(rollup): rollup_state table, rollup source type, tempora
 ### Task 3: Per-user synthetic rollup source
 
 **Files:**
+
 - Create: `src/lib/rollup/source.ts`
 - Test: `src/lib/rollup/source.test.ts`
 
@@ -721,6 +724,7 @@ git commit -m "✨ feat(rollup): per-user synthetic rollup source"
 ### Task 4: `ensurePeriodNode` (generalize `ensureDayNode`)
 
 **Files:**
+
 - Modify: `src/lib/temporal.ts`
 - Test: `src/lib/temporal.test.ts` (new)
 
@@ -1027,6 +1031,7 @@ git commit -m "♻️ refactor(temporal): generalize ensureDayNode into ensurePe
 ### Task 5: Input builders, compaction, fingerprint (pure) + DB fetchers
 
 **Files:**
+
 - Create: `src/lib/rollup/collect.ts`
 - Test: `src/lib/rollup/collect.test.ts` (pure builders only — the DB fetchers are exercised by Tasks 6–7's integration tests)
 
@@ -1086,7 +1091,12 @@ describe("buildDayInputText", () => {
     expect(buildDayInputText("2026-06-08", [])).toBeNull();
     expect(
       buildDayInputText("2026-06-08", [
-        { nodeType: "Event", label: null, description: null, createdAt: new Date(0) },
+        {
+          nodeType: "Event",
+          label: null,
+          description: null,
+          createdAt: new Date(0),
+        },
       ]),
     ).toBeNull();
   });
@@ -1223,11 +1233,7 @@ Create `src/lib/rollup/collect.ts`:
  * Aliases for search: rollup input collection, compaction, period
  * fingerprint, day entries.
  */
-import {
-  monthKeysOfYear,
-  weekDayKeys,
-  weeksOverlappingMonth,
-} from "./period";
+import { monthKeysOfYear, weekDayKeys, weeksOverlappingMonth } from "./period";
 import { and, eq, inArray } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import type { DrizzleDB } from "~/db";
@@ -1407,7 +1413,9 @@ export async function fetchTemporalNodesByLabels(
  * A child period's summary counts only when the rollup marker is present —
  * `description` alone may be the "Represents the …" boilerplate.
  */
-function summarizedDescriptionOf(row: TemporalNodeRow | undefined): string | null {
+function summarizedDescriptionOf(
+  row: TemporalNodeRow | undefined,
+): string | null {
   if (!row) return null;
   return readRollupMeta(row.additionalData) ? row.description : null;
 }
@@ -1542,6 +1550,7 @@ git commit -m "✨ feat(rollup): deterministic input builders, compaction, finge
 ### Task 6: `summarizePeriod` — one period, one LLM call
 
 **Files:**
+
 - Create: `src/lib/rollup/summarize-period.ts`
 - Test: `src/lib/rollup/summarize-period.test.ts`
 
@@ -1672,9 +1681,7 @@ export function stubLlm(): {
   const client = {
     chat: {
       completions: {
-        parse: async (body: {
-          messages: Array<{ content: string }>;
-        }) => {
+        parse: async (body: { messages: Array<{ content: string }> }) => {
           const prompt = body.messages.map((m) => m.content).join("\n");
           calls.push(prompt);
           return {
@@ -1795,7 +1802,9 @@ describeIfServer("summarizePeriod", () => {
       [dayNodeId],
     );
     expect(meta.rows[0].description).toBe("LLM summary #1");
-    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
 
     // Unchanged input → no second LLM call.
     expect(await summarizePeriod(params)).toBe("skipped-unchanged");
@@ -1875,11 +1884,7 @@ Create `src/lib/rollup/summarize-period.ts`:
  * node's `nodeMetadata.description` (+ `additionalData.rollup` marker) →
  * embedding refresh → idempotent PART_OF containment claims.
  */
-import {
-  collectPeriodInput,
-  fingerprintOf,
-  readRollupMeta,
-} from "./collect";
+import { collectPeriodInput, fingerprintOf, readRollupMeta } from "./collect";
 import { periodLevelOf, type PeriodLevel } from "./period";
 import { and, eq, inArray } from "drizzle-orm";
 import type OpenAI from "openai";
@@ -2097,6 +2102,7 @@ git commit -m "✨ feat(rollup): per-period summarization with fingerprint gate 
 ### Task 7: The sweep job (`runRollup`)
 
 **Files:**
+
 - Create: `src/lib/jobs/rollup.ts`
 - Create: `src/lib/schemas/rollup.ts`
 - Test: `src/lib/jobs/rollup.test.ts`
@@ -2145,11 +2151,11 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import * as schema from "~/db/schema";
-import { ensurePeriodNode } from "~/lib/temporal";
 import {
   ROLLUP_TEST_TABLES_SQL,
   stubLlm,
 } from "~/lib/rollup/summarize-period.test";
+import { ensurePeriodNode } from "~/lib/temporal";
 import { newTypeId } from "~/types/typeid";
 import {
   resetTestOverrides,
@@ -2267,7 +2273,10 @@ describeIfServer("runRollup", () => {
     return rows.rows[0]?.pending_periods ?? [];
   }
 
-  async function summaryOf(userId: string, label: string): Promise<string | null> {
+  async function summaryOf(
+    userId: string,
+    label: string,
+  ): Promise<string | null> {
     const rows = await client.query(
       `SELECT m."description" FROM "node_metadata" m
        JOIN "nodes" n ON n."id" = m."node_id"
@@ -2652,6 +2661,7 @@ git commit -m "✨ feat(rollup): catch-up sweep job with watermark, budget, and 
 ### Task 8: Queue registration + `POST /rollup` route
 
 **Files:**
+
 - Modify: `src/lib/queues.ts`
 - Create: `src/routes/rollup.post.ts`
 - Test: `src/rollup-route.test.ts` (route tests live at `src/` top level, e.g. `src/query-recent-changes-route.test.ts`)
@@ -2879,6 +2889,7 @@ git commit -m "✨ feat(rollup): POST /rollup route and BullMQ job registration"
 ### Task 9: SDK method
 
 **Files:**
+
 - Modify: `src/sdk/memory-client.ts`
 - Modify: `src/sdk/index.ts`
 
@@ -2968,8 +2979,3 @@ git commit -m "📚 docs(rollup): mark temporal rollup spec implemented"
 - **Don't touch** `pendingPeriods` semantics casually: the watermark always advances; pending is the only carrier of deferred work. Both tests in Task 7 encode this.
 - **`runRollup` accepts `maxLlmCalls: 0`** at the function level (used by tests to force-defer); the HTTP schema floor is 1 — that difference is intentional.
 - The `summarize-period.test.ts` file deliberately exports `ROLLUP_TEST_TABLES_SQL` and `stubLlm` for reuse by `rollup.test.ts`.
-
-
-
-
-

--- a/docs/superpowers/specs/2026-06-10-screenpipe-memory-distiller-design.md
+++ b/docs/superpowers/specs/2026-06-10-screenpipe-memory-distiller-design.md
@@ -6,11 +6,11 @@
 
 ## Context & Goal
 
-Marcel runs Screenpipe on his personal Mac, continuously capturing screen (OCR + accessibility), audio, and input. The hypothesis driving his memory stack: *the more AI knows about you, the better it can help you.* Screen observation is the missing source — alongside the existing n8n ingestion workflows (meeting transcripts, handwritten tablet notes, Oura) — feeding **Assistant Memory** (`~/code/assistant-memory`), which his chat app **Petals** reads from.
+Marcel runs Screenpipe on his personal Mac, continuously capturing screen (OCR + accessibility), audio, and input. The hypothesis driving his memory stack: _the more AI knows about you, the better it can help you._ Screen observation is the missing source — alongside the existing n8n ingestion workflows (meeting transcripts, handwritten tablet notes, Oura) — feeding **Assistant Memory** (`~/code/assistant-memory`), which his chat app **Petals** reads from.
 
 Goal: distill each day of noisy computer-use capture into a small set of **durable, true things worth knowing about Marcel** — what he worked on, who he interacted with, the tools/stack he uses, what he read/explored — and ingest them into Assistant Memory **without polluting it** with junk tasks or wrongly-inferred preferences.
 
-An existing Screenpipe "Obsidian pipe" (`obsidian-sync`) already writes daily notes to `/Users/marcel/Notes/screenpipe-daily-notes`. Its core failure mode — **inventing todos from passive observation** (its `pipe.md` literally says *"Extract TODOs: tasks, follow-ups, URLs to visit"*) — is the anti-pattern this design must avoid. That pipe is left untouched (different use case: a browsable journal).
+An existing Screenpipe "Obsidian pipe" (`obsidian-sync`) already writes daily notes to `/Users/marcel/Notes/screenpipe-daily-notes`. Its core failure mode — **inventing todos from passive observation** (its `pipe.md` literally says _"Extract TODOs: tasks, follow-ups, URLs to visit"_) — is the anti-pattern this design must avoid. That pipe is left untouched (different use case: a browsable journal).
 
 ## Non-Goals / Out of Scope
 
@@ -46,6 +46,7 @@ personal memory/search  →  Petals assistant
 ```
 
 Separate loop:
+
 ```
 health-check (launchd, ~2×/day): GET /health + last-frame freshness + audio-stall flag
   → macOS notification if recording is down or stale
@@ -61,24 +62,29 @@ New repo `~/code/screenpipe-distiller`, **Bun** runtime (Screenpipe is already b
   `SCREENPIPE_API_URL` (default `http://localhost:3030`), `SCREENPIPE_LOCAL_API_KEY`, `PETALS_BASE_URL` (default `https://petals.chat`), `PETALS_API_KEY`, `OPENROUTER_API_KEY`, `CURATION_MODEL` (default: a strong-but-cheap OpenRouter slug, trivially swappable), `USER_TIMEZONE` (default `Europe/Brussels` / `+02:00`).
 
 - **`screenpipe.ts`** — local Screenpipe REST client + **deterministic condenser**.
+
   - `fetchDayActivity(date: DayKey): Promise<DayDigest>` — for the day's window in `USER_TIMEZONE`, query `GET /search` (bearer `SCREENPIPE_LOCAL_API_KEY`) across `content_type=all` (OCR/accessibility, `min_length` filtered), `content_type=audio`, `content_type=input`, paginated/chunked by time so no single response is unbounded.
-  - **Condense before the LLM ever sees data**: group by `app_name` / `window_name` / `browser_url`, collapse consecutive duplicate frames, drop sub-threshold noise, attach representative timestamps and URLs. Output `DayDigest` is a compact (few-KB) structured summary — *not* raw frames. This is pure, deterministic, and the most-tested part.
+  - **Condense before the LLM ever sees data**: group by `app_name` / `window_name` / `browser_url`, collapse consecutive duplicate frames, drop sub-threshold noise, attach representative timestamps and URLs. Output `DayDigest` is a compact (few-KB) structured summary — _not_ raw frames. This is pure, deterministic, and the most-tested part.
   - Returns a digest that carries enough entity signal (app names, window titles, URLs, speaker labels when audio works) for good downstream graph extraction.
 
 - **`curate.ts`** — `curateDigest(digest: DayDigest): Promise<CuratedDoc>`. One OpenRouter call (OpenAI-compatible client pointed at `https://openrouter.ai/api/v1`, mirroring `assistant-memory/src/lib/ai.ts`). System prompt = the **curation contract** (§7). Returns `{ markdown, isEmptyDay }`.
 
 - **`upload.ts`** — `uploadDocument(date, doc): Promise<void>`. POST `${PETALS_BASE_URL}/api/memory/ingest/document` with headers `Content-Type: application/json`, `x-api-key: ${PETALS_API_KEY}`. Body matches Petals' `ingestDocumentBodySchema` + the new `mode`:
+
   ```jsonc
-  { // v1 sends no `mode`; Phase 2 adds "mode": "observed"
+  {
+    // v1 sends no `mode`; Phase 2 adds "mode": "observed"
     "document": {
-      "id": "screenpipe-activity-<date>",   // stable → idempotent replace
+      "id": "screenpipe-activity-<date>", // stable → idempotent replace
       "content": "<curated markdown>",
       "contentType": "markdown",
       "scope": "personal",
       "title": "Computer activity — <date>",
-      "timestamp": "<date>T12:00:00<tz>"
-    } }
+      "timestamp": "<date>T12:00:00<tz>",
+    },
+  }
   ```
+
   Retry with exponential backoff (internet-bound); treat 2xx as success, surface 4xx loudly (typed error), retry 5xx/network.
 
 - **`main.ts`** — CLI `distill [--date YYYY-MM-DD]` (default: **yesterday** in `USER_TIMEZONE`). Orchestrates fetch → condense → curate → upload. Idempotent and safe to re-run. Sparse/empty day → still uploads a short honest doc (or skips upload if truly nothing; decided in plan, default: upload a one-line "minimal activity" doc so the timeline has continuity).
@@ -86,13 +92,14 @@ New repo `~/code/screenpipe-distiller`, **Bun** runtime (Screenpipe is already b
 - **`health.ts`** — CLI `health-check`. `GET /health` + newest-frame age; if recording down, frames stale beyond a threshold, or `audio_db_write_stalled` true, fire a macOS notification (`osascript -e 'display notification …'`). Read-only, no memory writes.
 
 ### Why a separate owned repo (not the agentic pipe)
+
 Curation **judgment** is the whole value. It must be deterministic, version-controlled, testable on realistic messy data, and run on a model we choose — not delegated to Screenpipe's agentic Haiku harness writing throwaway scripts. The condenser + upload are pure functions; only the single curation call is non-deterministic.
 
 ## Component 2 — assistant-memory `observed` extraction mode (DEFERRED — Phase 2)
 
-**Status (decided 2026-06-10): deferred.** v1 ships on plain `scope:"personal"` documents, which already suppress self-attributed `HAS_PREFERENCE`/`MADE_DECISION`/`HAS_GOAL`/`HAS_PLAN` — the suppression in `extract-graph.ts:246-253` keys on `sourceType === "document"`, **not** on scope, and `/ingest/document` always sets `sourceType:"document"` — and they stay visible in personal memory/search (only *reference* scope is isolated). Residual gaps the observed mode would close: plain personal documents still mint *candidate* Task nodes (graph noise, never reminders) and use document-author framing. Building it is a real cross-repo job: `mode` threaded through **6 function hops** (route → save-document → job schema → ingest-document job → extract-document-graph → chunked-extract → extractGraph); a new `observed` provenance needing an enum change, trust-rank renumber, **a Postgres CHECK-constraint change + DB migration**, and partial-index band decisions; **a new `@marcelsamyn/memory` SDK release + Petals dependency bump** (the installed `1.22.0` silently strips unknown `mode`); and a redeploy of both hosted services. We revisit only after seeing real v1 output. The blueprint below stands as the Phase-2 design.
+**Status (decided 2026-06-10): deferred.** v1 ships on plain `scope:"personal"` documents, which already suppress self-attributed `HAS_PREFERENCE`/`MADE_DECISION`/`HAS_GOAL`/`HAS_PLAN` — the suppression in `extract-graph.ts:246-253` keys on `sourceType === "document"`, **not** on scope, and `/ingest/document` always sets `sourceType:"document"` — and they stay visible in personal memory/search (only _reference_ scope is isolated). Residual gaps the observed mode would close: plain personal documents still mint _candidate_ Task nodes (graph noise, never reminders) and use document-author framing. Building it is a real cross-repo job: `mode` threaded through **6 function hops** (route → save-document → job schema → ingest-document job → extract-document-graph → chunked-extract → extractGraph); a new `observed` provenance needing an enum change, trust-rank renumber, **a Postgres CHECK-constraint change + DB migration**, and partial-index band decisions; **a new `@marcelsamyn/memory` SDK release + Petals dependency bump** (the installed `1.22.0` silently strips unknown `mode`); and a redeploy of both hosted services. We revisit only after seeing real v1 output. The blueprint below stands as the Phase-2 design.
 
-The attribution problem: observed activity is *about* Marcel but he isn't *asserting* anything — he merely had something on screen. Neither existing scope fits: `personal` lets the extractor mint wrong `HAS_PREFERENCE`/`MADE_DECISION`/`HAS_GOAL` self-claims from passive viewing; `reference` is isolated from personal memory/search (invisible to the assistant — defeats the goal).
+The attribution problem: observed activity is _about_ Marcel but he isn't _asserting_ anything — he merely had something on screen. Neither existing scope fits: `personal` lets the extractor mint wrong `HAS_PREFERENCE`/`MADE_DECISION`/`HAS_GOAL` self-claims from passive viewing; `reference` is isolated from personal memory/search (invisible to the assistant — defeats the goal).
 
 **Solution:** a new extraction profile, selected per-ingestion, combined with `scope: "personal"` (so results are visible to personal memory/search).
 
@@ -109,8 +116,9 @@ The attribution problem: observed activity is *about* Marcel but he isn't *asser
 **Current state (verified 2026-06-10):** `~/Library/LaunchAgents/screenpipe.plist` launches the now-deleted `/Applications/screenpipe.app/...` → `launchctl` reports exit status 255. Live recording is a **manual** terminal `screenpipe record` (won't survive reboot). **After next restart, nothing records.**
 
 Deliverables (owned by the distiller repo, installed via a script):
+
 - **`com.marcel.screenpipe.record.plist`** — replaces the dead app plist. Runs `/opt/homebrew/bin/bun x screenpipe@latest record` (absolute paths; launchd has a minimal PATH), `RunAtLoad=true`, `KeepAlive` so it restarts on crash, logs to a file. Unload + remove the old `screenpipe` agent.
-- **`com.marcel.screenpipe-distiller.daily.plist`** — `StartCalendarInterval` ~08:00, runs `bun run distill`. Robust to boot timing because it targets *yesterday* and is idempotent; launchd also runs a missed calendar job once on next wake/boot.
+- **`com.marcel.screenpipe-distiller.daily.plist`** — `StartCalendarInterval` ~08:00, runs `bun run distill`. Robust to boot timing because it targets _yesterday_ and is idempotent; launchd also runs a missed calendar job once on next wake/boot.
 - **`com.marcel.screenpipe-distiller.health.plist`** — `StartCalendarInterval` ~2×/day, runs `bun run health-check`.
 
 ## 7. The Curation Contract (the core IP)
@@ -119,29 +127,35 @@ The `curate.ts` system prompt encodes seven rules:
 
 1. **Durable over ephemeral.** Record what is true beyond today — projects, people, tools, sustained topics. Drop window-focus mechanics, idle gaps, one-off lookups with no follow-through.
 2. **Zero action items.** Never emit todos, follow-ups, "should"/"could" items. The document has **no** action-items section. (Belt-and-suspenders with observed mode.)
-3. **Evidence-grounded, no intent inference.** Describe what was *done/seen* ("spent ~2h editing `extract-graph.ts`"), never *why*, never *prefers/decided/wants*.
+3. **Evidence-grounded, no intent inference.** Describe what was _done/seen_ ("spent ~2h editing `extract-graph.ts`"), never _why_, never _prefers/decided/wants_.
 4. **Entity-first.** Surface named people, orgs, repos, tools, article/video titles + URLs. Concrete entities → good graph nodes.
 5. **Consolidate.** A synthesized narrative + entity list, not a minute-by-minute log.
 6. **Honest about sparsity.** Idle/light day → say so briefly; never pad or invent.
 7. **Reading = exposure, not intent.** "Read about X" / "watched a video on Y" — never "wants to do X." (The exact Obsidian-pipe failure.)
 
 **Uploaded document shape:**
+
 ```markdown
 # Computer activity — <date>
 
 ## What I worked on
+
 <narrative: projects, repos, problems, concrete actions>
 
 ## People & conversations
-<who appeared / was interacted with + context>   (thin until audio is fixed — §9)
+
+<who appeared / was interacted with + context> (thin until audio is fixed — §9)
 
 ## Tools & environment
+
 <tools/tech actively used; notable setup/config work>
 
 ## Read & explored
+
 <articles/videos/repos engaged with + topic, as exposure not intent>
 
 ## Notes
+
 <sparse-day note / anything notable — never action items>
 ```
 
@@ -151,7 +165,7 @@ All via env, Zod-validated in `config.ts` (see Component 1). Secrets (`SCREENPIP
 
 ## 9. Tracked follow-up — fix Screenpipe audio (separate workstream)
 
-Audio transcription has been dead since 2026-06-05: `/health` shows `audio_level_rms: 0.0`, `avg_speech_ratio: 0.0`, all chunks VAD-rejected, `db_inserted: 0`, ~900 pending segments. **Lead:** level `0.0` = capturing silence → almost certainly a **device-selection** issue (listening to "Scarlett 2i2 USB" with no live signal), not a model/VAD bug. Until fixed, the distiller's *People & conversations* dimension stays empty; the health-check surfaces the stall. Tracked in memory `screenpipe-audio-transcription-broken`. Fix = a small Screenpipe config task, sequenced after the distiller MVP. **Note (2026-06-10):** recording autostart now runs under launchd with `--disable-audio` (the launchd binary has no Microphone TCC grant, so audio-enabled record crash-loops). Re-enabling audio additionally requires granting mic access to the launchd binary in System Settings → Privacy and removing `--disable-audio` from the record plist.
+Audio transcription has been dead since 2026-06-05: `/health` shows `audio_level_rms: 0.0`, `avg_speech_ratio: 0.0`, all chunks VAD-rejected, `db_inserted: 0`, ~900 pending segments. **Lead:** level `0.0` = capturing silence → almost certainly a **device-selection** issue (listening to "Scarlett 2i2 USB" with no live signal), not a model/VAD bug. Until fixed, the distiller's _People & conversations_ dimension stays empty; the health-check surfaces the stall. Tracked in memory `screenpipe-audio-transcription-broken`. Fix = a small Screenpipe config task, sequenced after the distiller MVP. **Note (2026-06-10):** recording autostart now runs under launchd with `--disable-audio` (the launchd binary has no Microphone TCC grant, so audio-enabled record crash-loops). Re-enabling audio additionally requires granting mic access to the launchd binary in System Settings → Privacy and removing `--disable-audio` from the record plist.
 
 ## 10. Testing
 
@@ -163,20 +177,18 @@ Audio transcription has been dead since 2026-06-05: `/health` shows `audio_level
 ## 11. Sequencing
 
 **v1 (this build) — no backend changes:**
+
 1. **Recording autostart** (urgent — reboot risk): replace the dead `.app` plist with a `screenpipe record` LaunchAgent.
 2. **Distiller**: scaffold → config/date-utils → Screenpipe client + condenser → curation → upload (`scope:"personal"`) → orchestrator + CLI → manual run for a recent day; verify the doc lands in memory and reads cleanly.
 3. **Scheduling**: distiller daily + health-check plists.
 
-**Follow-ups (separate, after v1 runs):**
-4. **Fix audio device selection** (unblocks People & conversations) — see §9.
-5. **Phase 2 — `observed` mode** (§2), only if v1 output shows the residual candidate-task noise / framing is worth the cross-repo release.
-6. **(Optional) backfill** historical days (~80 requests, within rate limits).
+**Follow-ups (separate, after v1 runs):** 4. **Fix audio device selection** (unblocks People & conversations) — see §9. 5. **Phase 2 — `observed` mode** (§2), only if v1 output shows the residual candidate-task noise / framing is worth the cross-repo release. 6. **(Optional) backfill** historical days (~80 requests, within rate limits).
 
 ## Resolved decisions
 
 - Capture all four categories (work/projects, people/interactions, tools/stack, reading/interests) — the lever is curation quality, not category selection.
 - Owned TS/Bun distiller (not the agentic pipe, not n8n).
-- Daily cadence, processes *yesterday*, idempotent.
+- Daily cadence, processes _yesterday_, idempotent.
 - **v1:** plain `scope: personal` documents (already suppress self-attributed preferences/decisions/goals; visible in personal memory). **Phase 2 (deferred):** `observed` extraction mode for zero candidate-task noise + observed-fact framing.
 - Upload via hosted Petals proxy (`https://petals.chat`), `x-api-key`.
 - Curation LLM via OpenRouter, model = swappable env var.

--- a/docs/superpowers/specs/2026-06-12-temporal-rollup-design.md
+++ b/docs/superpowers/specs/2026-06-12-temporal-rollup-design.md
@@ -1,0 +1,259 @@
+# Temporal Rollup: Multi-Layer Summarization (Day → Week → Month → Year)
+
+**Date:** 2026-06-12
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Ingested content links to day nodes (`Temporal` nodes labeled `yyyy-MM-dd`) via
+`OCCURRED_ON` claims, but nothing summarizes those days, and no higher-level
+temporal structure exists. We want a recursive summary hierarchy — day
+summaries from raw content, weekly summaries from days, monthly from weeks,
+yearly from months — so retrieval can answer "what happened in March?" and the
+graph carries durable, searchable period narratives.
+
+The trigger must be external (SDK/HTTP), never internally scheduled: the
+hosted deployment serves Petals, which must control exactly when and how much
+LLM spend each user (especially free-tier) incurs.
+
+## Decisions (settled during brainstorming)
+
+1. **Trigger shape:** catch-up sweep. One endpoint: "roll up everything stale
+   for user X." No internal scheduling.
+2. **No agentic exploration.** Deterministic input collection; one structured
+   LLM completion per period. Token cost per call is bounded and predictable.
+3. **Fully recursive hierarchy.** Days get LLM summaries first (written onto
+   the day node), weeks read day summaries, months read weekly summaries,
+   years read monthly summaries.
+4. **Completed periods only.** A period is summarized only after it ends.
+   Read-time views of the current day remain the job of `/digest`.
+5. **Staleness via per-user watermark + input fingerprints.** No ingestion
+   changes; backfill and crash recovery handled naturally.
+6. **`startDate` floor.** The request can carry a `startDate`; periods ending
+   before it are excluded outright, so a first sweep over an account with
+   years of history doesn't pay for ancient periods.
+
+## Data model
+
+### Period nodes
+
+All four layers are `Temporal` nodes (existing `NodeTypeEnum`), distinguished
+by label convention. Labels are the lookup key (same convention as
+`ensureDayNode` in `src/lib/temporal.ts`):
+
+| Layer | Label format            | Example      | Completeness rule (lexicographic vs today's label) |
+| ----- | ----------------------- | ------------ | -------------------------------------------------- |
+| Day   | `yyyy-MM-dd` (existing) | `2026-06-08` | label < today                                      |
+| Week  | ISO `RRRR-'W'II`        | `2026-W24`   | its Sunday's label < today                         |
+| Month | `yyyy-MM`               | `2026-06`    | its last day's label < today                       |
+| Year  | `yyyy`                  | `2026`       | its Dec 31 label < today                           |
+
+Weeks are ISO weeks (Monday start, ISO week-numbering year via date-fns
+`getISOWeek`/`getISOWeekYear`). "Today" uses the same server-side
+`format(new Date(), "yyyy-MM-dd")` convention as `ensureDayNode`; per-user
+timezones are out of scope (noted as a future refinement).
+
+`ensureDayNode` is generalized to `ensurePeriodNode(db, userId, periodKey)`
+in `src/lib/temporal.ts`: label-based lookup, create-if-missing with a
+boilerplate description and a jina-embeddings-v3 embedding, exactly like day
+nodes today.
+
+### Summary storage
+
+- `nodeMetadata.description` ← the summary text (day nodes' boilerplate
+  "Represents the day X" gets replaced; week/month/year nodes start with
+  boilerplate and get replaced the same way).
+- `nodeMetadata.additionalData.rollup` ← `{ fingerprint, summarizedAt }`.
+- `nodeEmbeddings` ← re-embedded as `${label}: ${description}` whenever the
+  description changes (upsert), so period summaries are vector-searchable.
+
+### Containment edges
+
+Claims with the **existing** `PART_OF` predicate (already in
+`RelationshipPredicateEnum`), `assertedByKind: "system"`, `scope: "personal"`,
+ensured idempotently when the sweep processes a period (each existing child
+node gets a `PART_OF` claim to the parent; `statement` e.g.
+`"2026-06-08 is part of week 2026-W24"`). Day nodes predate the rollup, so
+claims are attached at sweep time, not at node creation:
+
+- day `PART_OF` week — exactly 1
+- week `PART_OF` month — 1 per overlapping month (a week straddling a month
+  boundary gets 2)
+- month `PART_OF` year — exactly 1
+
+**Week/month overlap rule:** ISO weeks do not nest in months. A month's input
+is every ISO week that overlaps it (4–6 weeks); the month prompt is told which
+days of boundary weeks fall inside the month. Years read months, so no
+straddling exists at the year level.
+
+`claims.sourceId` is NOT NULL, so containment claims need a source: add
+`"rollup"` to the `SourceType` union (`src/types/graph.ts` — varchar column,
+no DB migration) and idempotently ensure one synthetic source per user
+(`externalId: "rollup"`), following the precedent of
+`src/lib/metrics/sources.ts`. All rollup-created claims use it.
+
+### Sweep state
+
+New table `rollup_state`:
+
+| Column           | Type                     | Notes                                  |
+| ---------------- | ------------------------ | -------------------------------------- |
+| `userId`         | text PK, FK → users      | one row per user                       |
+| `watermark`      | timestamptz, nullable    | max `claims.createdAt` fully processed |
+| `pendingPeriods` | jsonb (string[])         | period keys awaiting summarization     |
+| `updatedAt`      | timestamptz              |                                        |
+
+## Sweep algorithm
+
+Runs as one BullMQ job per trigger. Inputs: `userId`, `maxLlmCalls`,
+`startDate?`.
+
+1. **Discover.** Load `rollup_state`. Query active `OCCURRED_ON` claims with
+   `createdAt > watermark` (all claims if watermark is null), join to the
+   object node's metadata label → distinct day labels touched. Record the max
+   `createdAt` seen as the new watermark candidate.
+2. **Expand.** Work set = touched days ∪ their ancestor weeks/months/years ∪
+   `pendingPeriods`.
+3. **Filter.** Drop periods whose end < `startDate` (when given) — removed
+   from the work set *and* purged from `pendingPeriods` (excluded, not
+   deferred). Periods not yet complete move to `pendingPeriods` (deferred —
+   this is what makes "user goes quiet mid-week" safe: the week sits in
+   pending until a later sweep finds it complete, even if no new claims ever
+   arrive).
+4. **Process bottom-up,** oldest first within each level: all days, then
+   weeks, months, years. Per period:
+   - Collect input (see below) and compute its fingerprint (sha256 of the
+     exact compacted input text).
+   - If the stored fingerprint matches and a summary exists → skip (no LLM
+     call, does not count against the budget).
+   - Otherwise: one `parseStructuredCompletion` call (task
+     `"temporal_summary"`), write description + `additionalData.rollup`,
+     re-embed, ensure containment claims. Counts 1 against `maxLlmCalls`.
+   - On per-period failure: log loudly, leave the period in
+     `pendingPeriods`, continue with the rest (one poison period must not
+     block the sweep).
+   - When the budget is exhausted: stop; all unprocessed periods go to
+     `pendingPeriods`.
+5. **Commit state.** Watermark ← candidate from step 1 (always advances —
+   deferred/over-budget/failed work is carried by `pendingPeriods`, never by
+   holding the watermark back). Persist `pendingPeriods`.
+
+Backfill works without ingestion changes: importing old content creates *new*
+claims (fresh `createdAt`) pointing at *old* day nodes, so the old day
+re-enters the work set, its summary changes, the week's input fingerprint
+changes, and the change cascades up. If the day's effective input is
+unchanged, every level fingerprint-skips at zero LLM cost.
+
+## Input collection per level
+
+All collection is deterministic SQL + string assembly — no LLM involvement
+until the single summarization call.
+
+- **Day:** nodes linked to the day node via active `OCCURRED_ON` claims;
+  for each, label + description (+ a bounded number of associated claim
+  statements). Compacted deterministically: initial caps of 600 chars per
+  node entry and 24,000 chars total day input (constants in
+  `src/lib/rollup/collect.ts`, tunable); overflow is dropped by recency
+  priority and the prompt is told content was truncated. Bounds even heavy
+  days (e.g. screenpipe distiller documents).
+- **Week:** the descriptions of its 7 day nodes. Days with no node or no
+  summary are listed as "no summarized activity."
+- **Month:** descriptions of all overlapping weeks, annotated with which of
+  each week's days fall inside the month.
+- **Year:** descriptions of its 12 month nodes (missing months listed as "no
+  summarized activity").
+
+Output schema per call (Zod, via `zodResponseFormat` — mind the zod4/openai6
+constraints: `.nullish()` over `.optional()`, no `.transform()`):
+
+```ts
+z.object({
+  summary: z
+    .string()
+    .describe("Narrative summary of the period; concrete, specific, past tense"),
+});
+```
+
+Prompts differ per level (day: synthesize events/themes from raw content;
+week: narrate the arc of the week from day summaries; month/year: progressive
+abstraction — themes, changes, milestones over the children).
+
+## API, SDK, job
+
+### `POST /rollup`
+
+Request (`src/lib/schemas/rollup.ts`):
+
+```ts
+{
+  userId: string;
+  maxLlmCalls?: number; // default 50; each period summary costs 1
+  startDate?: string;   // "yyyy-MM-dd"; periods ending before this are excluded
+}
+```
+
+Behavior mirrors `src/routes/summarize.ts`: validate, enqueue a `"rollup"`
+job on `batchQueue` with `jobId: rollup:${userId}` (BullMQ-level dedup — concurrent
+triggers for the same user collapse while one is queued/running), return an
+"enqueued" message immediately. Job options: 3 attempts, exponential backoff
+(matching `SUMMARIZE_JOB_OPTIONS`).
+
+The SDK gains a `rollup(request)` method via the existing schema-driven
+client pattern (`src/sdk/memory-client.ts`).
+
+### Cost model (the Petals free-tier story)
+
+- A period costs **one LLM call ever**, unless its input genuinely changes.
+- A sweep with nothing stale costs **zero** LLM calls.
+- `maxLlmCalls` hard-caps each sweep; leftovers resume on the next call.
+- `startDate` caps history depth on first contact with a backlogged account.
+- Petals owns cadence entirely: call rarely/low-budget for free users,
+  frequently for paid. Spend is attributable per task/user via the existing
+  Helicone telemetry (`task: "temporal_summary"`).
+
+### Model routing
+
+Add `"temporal_summary"` to `ModelTask` (`src/utils/models.ts`) with a
+`MODEL_ID_TEMPORAL_SUMMARY` env override (`src/utils/env.ts`), falling back to
+`MODEL_ID_GRAPH_EXTRACTION` per the existing pattern. One task for all four
+levels; Helicone breaks down spend by task.
+
+## New/changed files
+
+| File                                   | Change                                                     |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `src/lib/rollup/period.ts`             | new — pure period math: keys, ancestors, ranges, completeness |
+| `src/lib/rollup/collect.ts`            | new — input collection, compaction, fingerprinting          |
+| `src/lib/jobs/rollup.ts`               | new — the sweep job                                         |
+| `src/lib/schemas/rollup.ts`            | new — request/response Zod schemas                          |
+| `src/routes/rollup.post.ts`            | new — HTTP trigger                                          |
+| `src/lib/temporal.ts`                  | generalize `ensureDayNode` → add `ensurePeriodNode`         |
+| `src/db/schema.ts`                     | add `rollup_state` table (+ drizzle migration)              |
+| `src/types/graph.ts`                   | add `"rollup"` to `SourceType`                              |
+| `src/utils/models.ts`, `src/utils/env.ts` | add `temporal_summary` task + env override               |
+| `src/lib/queues.ts`                    | register `"rollup"` job + options                           |
+| `src/sdk/memory-client.ts`             | add `rollup()` method                                       |
+
+## Testing
+
+- **Unit (pure functions):** period math — day→week/month/year key
+  derivation, ISO edge cases (W01 spanning a year boundary, W53 weeks,
+  month/week overlap sets, completeness vs a fixed "today"); fingerprint
+  stability; watermark/pending-set transitions including `startDate`
+  filtering and purge-from-pending.
+- **Integration (vitest, test DB on :5431, mocked LLM):** seed OCCURRED_ON
+  claims across a multi-week range → run the job → assert period nodes,
+  `PART_OF` claims, descriptions, embeddings; second run fingerprint-skips
+  (zero LLM calls); budget exhaustion defers to `pendingPeriods` and resumes;
+  backfilled claim re-summarizes the old day and cascades; `startDate`
+  excludes old periods.
+- CI does not run vitest — run tests locally.
+
+## Out of scope (explicitly)
+
+- Per-user timezones for period boundaries.
+- Summarizing in-progress periods (current day/week/month/year).
+- Agentic/tool-use summarization.
+- Internal scheduling of sweeps.
+- A `/query/week`-style read endpoint (period summaries surface via existing
+  vector search; dedicated read endpoints can come later if Petals needs them).

--- a/docs/superpowers/specs/2026-06-12-temporal-rollup-design.md
+++ b/docs/superpowers/specs/2026-06-12-temporal-rollup-design.md
@@ -1,7 +1,7 @@
 # Temporal Rollup: Multi-Layer Summarization (Day → Week → Month → Year)
 
 **Date:** 2026-06-12
-**Status:** Approved design, pending implementation plan
+**Status:** Implemented — plan at docs/superpowers/plans/2026-06-12-temporal-rollup.md
 
 ## Problem
 
@@ -96,12 +96,12 @@ no DB migration) and idempotently ensure one synthetic source per user
 
 New table `rollup_state`:
 
-| Column           | Type                     | Notes                                  |
-| ---------------- | ------------------------ | -------------------------------------- |
-| `userId`         | text PK, FK → users      | one row per user                       |
-| `watermark`      | timestamptz, nullable    | max `claims.createdAt` fully processed |
-| `pendingPeriods` | jsonb (string[])         | period keys awaiting summarization     |
-| `updatedAt`      | timestamptz              |                                        |
+| Column           | Type                  | Notes                                  |
+| ---------------- | --------------------- | -------------------------------------- |
+| `userId`         | text PK, FK → users   | one row per user                       |
+| `watermark`      | timestamptz, nullable | max `claims.createdAt` fully processed |
+| `pendingPeriods` | jsonb (string[])      | period keys awaiting summarization     |
+| `updatedAt`      | timestamptz           |                                        |
 
 ## Sweep algorithm
 
@@ -115,7 +115,7 @@ Runs as one BullMQ job per trigger. Inputs: `userId`, `maxLlmCalls`,
 2. **Expand.** Work set = touched days ∪ their ancestor weeks/months/years ∪
    `pendingPeriods`.
 3. **Filter.** Drop periods whose end < `startDate` (when given) — removed
-   from the work set *and* purged from `pendingPeriods` (excluded, not
+   from the work set _and_ purged from `pendingPeriods` (excluded, not
    deferred). Periods not yet complete move to `pendingPeriods` (deferred —
    this is what makes "user goes quiet mid-week" safe: the week sits in
    pending until a later sweep finds it complete, even if no new claims ever
@@ -138,8 +138,8 @@ Runs as one BullMQ job per trigger. Inputs: `userId`, `maxLlmCalls`,
    deferred/over-budget/failed work is carried by `pendingPeriods`, never by
    holding the watermark back). Persist `pendingPeriods`.
 
-Backfill works without ingestion changes: importing old content creates *new*
-claims (fresh `createdAt`) pointing at *old* day nodes, so the old day
+Backfill works without ingestion changes: importing old content creates _new_
+claims (fresh `createdAt`) pointing at _old_ day nodes, so the old day
 re-enters the work set, its summary changes, the week's input fingerprint
 changes, and the change cascades up. If the day's effective input is
 unchanged, every level fingerprint-skips at zero LLM cost.
@@ -170,7 +170,9 @@ constraints: `.nullish()` over `.optional()`, no `.transform()`):
 z.object({
   summary: z
     .string()
-    .describe("Narrative summary of the period; concrete, specific, past tense"),
+    .describe(
+      "Narrative summary of the period; concrete, specific, past tense",
+    ),
 });
 ```
 
@@ -220,19 +222,19 @@ levels; Helicone breaks down spend by task.
 
 ## New/changed files
 
-| File                                   | Change                                                     |
-| -------------------------------------- | ---------------------------------------------------------- |
-| `src/lib/rollup/period.ts`             | new — pure period math: keys, ancestors, ranges, completeness |
-| `src/lib/rollup/collect.ts`            | new — input collection, compaction, fingerprinting          |
-| `src/lib/jobs/rollup.ts`               | new — the sweep job                                         |
-| `src/lib/schemas/rollup.ts`            | new — request/response Zod schemas                          |
-| `src/routes/rollup.post.ts`            | new — HTTP trigger                                          |
-| `src/lib/temporal.ts`                  | generalize `ensureDayNode` → add `ensurePeriodNode`         |
-| `src/db/schema.ts`                     | add `rollup_state` table (+ drizzle migration)              |
-| `src/types/graph.ts`                   | add `"rollup"` to `SourceType`                              |
-| `src/utils/models.ts`, `src/utils/env.ts` | add `temporal_summary` task + env override               |
-| `src/lib/queues.ts`                    | register `"rollup"` job + options                           |
-| `src/sdk/memory-client.ts`             | add `rollup()` method                                       |
+| File                                      | Change                                                        |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| `src/lib/rollup/period.ts`                | new — pure period math: keys, ancestors, ranges, completeness |
+| `src/lib/rollup/collect.ts`               | new — input collection, compaction, fingerprinting            |
+| `src/lib/jobs/rollup.ts`                  | new — the sweep job                                           |
+| `src/lib/schemas/rollup.ts`               | new — request/response Zod schemas                            |
+| `src/routes/rollup.post.ts`               | new — HTTP trigger                                            |
+| `src/lib/temporal.ts`                     | generalize `ensureDayNode` → add `ensurePeriodNode`           |
+| `src/db/schema.ts`                        | add `rollup_state` table (+ drizzle migration)                |
+| `src/types/graph.ts`                      | add `"rollup"` to `SourceType`                                |
+| `src/utils/models.ts`, `src/utils/env.ts` | add `temporal_summary` task + env override                    |
+| `src/lib/queues.ts`                       | register `"rollup"` job + options                             |
+| `src/sdk/memory-client.ts`                | add `rollup()` method                                         |
 
 ## Testing
 

--- a/drizzle/0021_colorful_miss_america.sql
+++ b/drizzle/0021_colorful_miss_america.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "rollup_state" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"watermark" timestamp with time zone,
+	"pending_periods" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "rollup_state" ADD CONSTRAINT "rollup_state_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/0022_last_patch.sql
+++ b/drizzle/0022_last_patch.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "claims_occurred_on_discovery_idx" ON "claims" USING btree ("user_id","created_at") WHERE "claims"."predicate" = 'OCCURRED_ON' AND "claims"."status" = 'active';

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2114 @@
+{
+  "id": "e0906e7d-d3c3-44d1-9753-32aec059ca84",
+  "prevId": "c1971493-4051-4ce8-ab7f-4a956b766fae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2136 @@
+{
+  "id": "6bc23d4d-ca8a-4b30-88d1-0fd011ce4ed6",
+  "prevId": "e0906e7d-d3c3-44d1-9753-32aec059ca84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780909705240,
       "tag": "0020_clever_jimmy_woo",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1781255958048,
+      "tag": "0021_colorful_miss_america",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781255958048,
       "tag": "0021_colorful_miss_america",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1781264303934,
+      "tag": "0022_last_patch",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -517,6 +517,33 @@ export const scratchpadsRelations = relations(scratchpads, ({ one }) => ({
   }),
 }));
 
+/**
+ * Per-user temporal-rollup sweep state (see
+ * docs/superpowers/specs/2026-06-12-temporal-rollup-design.md).
+ *
+ * `watermark`: max `claims.createdAt` whose OCCURRED_ON claims have been
+ * incorporated into the work set. Always advances; deferred work is
+ * carried by `pendingPeriods`, never by holding the watermark back.
+ * `pendingPeriods`: period keys (day/week/month/year) awaiting
+ * summarization — incomplete periods, over-budget leftovers, failures.
+ */
+export const rollupState = pgTable("rollup_state", {
+  userId: text()
+    .primaryKey()
+    .notNull()
+    .references(() => users.id),
+  watermark: timestamp({ withTimezone: true }),
+  pendingPeriods: jsonb().$type<string[]>().notNull().default([]),
+  updatedAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+});
+
+export const rollupStateRelations = relations(rollupState, ({ one }) => ({
+  user: one(users, {
+    fields: [rollupState.userId],
+    references: [users.id],
+  }),
+}));
+
 // --- Metrics ---
 
 export const metricDefinitions = pgTable(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -217,6 +217,14 @@ export const claims = pgTable(
       .where(
         sql`${table.predicate} = 'DUE_ON' AND ${table.status} = 'active' AND ${table.scope} = 'personal' AND ${table.objectInstant} IS NOT NULL`,
       ),
+    // Rollup discovery sweep (src/lib/jobs/rollup.ts): active OCCURRED_ON
+    // claims past the per-user watermark, without heap-filtering a heavy
+    // user's full claim history on a first sweep.
+    index("claims_occurred_on_discovery_idx")
+      .on(table.userId, table.createdAt)
+      .where(
+        sql`${table.predicate} = 'OCCURRED_ON' AND ${table.status} = 'active'`,
+      ),
     index("claims_source_id_idx").on(table.sourceId),
     check(
       "claims_object_shape_xor_ck",

--- a/src/lib/jobs/rollup.test.ts
+++ b/src/lib/jobs/rollup.test.ts
@@ -4,10 +4,7 @@ import { Client } from "pg";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { DrizzleDB } from "~/db";
 import * as schema from "~/db/schema";
-import {
-  ROLLUP_TEST_TABLES_SQL,
-  stubLlm,
-} from "~/lib/rollup/summarize-period.test";
+import { ROLLUP_TEST_TABLES_SQL, stubLlm } from "~/lib/rollup/test-helpers";
 import { ensurePeriodNode } from "~/lib/temporal";
 import { newTypeId } from "~/types/typeid";
 import {

--- a/src/lib/jobs/rollup.test.ts
+++ b/src/lib/jobs/rollup.test.ts
@@ -14,6 +14,7 @@ import {
   resetTestOverrides,
   setExtractionClientOverride,
   setSkipEmbeddingPersistence,
+  type StubCompletionClient,
 } from "~/utils/test-overrides";
 
 const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
@@ -137,6 +138,42 @@ describeIfServer("runRollup", () => {
       [userId, label],
     );
     return rows.rows[0]?.description ?? null;
+  }
+
+  /** Like stubLlm, but throws AFTER recording any call whose prompt contains the marker. */
+  function poisonLlm(poisonMarker: string): {
+    client: StubCompletionClient;
+    calls: string[];
+  } {
+    const calls: string[] = [];
+    const client = {
+      chat: {
+        completions: {
+          parse: async (body: { messages: Array<{ content: string }> }) => {
+            const prompt = body.messages.map((m) => m.content).join("\n");
+            calls.push(prompt);
+            if (prompt.includes(poisonMarker)) {
+              throw new Error("poisoned completion");
+            }
+            return {
+              choices: [
+                {
+                  message: {
+                    parsed: { summary: `LLM summary #${calls.length}` },
+                  },
+                },
+              ],
+              usage: {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+              },
+            };
+          },
+        },
+      },
+    } as unknown as StubCompletionClient;
+    return { client, calls };
   }
 
   it("builds the full hierarchy bottom-up and defers the open year", async () => {
@@ -307,5 +344,65 @@ describeIfServer("runRollup", () => {
     expect(await summaryOf(userId, "2025-12-15")).toBeNull();
     expect(await summaryOf(userId, "2025-12")).toBeNull();
     expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("re-summarizes ancestors after a failed period recovers", async () => {
+    const userId = "u_poison";
+    await seedUser(userId);
+    // W06 2026 = Feb 2–8; both days in the same week/month.
+    await seedContent(userId, "2026-02-02", "Solid");
+    await seedContent(userId, "2026-02-03", "Poison");
+
+    // Sweep 1: the poison day's LLM call throws after being made. The rest
+    // of the sweep continues: week + month summarize WITHOUT the poison day.
+    const { client: flaky, calls: flakyCalls } = poisonLlm("Poison");
+    setExtractionClientOverride(flaky);
+    const first = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    expect(first).toMatchObject({ summarized: 3, failed: 1 });
+    expect(flakyCalls).toHaveLength(4); // 2 days + week + month
+    expect(await pendingOf(userId)).toContain("2026-02-03");
+
+    // Sweep 2 (healthy): the recovered day re-stales its week and month.
+    const { client: healthy, calls: healthyCalls } = stubLlm();
+    setExtractionClientOverride(healthy);
+    const second = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    expect(second).toMatchObject({ summarized: 3, failed: 0 });
+    expect(healthyCalls).toHaveLength(3); // day + week + month re-run
+    expect(await summaryOf(userId, "2026-02-03")).toMatch(/^LLM summary/);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("counts failed LLM calls against the budget", async () => {
+    const userId = "u_cap";
+    await seedUser(userId);
+    // W10 2026 = Mar 2–8; the poison day sorts first.
+    await seedContent(userId, "2026-03-02", "Poison");
+    await seedContent(userId, "2026-03-03", "Solid");
+
+    const { client: flaky, calls } = poisonLlm("Poison");
+    setExtractionClientOverride(flaky);
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 1,
+      todayKey: TODAY,
+    });
+
+    // The poison day's call failed but still consumed the only budget slot.
+    expect(calls).toHaveLength(1);
+    expect(result).toMatchObject({ summarized: 0, failed: 1 });
+    const pending = await pendingOf(userId);
+    expect(pending).toContain("2026-03-02");
+    expect(pending).toContain("2026-03-03");
   });
 });

--- a/src/lib/jobs/rollup.test.ts
+++ b/src/lib/jobs/rollup.test.ts
@@ -1,0 +1,308 @@
+import { runRollup } from "./rollup";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { DrizzleDB } from "~/db";
+import * as schema from "~/db/schema";
+import { ensurePeriodNode } from "~/lib/temporal";
+import {
+  ROLLUP_TEST_TABLES_SQL,
+  stubLlm,
+} from "~/lib/rollup/summarize-period.test";
+import { newTypeId } from "~/types/typeid";
+import {
+  resetTestOverrides,
+  setExtractionClientOverride,
+  setSkipEmbeddingPersistence,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+const TODAY = "2026-06-15";
+
+describeIfServer("runRollup", () => {
+  const dbName = `memory_rollup_job_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+  let db: DrizzleDB;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(ROLLUP_TEST_TABLES_SQL);
+    db = drizzle(client, { schema, casing: "snake_case" });
+  });
+
+  afterEach(() => {
+    resetTestOverrides();
+    setSkipEmbeddingPersistence(true);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  async function seedUser(userId: string): Promise<void> {
+    await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+  }
+
+  /** A content node OCCURRED_ON the given day (creates the day node too). */
+  async function seedContent(
+    userId: string,
+    dayKey: string,
+    label: string,
+  ): Promise<void> {
+    const dayNodeId = await ensurePeriodNode(db, userId, dayKey);
+    const contentNodeId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    await client.query(
+      `INSERT INTO "sources" ("id", "user_id", "type", "external_id")
+       VALUES ($1, $2, 'conversation', $3)`,
+      [sourceId, userId, `conv-${label}`],
+    );
+    await client.query(
+      `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Conversation')`,
+      [contentNodeId, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata" ("id", "node_id", "label", "description")
+       VALUES ($1, $2, $3, 'Some details.')`,
+      [newTypeId("node_metadata"), contentNodeId, label],
+    );
+    await client.query(
+      `INSERT INTO "claims" (
+        "id", "user_id", "subject_node_id", "object_node_id", "predicate",
+        "statement", "source_id", "asserted_by_kind", "stated_at"
+      ) VALUES ($1, $2, $3, $4, 'OCCURRED_ON', 'occurred', $5, 'system', now())`,
+      [newTypeId("claim"), userId, contentNodeId, dayNodeId, sourceId],
+    );
+  }
+
+  async function pendingOf(userId: string): Promise<string[]> {
+    const rows = await client.query(
+      `SELECT "pending_periods" FROM "rollup_state" WHERE "user_id" = $1`,
+      [userId],
+    );
+    return rows.rows[0]?.pending_periods ?? [];
+  }
+
+  async function summaryOf(userId: string, label: string): Promise<string | null> {
+    const rows = await client.query(
+      `SELECT m."description" FROM "node_metadata" m
+       JOIN "nodes" n ON n."id" = m."node_id"
+       WHERE n."user_id" = $1 AND m."label" = $2 AND m."additional_data" -> 'rollup' IS NOT NULL`,
+      [userId, label],
+    );
+    return rows.rows[0]?.description ?? null;
+  }
+
+  it("builds the full hierarchy bottom-up and defers the open year", async () => {
+    const userId = "u_full";
+    await seedUser(userId);
+    // W02 2026 = Jan 5–11; W03 = Jan 12–18.
+    await seedContent(userId, "2026-01-05", "Kickoff");
+    await seedContent(userId, "2026-01-07", "Design review");
+    await seedContent(userId, "2026-01-13", "Retro");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+
+    // 3 days + 2 weeks + 1 month = 6; year 2026 is still open.
+    expect(result).toMatchObject({ summarized: 6, failed: 0 });
+    expect(calls).toHaveLength(6);
+    expect(await summaryOf(userId, "2026-01-05")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-W02")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-W03")).toMatch(/^LLM summary/);
+    expect(await summaryOf(userId, "2026-01")).toMatch(/^LLM summary/);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+
+    // PART_OF: 3 day→week + 2 week→month (only existing week nodes link).
+    const partOf = await client.query(
+      `SELECT count(*)::int AS n FROM "claims" WHERE "user_id" = $1 AND "predicate" = 'PART_OF'`,
+      [userId],
+    );
+    expect(partOf.rows[0].n).toBe(5);
+
+    const state = await client.query(
+      `SELECT "watermark" FROM "rollup_state" WHERE "user_id" = $1`,
+      [userId],
+    );
+    expect(state.rows[0].watermark).not.toBeNull();
+  });
+
+  it("costs zero LLM calls when nothing changed", async () => {
+    const userId = "u_full";
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    expect(result.summarized).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("summarizes a completed year", async () => {
+    const userId = "u_year";
+    await seedUser(userId);
+    await seedContent(userId, "2025-03-10", "Spring planning");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // day + week (2025-W11) + month (2025-03) + year (2025) = 4.
+    expect(result.summarized).toBe(4);
+    expect(calls).toHaveLength(4);
+    expect(await summaryOf(userId, "2025")).toMatch(/^LLM summary/);
+    expect(await pendingOf(userId)).toEqual([]);
+  });
+
+  it("re-summarizes the cascade when old content is backfilled", async () => {
+    const userId = "u_full";
+    // New claim (createdAt = now > watermark) pointing at the old day.
+    await seedContent(userId, "2026-01-07", "Backfilled memo");
+
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // Day 2026-01-07 + week W02 + month 2026-01 re-run; W03 untouched.
+    expect(result.summarized).toBe(3);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("defers over-budget work to pending and resumes on the next sweep", async () => {
+    const userId = "u_budget";
+    await seedUser(userId);
+    await seedContent(userId, "2026-01-05", "A");
+    await seedContent(userId, "2026-01-06", "B");
+    await seedContent(userId, "2026-01-07", "C");
+    await seedContent(userId, "2026-01-08", "D");
+    await seedContent(userId, "2026-01-12", "E");
+
+    const { client: llm1, calls: calls1 } = stubLlm();
+    setExtractionClientOverride(llm1);
+    const first = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 3,
+      todayKey: TODAY,
+    });
+    expect(first.summarized).toBe(3);
+    expect(calls1).toHaveLength(3);
+    const pendingAfterFirst = await pendingOf(userId);
+    expect(pendingAfterFirst).toContain("2026-01-08");
+    expect(pendingAfterFirst).toContain("2026-W02");
+
+    const { client: llm2, calls: calls2 } = stubLlm();
+    setExtractionClientOverride(llm2);
+    const second = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      todayKey: TODAY,
+    });
+    // Remaining: days 01-08, 01-12 + weeks W02, W03 + month 2026-01 = 5.
+    expect(second.summarized).toBe(5);
+    expect(calls2).toHaveLength(5);
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+
+  it("startDate excludes pre-floor periods and purges them from pending", async () => {
+    const userId = "u_floor";
+    await seedUser(userId);
+    await seedContent(userId, "2025-12-15", "Old era");
+    await seedContent(userId, "2026-01-06", "New era");
+
+    // First sweep with a zero budget: everything ready lands in pending.
+    const { client: llm0 } = stubLlm();
+    setExtractionClientOverride(llm0);
+    const zero = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 0,
+      todayKey: TODAY,
+    });
+    expect(zero.summarized).toBe(0);
+    expect(await pendingOf(userId)).toContain("2025-12-15");
+
+    // Second sweep with the floor: 2025 periods are gone for good.
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const result = await runRollup({
+      db,
+      userId,
+      maxLlmCalls: 50,
+      startDate: "2026-01-01",
+      todayKey: TODAY,
+    });
+    // 2026-01-06 + W02 + 2026-01 = 3 (W02 ends 2026-01-11 ≥ floor).
+    expect(result.summarized).toBe(3);
+    expect(calls).toHaveLength(3);
+    expect(await summaryOf(userId, "2025-12-15")).toBeNull();
+    expect(await summaryOf(userId, "2025-12")).toBeNull();
+    expect(await pendingOf(userId)).toEqual(["2026"]);
+  });
+});

--- a/src/lib/jobs/rollup.test.ts
+++ b/src/lib/jobs/rollup.test.ts
@@ -4,11 +4,11 @@ import { Client } from "pg";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { DrizzleDB } from "~/db";
 import * as schema from "~/db/schema";
-import { ensurePeriodNode } from "~/lib/temporal";
 import {
   ROLLUP_TEST_TABLES_SQL,
   stubLlm,
 } from "~/lib/rollup/summarize-period.test";
+import { ensurePeriodNode } from "~/lib/temporal";
 import { newTypeId } from "~/types/typeid";
 import {
   resetTestOverrides,
@@ -126,7 +126,10 @@ describeIfServer("runRollup", () => {
     return rows.rows[0]?.pending_periods ?? [];
   }
 
-  async function summaryOf(userId: string, label: string): Promise<string | null> {
+  async function summaryOf(
+    userId: string,
+    label: string,
+  ): Promise<string | null> {
     const rows = await client.query(
       `SELECT m."description" FROM "node_metadata" m
        JOIN "nodes" n ON n."id" = m."node_id"

--- a/src/lib/jobs/rollup.ts
+++ b/src/lib/jobs/rollup.ts
@@ -82,7 +82,10 @@ export async function runRollup({
   let watermark = state?.watermark ?? null;
   const touchedDayKeys = new Set<string>();
   for (const row of touched) {
-    if (row.maxClaimCreatedAt && (!watermark || row.maxClaimCreatedAt > watermark)) {
+    if (
+      row.maxClaimCreatedAt &&
+      (!watermark || row.maxClaimCreatedAt > watermark)
+    ) {
       watermark = row.maxClaimCreatedAt;
     }
     if (row.dayLabel && isDayKey(row.dayLabel)) {

--- a/src/lib/jobs/rollup.ts
+++ b/src/lib/jobs/rollup.ts
@@ -1,0 +1,179 @@
+/**
+ * Temporal rollup sweep (see
+ * docs/superpowers/specs/2026-06-12-temporal-rollup-design.md).
+ *
+ * Catch-up semantics: discover days touched by OCCURRED_ON claims since
+ * the per-user watermark, expand to ancestor periods, union the pending
+ * set, then summarize completed periods bottom-up within an LLM-call
+ * budget. Never scheduled internally — triggered via POST /rollup.
+ */
+import {
+  ancestorKeysForDay,
+  dayKeyOf,
+  isDayKey,
+  isPeriodComplete,
+  periodEndDayKey,
+  sortForProcessing,
+} from "../rollup/period";
+import { ensureRollupSource } from "../rollup/source";
+import { summarizePeriod } from "../rollup/summarize-period";
+import { and, eq, gt, max, type SQL } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes, rollupState } from "~/db/schema";
+import { createCompletionClient } from "~/lib/ai";
+
+export interface RunRollupParams {
+  db: DrizzleDB;
+  userId: string;
+  /** Hard cap on LLM calls this sweep (fingerprint skips are free). */
+  maxLlmCalls: number;
+  /** History floor: periods ending before this day key are excluded. */
+  startDate?: string | undefined;
+  /** Test seam for completeness checks; defaults to the real today. */
+  todayKey?: string | undefined;
+}
+
+export interface RollupJobResult {
+  summarized: number;
+  skippedUnchanged: number;
+  skippedEmpty: number;
+  failed: number;
+  /** Periods left in pendingPeriods (incomplete, over budget, or failed). */
+  deferred: number;
+}
+
+export async function runRollup({
+  db,
+  userId,
+  maxLlmCalls,
+  startDate,
+  todayKey = dayKeyOf(new Date()),
+}: RunRollupParams): Promise<RollupJobResult> {
+  const [state] = await db
+    .select()
+    .from(rollupState)
+    .where(eq(rollupState.userId, userId))
+    .limit(1);
+
+  // 1. Discover: day labels touched by active OCCURRED_ON claims since
+  //    the watermark (all claims on the first sweep).
+  const conditions: SQL[] = [
+    eq(claims.userId, userId),
+    eq(claims.predicate, "OCCURRED_ON"),
+    eq(claims.status, "active"),
+    eq(nodes.nodeType, "Temporal"),
+  ];
+  if (state?.watermark) {
+    conditions.push(gt(claims.createdAt, state.watermark));
+  }
+  // Aggregated per day label: a heavy day (hundreds of claims) must not
+  // materialize one row per claim on a first, watermark-less sweep.
+  const touched = await db
+    .select({
+      dayLabel: nodeMetadata.label,
+      maxClaimCreatedAt: max(claims.createdAt),
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.objectNodeId))
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(and(...conditions))
+    .groupBy(nodeMetadata.label);
+
+  let watermark = state?.watermark ?? null;
+  const touchedDayKeys = new Set<string>();
+  for (const row of touched) {
+    if (row.maxClaimCreatedAt && (!watermark || row.maxClaimCreatedAt > watermark)) {
+      watermark = row.maxClaimCreatedAt;
+    }
+    if (row.dayLabel && isDayKey(row.dayLabel)) {
+      touchedDayKeys.add(row.dayLabel);
+    }
+  }
+
+  // 2. Expand to ancestors; union the carried-over pending set.
+  const workSet = new Set<string>(state?.pendingPeriods ?? []);
+  for (const dayKey of touchedDayKeys) {
+    workSet.add(dayKey);
+    for (const ancestor of ancestorKeysForDay(dayKey)) {
+      workSet.add(ancestor);
+    }
+  }
+
+  // 3. Filter: startDate floor excludes outright (incl. purging pending);
+  //    incomplete periods are deferred until they end.
+  const pending = new Set<string>();
+  const ready: string[] = [];
+  for (const key of workSet) {
+    if (startDate !== undefined && periodEndDayKey(key) < startDate) continue;
+    if (!isPeriodComplete(key, todayKey)) {
+      pending.add(key);
+      continue;
+    }
+    ready.push(key);
+  }
+
+  // 4. Process bottom-up, oldest first, within budget. A failing period
+  //    is logged, left pending, and must not block the rest.
+  const result: RollupJobResult = {
+    summarized: 0,
+    skippedUnchanged: 0,
+    skippedEmpty: 0,
+    failed: 0,
+    deferred: 0,
+  };
+  let budget = maxLlmCalls;
+  const client = await createCompletionClient(userId, {
+    task: "temporal_summary",
+  });
+  const rollupSourceId = await ensureRollupSource(db, userId);
+
+  for (const periodKey of sortForProcessing(ready)) {
+    if (budget <= 0) {
+      pending.add(periodKey);
+      continue;
+    }
+    try {
+      const outcome = await summarizePeriod({
+        db,
+        userId,
+        periodKey,
+        client,
+        rollupSourceId,
+      });
+      if (outcome === "summarized") {
+        budget -= 1;
+        result.summarized += 1;
+      } else if (outcome === "skipped-unchanged") {
+        result.skippedUnchanged += 1;
+      } else {
+        result.skippedEmpty += 1;
+      }
+    } catch (error) {
+      console.error(
+        `Rollup: failed to summarize ${periodKey} for user ${userId}:`,
+        error,
+      );
+      pending.add(periodKey);
+      result.failed += 1;
+    }
+  }
+  result.deferred = pending.size;
+
+  // 5. Commit state. The watermark always advances; pending carries the
+  //    deferred work.
+  const pendingPeriods = [...pending].sort();
+  await db
+    .insert(rollupState)
+    .values({
+      userId,
+      watermark,
+      pendingPeriods,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: rollupState.userId,
+      set: { watermark, pendingPeriods, updatedAt: new Date() },
+    });
+
+  return result;
+}

--- a/src/lib/jobs/rollup.ts
+++ b/src/lib/jobs/rollup.ts
@@ -8,7 +8,7 @@
  * budget. Never scheduled internally — triggered via POST /rollup.
  */
 import {
-  ancestorKeysForDay,
+  ancestorKeysOf,
   dayKeyOf,
   isDayKey,
   isPeriodComplete,
@@ -66,6 +66,11 @@ export async function runRollup({
   if (state?.watermark) {
     conditions.push(gt(claims.createdAt, state.watermark));
   }
+  // Known limitation: createdAt is assigned at INSERT but only becomes
+  // visible at COMMIT. A claim whose transaction commits after this query
+  // with a createdAt at or below the new watermark is missed until a later
+  // claim touches the same day. Acceptable: sweeps are caller-triggered
+  // and ingestion typically completes before the caller triggers one.
   // Aggregated per day label: a heavy day (hundreds of claims) must not
   // materialize one row per claim on a first, watermark-less sweep.
   const touched = await db
@@ -93,11 +98,16 @@ export async function runRollup({
     }
   }
 
-  // 2. Expand to ancestors; union the carried-over pending set.
+  // 2. Union touched days with the carried-over pending set, then expand
+  //    ancestors for EVERY key — including pending ones — so a period that
+  //    recovers from a failure or deferral re-stales its week/month/year.
+  //    Over-inclusion is free: unchanged ancestors fingerprint-skip.
   const workSet = new Set<string>(state?.pendingPeriods ?? []);
   for (const dayKey of touchedDayKeys) {
     workSet.add(dayKey);
-    for (const ancestor of ancestorKeysForDay(dayKey)) {
+  }
+  for (const key of [...workSet]) {
+    for (const ancestor of ancestorKeysOf(key)) {
       workSet.add(ancestor);
     }
   }
@@ -135,6 +145,10 @@ export async function runRollup({
       pending.add(periodKey);
       continue;
     }
+    // Pessimistic charge: the paid LLM call happens mid-summarizePeriod,
+    // and a failure after that call must still count against the cap.
+    // Skip outcomes never reach the LLM, so they refund the charge.
+    budget -= 1;
     try {
       const outcome = await summarizePeriod({
         db,
@@ -144,11 +158,12 @@ export async function runRollup({
         rollupSourceId,
       });
       if (outcome === "summarized") {
-        budget -= 1;
         result.summarized += 1;
       } else if (outcome === "skipped-unchanged") {
+        budget += 1;
         result.skippedUnchanged += 1;
       } else {
+        budget += 1;
         result.skippedEmpty += 1;
       }
     } catch (error) {

--- a/src/lib/queues.ts
+++ b/src/lib/queues.ts
@@ -10,6 +10,7 @@ import { IngestTranscriptJobInputSchema } from "./jobs/ingest-transcript";
 import { ProfileSynthesisJobInputSchema } from "./jobs/profile-synthesis";
 import { summarizeUserConversations } from "./jobs/summarize-conversation";
 import { DeepResearchJobInputSchema } from "./schemas/deep-research";
+import { rollupRequestSchema } from "./schemas/rollup";
 import { FlowProducer, Queue, Worker } from "bullmq";
 import IORedis from "ioredis";
 import { z } from "zod";
@@ -42,6 +43,21 @@ export const batchQueue = new Queue("batchProcessing", {
 export const SUMMARIZE_JOB_OPTIONS = {
   attempts: 3,
   backoff: { type: "exponential", delay: 1_000 },
+} as const;
+
+/**
+ * Retry profile for the temporal-rollup sweep. The sweep is idempotent
+ * (watermark + per-period fingerprints), so a BullMQ retry after a partial
+ * failure only re-pays for periods that were never written. `removeOnFail`
+ * keeps a short failure history without blocking the deterministic
+ * `rollup:<userId>` jobId from being re-enqueued later (the route removes
+ * finished/failed jobs before re-adding).
+ */
+export const ROLLUP_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: { type: "exponential", delay: 1_000 },
+  removeOnComplete: true,
+  removeOnFail: 100,
 } as const;
 
 /**
@@ -100,6 +116,21 @@ const worker = new Worker<SummarizeJobData | DreamJobData>(
         });
         console.log(
           `Summarized ${summaryResult.summarizedCount} conversations for user ${userId}.`,
+        );
+      } else if (job.name === "rollup") {
+        const { userId, maxLlmCalls, startDate } = rollupRequestSchema.parse(
+          job.data,
+        );
+        console.log(`Starting rollup job for user ${userId}`);
+        const { runRollup } = await import("./jobs/rollup");
+        const result = await runRollup({
+          db,
+          userId,
+          maxLlmCalls,
+          ...(startDate !== undefined ? { startDate } : {}),
+        });
+        console.log(
+          `Rollup for user ${userId}: ${result.summarized} summarized, ${result.skippedUnchanged} unchanged, ${result.skippedEmpty} empty, ${result.failed} failed, ${result.deferred} deferred.`,
         );
       } else if (job.name === "dream") {
         const { userId, assistantId, assistantDescription } =

--- a/src/lib/rollup/collect.test.ts
+++ b/src/lib/rollup/collect.test.ts
@@ -49,7 +49,12 @@ describe("buildDayInputText", () => {
     expect(buildDayInputText("2026-06-08", [])).toBeNull();
     expect(
       buildDayInputText("2026-06-08", [
-        { nodeType: "Event", label: null, description: null, createdAt: new Date(0) },
+        {
+          nodeType: "Event",
+          label: null,
+          description: null,
+          createdAt: new Date(0),
+        },
       ]),
     ).toBeNull();
   });

--- a/src/lib/rollup/collect.test.ts
+++ b/src/lib/rollup/collect.test.ts
@@ -1,0 +1,165 @@
+import {
+  DAY_ENTRY_MAX_CHARS,
+  DAY_INPUT_MAX_CHARS,
+  buildDayInputText,
+  buildMonthInputText,
+  buildWeekInputText,
+  buildYearInputText,
+  fingerprintOf,
+  readRollupMeta,
+} from "./collect";
+import { describe, expect, it } from "vitest";
+
+describe("fingerprintOf", () => {
+  it("is a stable sha256 hex of the input", () => {
+    expect(fingerprintOf("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect(fingerprintOf("abc")).toBe(fingerprintOf("abc"));
+    expect(fingerprintOf("abc")).not.toBe(fingerprintOf("abd"));
+  });
+});
+
+describe("readRollupMeta", () => {
+  it("reads a valid rollup marker", () => {
+    expect(
+      readRollupMeta({ rollup: { fingerprint: "f1", summarizedAt: "t1" } }),
+    ).toEqual({ fingerprint: "f1", summarizedAt: "t1" });
+  });
+
+  it("returns null for anything else", () => {
+    expect(readRollupMeta(null)).toBeNull();
+    expect(readRollupMeta(undefined)).toBeNull();
+    expect(readRollupMeta({})).toBeNull();
+    expect(readRollupMeta({ rollup: { fingerprint: 42 } })).toBeNull();
+    expect(readRollupMeta([])).toBeNull();
+    expect(readRollupMeta("rollup")).toBeNull();
+  });
+});
+
+describe("buildDayInputText", () => {
+  const entry = (label: string, description: string | null) => ({
+    nodeType: "Conversation",
+    label,
+    description,
+    createdAt: new Date("2026-06-08T10:00:00Z"),
+  });
+
+  it("returns null when there are no usable entries", () => {
+    expect(buildDayInputText("2026-06-08", [])).toBeNull();
+    expect(
+      buildDayInputText("2026-06-08", [
+        { nodeType: "Event", label: null, description: null, createdAt: new Date(0) },
+      ]),
+    ).toBeNull();
+  });
+
+  it("renders one capped line per entry, chronologically", () => {
+    const text = buildDayInputText("2026-06-08", [
+      entry("Standup", "Discussed the rollout plan with Sam."),
+      entry("Gym session", null),
+    ]);
+    expect(text).toContain("Day: 2026-06-08");
+    expect(text).toContain(
+      "- [Conversation] Standup: Discussed the rollout plan with Sam.",
+    );
+    expect(text).toContain("- [Conversation] Gym session");
+  });
+
+  it("truncates an oversize entry to the per-entry cap", () => {
+    const text = buildDayInputText("2026-06-08", [
+      entry("Long", "x".repeat(DAY_ENTRY_MAX_CHARS * 2)),
+    ]);
+    const line = text!.split("\n").find((l) => l.startsWith("- "));
+    expect(line!.length).toBeLessThanOrEqual(DAY_ENTRY_MAX_CHARS);
+  });
+
+  it("drops oldest entries beyond the total cap and says so", () => {
+    const entries = Array.from({ length: 100 }, (_, i) => ({
+      nodeType: "Document",
+      label: `Doc ${String(i).padStart(3, "0")}`,
+      description: "y".repeat(500),
+      createdAt: new Date(2026, 5, 8, 0, i),
+    }));
+    const text = buildDayInputText("2026-06-08", entries);
+    expect(text!.length).toBeLessThanOrEqual(DAY_INPUT_MAX_CHARS + 200);
+    expect(text).toContain("older entries omitted");
+    // newest entry survives, oldest is dropped
+    expect(text).toContain("Doc 099");
+    expect(text).not.toContain("Doc 000");
+  });
+});
+
+describe("buildWeekInputText", () => {
+  it("returns null when no day has a summary", () => {
+    expect(
+      buildWeekInputText("2026-W24", [
+        { key: "2026-06-08", summary: null },
+        { key: "2026-06-09", summary: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it("lists each day with its summary or a no-activity marker", () => {
+    const text = buildWeekInputText("2026-W24", [
+      { key: "2026-06-08", summary: "Shipped the rollup spec." },
+      { key: "2026-06-09", summary: null },
+    ]);
+    expect(text).toContain("Week: 2026-W24");
+    expect(text).toContain("2026-06-08: Shipped the rollup spec.");
+    expect(text).toContain("2026-06-09: (no summarized activity)");
+  });
+});
+
+describe("buildMonthInputText", () => {
+  it("annotates boundary weeks with their in-month days", () => {
+    const text = buildMonthInputText("2026-06", [
+      {
+        weekKey: "2026-W23",
+        summary: "Full week in June.",
+        dayKeysInMonth: [
+          "2026-06-01",
+          "2026-06-02",
+          "2026-06-03",
+          "2026-06-04",
+          "2026-06-05",
+          "2026-06-06",
+          "2026-06-07",
+        ],
+      },
+      {
+        weekKey: "2026-W27",
+        summary: "Straddles into July.",
+        dayKeysInMonth: ["2026-06-29", "2026-06-30"],
+      },
+    ]);
+    expect(text).toContain("Month: 2026-06");
+    expect(text).toContain("2026-W23: Full week in June.");
+    expect(text).toContain(
+      "2026-W27 (only 2026-06-29 to 2026-06-30 fall in this month): Straddles into July.",
+    );
+  });
+
+  it("returns null when no week has a summary", () => {
+    expect(
+      buildMonthInputText("2026-06", [
+        { weekKey: "2026-W23", summary: null, dayKeysInMonth: [] },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("buildYearInputText", () => {
+  it("lists months with summaries or markers, null when empty", () => {
+    expect(
+      buildYearInputText("2026", [{ key: "2026-01", summary: null }]),
+    ).toBeNull();
+    const text = buildYearInputText("2026", [
+      { key: "2026-01", summary: "January arc." },
+      { key: "2026-02", summary: null },
+    ]);
+    expect(text).toContain("Year: 2026");
+    expect(text).toContain("2026-01: January arc.");
+    expect(text).toContain("2026-02: (no summarized activity)");
+  });
+});

--- a/src/lib/rollup/collect.ts
+++ b/src/lib/rollup/collect.ts
@@ -1,0 +1,317 @@
+/**
+ * Deterministic input assembly for temporal rollup summaries.
+ *
+ * Pure builders turn child rows into the exact prompt-input text; the
+ * sha256 of that text is the period's staleness fingerprint (input
+ * unchanged → fingerprint match → no LLM call). Thin DB fetchers load
+ * the child rows. No LLM calls happen here.
+ *
+ * Aliases for search: rollup input collection, compaction, period
+ * fingerprint, day entries.
+ */
+import {
+  monthKeysOfYear,
+  weekDayKeys,
+  weeksOverlappingMonth,
+} from "./period";
+import { and, eq, inArray } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+
+/** Initial caps — tunable. Bounds even heavy days (e.g. screenpipe docs). */
+export const DAY_ENTRY_MAX_CHARS = 600;
+export const DAY_INPUT_MAX_CHARS = 24_000;
+
+export function fingerprintOf(inputText: string): string {
+  return createHash("sha256").update(inputText, "utf8").digest("hex");
+}
+
+export interface RollupMeta {
+  fingerprint: string;
+  summarizedAt: string;
+}
+
+/** Defensive read of `nodeMetadata.additionalData.rollup`. */
+export function readRollupMeta(additionalData: unknown): RollupMeta | null {
+  if (
+    !additionalData ||
+    typeof additionalData !== "object" ||
+    Array.isArray(additionalData)
+  ) {
+    return null;
+  }
+  const rollup = (additionalData as Record<string, unknown>)["rollup"];
+  if (!rollup || typeof rollup !== "object" || Array.isArray(rollup)) {
+    return null;
+  }
+  const { fingerprint, summarizedAt } = rollup as Record<string, unknown>;
+  if (typeof fingerprint !== "string" || typeof summarizedAt !== "string") {
+    return null;
+  }
+  return { fingerprint, summarizedAt };
+}
+
+// --- Pure builders ---
+
+export interface DayEntry {
+  nodeType: string;
+  label: string | null;
+  description: string | null;
+  createdAt: Date;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+export function buildDayInputText(
+  dayKey: string,
+  entries: DayEntry[],
+): string | null {
+  const usable = entries
+    .filter((e) => e.label !== null || e.description !== null)
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  if (usable.length === 0) return null;
+
+  const lines = usable.map((e) =>
+    truncate(
+      `- [${e.nodeType}] ${e.label ?? "(unlabeled)"}${
+        e.description ? `: ${e.description}` : ""
+      }`,
+      DAY_ENTRY_MAX_CHARS,
+    ),
+  );
+
+  // Keep the newest lines under the total cap; render chronologically.
+  const kept: string[] = [];
+  let total = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!;
+    if (total + line.length + 1 > DAY_INPUT_MAX_CHARS) break;
+    kept.unshift(line);
+    total += line.length + 1;
+  }
+  const dropped = lines.length - kept.length;
+
+  return [
+    `Day: ${dayKey}`,
+    ...(dropped > 0 ? [`(${dropped} older entries omitted for length)`] : []),
+    ...kept,
+  ].join("\n");
+}
+
+export interface ChildSummary {
+  key: string;
+  summary: string | null;
+}
+
+export function buildWeekInputText(
+  weekKey: string,
+  days: ChildSummary[],
+): string | null {
+  if (days.every((d) => d.summary === null)) return null;
+  const lines = days.map(
+    (d) => `${d.key}: ${d.summary ?? "(no summarized activity)"}`,
+  );
+  return [`Week: ${weekKey}`, ...lines].join("\n\n");
+}
+
+export interface WeekSummaryInMonth {
+  weekKey: string;
+  summary: string | null;
+  dayKeysInMonth: string[];
+}
+
+export function buildMonthInputText(
+  monthKey: string,
+  weeks: WeekSummaryInMonth[],
+): string | null {
+  if (weeks.every((w) => w.summary === null)) return null;
+  const lines = weeks.map((w) => {
+    const partial =
+      w.dayKeysInMonth.length > 0 && w.dayKeysInMonth.length < 7
+        ? ` (only ${w.dayKeysInMonth[0]} to ${w.dayKeysInMonth[w.dayKeysInMonth.length - 1]} fall in this month)`
+        : "";
+    return `${w.weekKey}${partial}: ${w.summary ?? "(no summarized activity)"}`;
+  });
+  return [`Month: ${monthKey}`, ...lines].join("\n\n");
+}
+
+export function buildYearInputText(
+  yearKey: string,
+  months: ChildSummary[],
+): string | null {
+  if (months.every((m) => m.summary === null)) return null;
+  const lines = months.map(
+    (m) => `${m.key}: ${m.summary ?? "(no summarized activity)"}`,
+  );
+  return [`Year: ${yearKey}`, ...lines].join("\n\n");
+}
+
+// --- DB fetchers (exercised by the summarize-period and rollup job tests) ---
+
+export interface TemporalNodeRow {
+  nodeId: TypeId<"node">;
+  label: string;
+  description: string | null;
+  additionalData: unknown;
+}
+
+/** Fetch the user's Temporal nodes for the given period-key labels. */
+export async function fetchTemporalNodesByLabels(
+  db: DrizzleDB,
+  userId: string,
+  labels: string[],
+): Promise<Map<string, TemporalNodeRow>> {
+  if (labels.length === 0) return new Map();
+  const rows = await db
+    .select({
+      nodeId: nodes.id,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      additionalData: nodeMetadata.additionalData,
+    })
+    .from(nodes)
+    .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(nodes.userId, userId),
+        eq(nodes.nodeType, "Temporal"),
+        inArray(nodeMetadata.label, labels),
+      ),
+    );
+  return new Map(
+    rows
+      .filter((r): r is typeof r & { label: string } => r.label !== null)
+      .map((r) => [r.label, r]),
+  );
+}
+
+/**
+ * A child period's summary counts only when the rollup marker is present —
+ * `description` alone may be the "Represents the …" boilerplate.
+ */
+function summarizedDescriptionOf(row: TemporalNodeRow | undefined): string | null {
+  if (!row) return null;
+  return readRollupMeta(row.additionalData) ? row.description : null;
+}
+
+/** Content entries linked to a day node via active OCCURRED_ON claims. */
+export async function fetchDayEntries(
+  db: DrizzleDB,
+  userId: string,
+  dayNodeId: TypeId<"node">,
+): Promise<DayEntry[]> {
+  return db
+    .select({
+      nodeType: nodes.nodeType,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      createdAt: nodes.createdAt,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.objectNodeId, dayNodeId),
+        eq(claims.predicate, "OCCURRED_ON"),
+        eq(claims.status, "active"),
+      ),
+    )
+    // Stable order even for same-millisecond rows: createdAt ties would
+    // otherwise flip with heap order and churn the input fingerprint,
+    // causing spurious paid LLM re-summarizations.
+    .orderBy(nodes.createdAt, nodes.id);
+}
+
+export interface CollectedInput {
+  inputText: string;
+  /** Existing child period nodes — used to ensure PART_OF claims. */
+  childNodeIds: TypeId<"node">[];
+}
+
+/**
+ * Assemble the full prompt input for a period. Returns null when there is
+ * nothing to summarize (no content for a day; no summarized children for
+ * week/month/year).
+ */
+export async function collectPeriodInput(
+  db: DrizzleDB,
+  userId: string,
+  periodKey: string,
+  level: "day" | "week" | "month" | "year",
+): Promise<CollectedInput | null> {
+  if (level === "day") {
+    const dayNode = (
+      await fetchTemporalNodesByLabels(db, userId, [periodKey])
+    ).get(periodKey);
+    if (!dayNode) return null;
+    const entries = await fetchDayEntries(db, userId, dayNode.nodeId);
+    const inputText = buildDayInputText(periodKey, entries);
+    return inputText ? { inputText, childNodeIds: [] } : null;
+  }
+
+  if (level === "week") {
+    const dayKeys = weekDayKeys(periodKey);
+    const dayNodes = await fetchTemporalNodesByLabels(db, userId, dayKeys);
+    const inputText = buildWeekInputText(
+      periodKey,
+      dayKeys.map((key) => ({
+        key,
+        summary: summarizedDescriptionOf(dayNodes.get(key)),
+      })),
+    );
+    if (!inputText) return null;
+    return {
+      inputText,
+      childNodeIds: dayKeys
+        .map((key) => dayNodes.get(key)?.nodeId)
+        .filter((id): id is TypeId<"node"> => id !== undefined),
+    };
+  }
+
+  if (level === "month") {
+    const weeks = weeksOverlappingMonth(periodKey);
+    const weekNodes = await fetchTemporalNodesByLabels(
+      db,
+      userId,
+      weeks.map((w) => w.weekKey),
+    );
+    const inputText = buildMonthInputText(
+      periodKey,
+      weeks.map((w) => ({
+        weekKey: w.weekKey,
+        summary: summarizedDescriptionOf(weekNodes.get(w.weekKey)),
+        dayKeysInMonth: w.dayKeysInMonth,
+      })),
+    );
+    if (!inputText) return null;
+    return {
+      inputText,
+      childNodeIds: weeks
+        .map((w) => weekNodes.get(w.weekKey)?.nodeId)
+        .filter((id): id is TypeId<"node"> => id !== undefined),
+    };
+  }
+
+  const monthKeys = monthKeysOfYear(periodKey);
+  const monthNodes = await fetchTemporalNodesByLabels(db, userId, monthKeys);
+  const inputText = buildYearInputText(
+    periodKey,
+    monthKeys.map((key) => ({
+      key,
+      summary: summarizedDescriptionOf(monthNodes.get(key)),
+    })),
+  );
+  if (!inputText) return null;
+  return {
+    inputText,
+    childNodeIds: monthKeys
+      .map((key) => monthNodes.get(key)?.nodeId)
+      .filter((id): id is TypeId<"node"> => id !== undefined),
+  };
+}

--- a/src/lib/rollup/collect.ts
+++ b/src/lib/rollup/collect.ts
@@ -9,11 +9,7 @@
  * Aliases for search: rollup input collection, compaction, period
  * fingerprint, day entries.
  */
-import {
-  monthKeysOfYear,
-  weekDayKeys,
-  weeksOverlappingMonth,
-} from "./period";
+import { monthKeysOfYear, weekDayKeys, weeksOverlappingMonth } from "./period";
 import { and, eq, inArray } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import type { DrizzleDB } from "~/db";
@@ -193,7 +189,9 @@ export async function fetchTemporalNodesByLabels(
  * A child period's summary counts only when the rollup marker is present —
  * `description` alone may be the "Represents the …" boilerplate.
  */
-function summarizedDescriptionOf(row: TemporalNodeRow | undefined): string | null {
+function summarizedDescriptionOf(
+  row: TemporalNodeRow | undefined,
+): string | null {
   if (!row) return null;
   return readRollupMeta(row.additionalData) ? row.description : null;
 }
@@ -204,28 +202,30 @@ export async function fetchDayEntries(
   userId: string,
   dayNodeId: TypeId<"node">,
 ): Promise<DayEntry[]> {
-  return db
-    .select({
-      nodeType: nodes.nodeType,
-      label: nodeMetadata.label,
-      description: nodeMetadata.description,
-      createdAt: nodes.createdAt,
-    })
-    .from(claims)
-    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
-    .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
-    .where(
-      and(
-        eq(claims.userId, userId),
-        eq(claims.objectNodeId, dayNodeId),
-        eq(claims.predicate, "OCCURRED_ON"),
-        eq(claims.status, "active"),
-      ),
-    )
-    // Stable order even for same-millisecond rows: createdAt ties would
-    // otherwise flip with heap order and churn the input fingerprint,
-    // causing spurious paid LLM re-summarizations.
-    .orderBy(nodes.createdAt, nodes.id);
+  return (
+    db
+      .select({
+        nodeType: nodes.nodeType,
+        label: nodeMetadata.label,
+        description: nodeMetadata.description,
+        createdAt: nodes.createdAt,
+      })
+      .from(claims)
+      .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+      .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .where(
+        and(
+          eq(claims.userId, userId),
+          eq(claims.objectNodeId, dayNodeId),
+          eq(claims.predicate, "OCCURRED_ON"),
+          eq(claims.status, "active"),
+        ),
+      )
+      // Stable order even for same-millisecond rows: createdAt ties would
+      // otherwise flip with heap order and churn the input fingerprint,
+      // causing spurious paid LLM re-summarizations.
+      .orderBy(nodes.createdAt, nodes.id)
+  );
 }
 
 export interface CollectedInput {

--- a/src/lib/rollup/period.test.ts
+++ b/src/lib/rollup/period.test.ts
@@ -1,5 +1,6 @@
 import {
   ancestorKeysForDay,
+  ancestorKeysOf,
   isPeriodComplete,
   monthKeyForDay,
   monthKeysForWeek,
@@ -115,6 +116,25 @@ describe("ancestorKeysForDay", () => {
       "2026",
       "2027",
     ]);
+  });
+});
+
+describe("ancestorKeysOf", () => {
+  it("returns transitive ancestors for any period level", () => {
+    expect(ancestorKeysOf("2026-06-08")).toEqual([
+      "2026-W24",
+      "2026-06",
+      "2026",
+    ]);
+    expect(ancestorKeysOf("2026-W24")).toEqual(["2026-06", "2026"]);
+    expect(ancestorKeysOf("2026-W53")).toEqual([
+      "2026-12",
+      "2027-01",
+      "2026",
+      "2027",
+    ]);
+    expect(ancestorKeysOf("2026-06")).toEqual(["2026"]);
+    expect(ancestorKeysOf("2026")).toEqual([]);
   });
 });
 

--- a/src/lib/rollup/period.test.ts
+++ b/src/lib/rollup/period.test.ts
@@ -1,0 +1,159 @@
+import {
+  ancestorKeysForDay,
+  isPeriodComplete,
+  monthKeyForDay,
+  monthKeysForWeek,
+  monthKeysOfYear,
+  periodEndDayKey,
+  periodLevelOf,
+  sortForProcessing,
+  weekDayKeys,
+  weekKeyForDay,
+  weeksOverlappingMonth,
+  yearKeyForMonth,
+} from "./period";
+import { describe, expect, it } from "vitest";
+
+describe("periodLevelOf", () => {
+  it("classifies keys by shape", () => {
+    expect(periodLevelOf("2026-06-08")).toBe("day");
+    expect(periodLevelOf("2026-W24")).toBe("week");
+    expect(periodLevelOf("2026-06")).toBe("month");
+    expect(periodLevelOf("2026")).toBe("year");
+  });
+
+  it("throws on malformed keys", () => {
+    expect(() => periodLevelOf("2026-6-8")).toThrow();
+    expect(() => periodLevelOf("W24")).toThrow();
+    expect(() => periodLevelOf("")).toThrow();
+  });
+});
+
+describe("weekKeyForDay", () => {
+  it("maps a mid-year Monday to its ISO week", () => {
+    // 2026-06-08 is a Monday in ISO week 24 of 2026.
+    expect(weekKeyForDay("2026-06-08")).toBe("2026-W24");
+    expect(weekKeyForDay("2026-06-14")).toBe("2026-W24"); // its Sunday
+  });
+
+  it("assigns early-January days to the correct ISO week-numbering year", () => {
+    // 2026 W01 spans 2025-12-29 .. 2026-01-04.
+    expect(weekKeyForDay("2025-12-29")).toBe("2026-W01");
+    expect(weekKeyForDay("2026-01-01")).toBe("2026-W01");
+    // 2026 has 53 ISO weeks; W53 spans 2026-12-28 .. 2027-01-03.
+    expect(weekKeyForDay("2027-01-01")).toBe("2026-W53");
+  });
+});
+
+describe("weekDayKeys", () => {
+  it("returns Monday..Sunday day keys", () => {
+    expect(weekDayKeys("2026-W24")).toEqual([
+      "2026-06-08",
+      "2026-06-09",
+      "2026-06-10",
+      "2026-06-11",
+      "2026-06-12",
+      "2026-06-13",
+      "2026-06-14",
+    ]);
+  });
+
+  it("handles a year-straddling week", () => {
+    expect(weekDayKeys("2026-W53")[0]).toBe("2026-12-28");
+    expect(weekDayKeys("2026-W53")[6]).toBe("2027-01-03");
+  });
+});
+
+describe("month/year containment", () => {
+  it("maps days and months upward by prefix", () => {
+    expect(monthKeyForDay("2026-06-08")).toBe("2026-06");
+    expect(yearKeyForMonth("2026-06")).toBe("2026");
+    expect(monthKeysOfYear("2026")).toHaveLength(12);
+    expect(monthKeysOfYear("2026")[0]).toBe("2026-01");
+    expect(monthKeysOfYear("2026")[11]).toBe("2026-12");
+  });
+
+  it("finds the month(s) a week overlaps", () => {
+    expect(monthKeysForWeek("2026-W24")).toEqual(["2026-06"]);
+    // W53 2026 straddles December 2026 and January 2027.
+    expect(monthKeysForWeek("2026-W53")).toEqual(["2026-12", "2027-01"]);
+  });
+});
+
+describe("weeksOverlappingMonth", () => {
+  it("lists every overlapping ISO week with its in-month days", () => {
+    // June 2026: Jun 1 is a Monday (W23); Jun 29-30 fall in W27.
+    const weeks = weeksOverlappingMonth("2026-06");
+    expect(weeks.map((w) => w.weekKey)).toEqual([
+      "2026-W23",
+      "2026-W24",
+      "2026-W25",
+      "2026-W26",
+      "2026-W27",
+    ]);
+    const last = weeks[4]!;
+    expect(last.dayKeysInMonth).toEqual(["2026-06-29", "2026-06-30"]);
+    const first = weeks[0]!;
+    expect(first.dayKeysInMonth).toHaveLength(7);
+  });
+});
+
+describe("ancestorKeysForDay", () => {
+  it("returns week, overlapping months, and their years", () => {
+    expect(ancestorKeysForDay("2026-06-08")).toEqual([
+      "2026-W24",
+      "2026-06",
+      "2026",
+    ]);
+  });
+
+  it("includes both straddled months and years at a boundary", () => {
+    expect(ancestorKeysForDay("2027-01-01")).toEqual([
+      "2026-W53",
+      "2026-12",
+      "2027-01",
+      "2026",
+      "2027",
+    ]);
+  });
+});
+
+describe("periodEndDayKey / isPeriodComplete", () => {
+  it("computes the period's final day", () => {
+    expect(periodEndDayKey("2026-06-08")).toBe("2026-06-08");
+    expect(periodEndDayKey("2026-W24")).toBe("2026-06-14");
+    expect(periodEndDayKey("2026-06")).toBe("2026-06-30");
+    expect(periodEndDayKey("2026-02")).toBe("2026-02-28");
+    expect(periodEndDayKey("2026")).toBe("2026-12-31");
+  });
+
+  it("a period is complete only when its last day is strictly before today", () => {
+    expect(isPeriodComplete("2026-W24", "2026-06-14")).toBe(false);
+    expect(isPeriodComplete("2026-W24", "2026-06-15")).toBe(true);
+    expect(isPeriodComplete("2026-06-14", "2026-06-15")).toBe(true);
+    expect(isPeriodComplete("2026", "2026-12-31")).toBe(false);
+    expect(isPeriodComplete("2026", "2027-01-01")).toBe(true);
+  });
+});
+
+describe("sortForProcessing", () => {
+  it("orders bottom-up by level, then oldest-first within a level", () => {
+    expect(
+      sortForProcessing([
+        "2026",
+        "2026-06",
+        "2026-W24",
+        "2026-06-09",
+        "2026-06-08",
+        "2026-W23",
+      ]),
+    ).toEqual([
+      "2026-06-08",
+      "2026-06-09",
+      "2026-W23",
+      "2026-W24",
+      "2026-06",
+      "2026",
+    ]);
+  });
+});

--- a/src/lib/rollup/period.ts
+++ b/src/lib/rollup/period.ts
@@ -120,9 +120,7 @@ export function weeksOverlappingMonth(monthKey: string): WeekInMonth[] {
   let weekKey = weekKeyForDay(firstDayKey);
   for (;;) {
     const days = weekDayKeys(weekKey);
-    const dayKeysInMonth = days.filter(
-      (d) => monthKeyForDay(d) === monthKey,
-    );
+    const dayKeysInMonth = days.filter((d) => monthKeyForDay(d) === monthKey);
     result.push({ weekKey, dayKeysInMonth });
     const sunday = days[6]!;
     if (sunday >= lastDayKey) break;
@@ -172,7 +170,8 @@ const LEVEL_ORDER: Record<PeriodLevel, number> = {
 /** Bottom-up (day→week→month→year), oldest-first within each level. */
 export function sortForProcessing(keys: string[]): string[] {
   return [...keys].sort((a, b) => {
-    const levelDiff = LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
+    const levelDiff =
+      LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
     if (levelDiff !== 0) return levelDiff;
     return a < b ? -1 : a > b ? 1 : 0;
   });

--- a/src/lib/rollup/period.ts
+++ b/src/lib/rollup/period.ts
@@ -141,6 +141,29 @@ export function ancestorKeysForDay(dayKey: string): string[] {
   return [weekKey, ...monthKeys, ...yearKeys];
 }
 
+/**
+ * Ancestors of any period key, transitively up the hierarchy: a day's
+ * week/months/years, a week's months and their years, a month's year.
+ * Lets the sweep re-stale ancestors whenever a period (re-)runs, so
+ * recovered failures and deferred work cascade upward exactly like
+ * fresh claims.
+ */
+export function ancestorKeysOf(key: string): string[] {
+  switch (periodLevelOf(key)) {
+    case "day":
+      return ancestorKeysForDay(key);
+    case "week": {
+      const monthKeys = monthKeysForWeek(key);
+      const yearKeys = [...new Set(monthKeys.map(yearKeyForMonth))];
+      return [...monthKeys, ...yearKeys];
+    }
+    case "month":
+      return [yearKeyForMonth(key)];
+    case "year":
+      return [];
+  }
+}
+
 export function periodEndDayKey(key: string): string {
   const level = periodLevelOf(key);
   switch (level) {

--- a/src/lib/rollup/period.ts
+++ b/src/lib/rollup/period.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure period-key math for the temporal rollup hierarchy.
+ *
+ * Period keys (all derived from the day-label convention used by
+ * `ensureDayNode`): day `yyyy-MM-dd`, ISO week `yyyy-Www` (ISO
+ * week-numbering year), month `yyyy-MM`, year `yyyy`. All functions are
+ * pure and timezone-stable: day keys are parsed and re-formatted with
+ * date-fns in local time, so round-trips never shift dates.
+ *
+ * Aliases for search: period keys, temporal hierarchy, ISO week math,
+ * rollup periods.
+ */
+import {
+  addDays,
+  format,
+  getISOWeek,
+  getISOWeekYear,
+  lastDayOfMonth,
+  parse,
+  setISOWeek,
+  setISOWeekYear,
+  startOfISOWeek,
+} from "date-fns";
+
+export type PeriodLevel = "day" | "week" | "month" | "year";
+
+const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const WEEK_KEY_RE = /^(\d{4})-W(\d{2})$/;
+const MONTH_KEY_RE = /^\d{4}-\d{2}$/;
+const YEAR_KEY_RE = /^\d{4}$/;
+
+const REFERENCE_DATE = new Date(2000, 0, 1);
+
+export function periodLevelOf(key: string): PeriodLevel {
+  if (DAY_KEY_RE.test(key)) return "day";
+  if (WEEK_KEY_RE.test(key)) return "week";
+  if (MONTH_KEY_RE.test(key)) return "month";
+  if (YEAR_KEY_RE.test(key)) return "year";
+  throw new Error(`Malformed period key: "${key}"`);
+}
+
+export function isDayKey(key: string): boolean {
+  return DAY_KEY_RE.test(key);
+}
+
+function dayDate(dayKey: string): Date {
+  return parse(dayKey, "yyyy-MM-dd", REFERENCE_DATE);
+}
+
+export function dayKeyOf(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+export function weekKeyForDay(dayKey: string): string {
+  const d = dayDate(dayKey);
+  const isoYear = String(getISOWeekYear(d)).padStart(4, "0");
+  const isoWeek = String(getISOWeek(d)).padStart(2, "0");
+  return `${isoYear}-W${isoWeek}`;
+}
+
+function mondayOfWeek(weekKey: string): Date {
+  const match = WEEK_KEY_RE.exec(weekKey);
+  if (!match) throw new Error(`Malformed week key: "${weekKey}"`);
+  const isoYear = Number(match[1]);
+  const isoWeek = Number(match[2]);
+  // Anchor mid-year so week 26 always exists before the ISO fields are set.
+  let d = new Date(2000, 6, 1);
+  d = setISOWeekYear(d, isoYear);
+  d = setISOWeek(d, isoWeek);
+  return startOfISOWeek(d);
+}
+
+export function weekDayKeys(weekKey: string): string[] {
+  const monday = mondayOfWeek(weekKey);
+  return Array.from({ length: 7 }, (_, i) => dayKeyOf(addDays(monday, i)));
+}
+
+export function monthKeyForDay(dayKey: string): string {
+  if (!DAY_KEY_RE.test(dayKey)) {
+    throw new Error(`Malformed day key: "${dayKey}"`);
+  }
+  return dayKey.slice(0, 7);
+}
+
+export function monthKeysForWeek(weekKey: string): string[] {
+  const days = weekDayKeys(weekKey);
+  return [...new Set(days.map(monthKeyForDay))];
+}
+
+export function yearKeyForMonth(monthKey: string): string {
+  if (!MONTH_KEY_RE.test(monthKey)) {
+    throw new Error(`Malformed month key: "${monthKey}"`);
+  }
+  return monthKey.slice(0, 4);
+}
+
+export function monthKeysOfYear(yearKey: string): string[] {
+  if (!YEAR_KEY_RE.test(yearKey)) {
+    throw new Error(`Malformed year key: "${yearKey}"`);
+  }
+  return Array.from(
+    { length: 12 },
+    (_, i) => `${yearKey}-${String(i + 1).padStart(2, "0")}`,
+  );
+}
+
+export interface WeekInMonth {
+  weekKey: string;
+  /** The subset of this week's 7 days that fall inside the month. */
+  dayKeysInMonth: string[];
+}
+
+export function weeksOverlappingMonth(monthKey: string): WeekInMonth[] {
+  if (!MONTH_KEY_RE.test(monthKey)) {
+    throw new Error(`Malformed month key: "${monthKey}"`);
+  }
+  const firstDayKey = `${monthKey}-01`;
+  const lastDayKey = dayKeyOf(lastDayOfMonth(dayDate(firstDayKey)));
+  const result: WeekInMonth[] = [];
+  let weekKey = weekKeyForDay(firstDayKey);
+  for (;;) {
+    const days = weekDayKeys(weekKey);
+    const dayKeysInMonth = days.filter(
+      (d) => monthKeyForDay(d) === monthKey,
+    );
+    result.push({ weekKey, dayKeysInMonth });
+    const sunday = days[6]!;
+    if (sunday >= lastDayKey) break;
+    weekKey = weekKeyForDay(dayKeyOf(addDays(dayDate(sunday), 1)));
+  }
+  return result;
+}
+
+/**
+ * Every period whose summary input can change when this day's summary
+ * changes: the day's ISO week, every month that week overlaps (a
+ * boundary week feeds two month summaries), and those months' years.
+ */
+export function ancestorKeysForDay(dayKey: string): string[] {
+  const weekKey = weekKeyForDay(dayKey);
+  const monthKeys = monthKeysForWeek(weekKey);
+  const yearKeys = [...new Set(monthKeys.map(yearKeyForMonth))];
+  return [weekKey, ...monthKeys, ...yearKeys];
+}
+
+export function periodEndDayKey(key: string): string {
+  const level = periodLevelOf(key);
+  switch (level) {
+    case "day":
+      return key;
+    case "week":
+      return weekDayKeys(key)[6]!;
+    case "month":
+      return dayKeyOf(lastDayOfMonth(dayDate(`${key}-01`)));
+    case "year":
+      return `${key}-12-31`;
+  }
+}
+
+/** A period is complete once its final day is strictly before today. */
+export function isPeriodComplete(key: string, todayDayKey: string): boolean {
+  return periodEndDayKey(key) < todayDayKey;
+}
+
+const LEVEL_ORDER: Record<PeriodLevel, number> = {
+  day: 0,
+  week: 1,
+  month: 2,
+  year: 3,
+};
+
+/** Bottom-up (day→week→month→year), oldest-first within each level. */
+export function sortForProcessing(keys: string[]): string[] {
+  return [...keys].sort((a, b) => {
+    const levelDiff = LEVEL_ORDER[periodLevelOf(a)] - LEVEL_ORDER[periodLevelOf(b)];
+    if (levelDiff !== 0) return levelDiff;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+}

--- a/src/lib/rollup/source.test.ts
+++ b/src/lib/rollup/source.test.ts
@@ -1,0 +1,99 @@
+import { ensureRollupSource } from "./source";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("ensureRollupSource", () => {
+  const dbName = `memory_rollup_source_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(`
+      CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE "sources" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "type" varchar(50) NOT NULL,
+        "external_id" text NOT NULL,
+        "parent_source" text,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "metadata" jsonb,
+        "last_ingested_at" timestamp with time zone,
+        "status" varchar(20) DEFAULT 'pending',
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "deleted_at" timestamp with time zone,
+        "content_type" varchar(100),
+        "content_length" integer,
+        CONSTRAINT "sources_user_type_external_unique"
+          UNIQUE ("user_id", "type", "external_id")
+      );
+    `);
+    await client.query(`INSERT INTO "users" ("id") VALUES ('user_rollup')`);
+  });
+
+  afterAll(async () => {
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("creates the source once and returns the same id thereafter", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    const first = await ensureRollupSource(db, "user_rollup");
+    const second = await ensureRollupSource(db, "user_rollup");
+    expect(second).toBe(first);
+
+    const rows = await client.query(
+      `SELECT "type", "external_id", "status" FROM "sources" WHERE "user_id" = 'user_rollup'`,
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0]).toMatchObject({
+      type: "rollup",
+      external_id: "rollup",
+      status: "completed",
+    });
+  });
+});

--- a/src/lib/rollup/source.ts
+++ b/src/lib/rollup/source.ts
@@ -1,0 +1,48 @@
+/**
+ * Synthetic per-user source backing rollup-generated PART_OF claims
+ * (`claims.sourceId` is NOT NULL and containment claims have no natural
+ * ingestion source). Mirrors the metric-source pattern in
+ * `src/lib/metrics/sources.ts`.
+ */
+import { and, eq } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { sources } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+
+const ROLLUP_EXTERNAL_ID = "rollup";
+
+export async function ensureRollupSource(
+  db: DrizzleDB,
+  userId: string,
+): Promise<TypeId<"source">> {
+  const [inserted] = await db
+    .insert(sources)
+    .values({
+      userId,
+      type: "rollup",
+      externalId: ROLLUP_EXTERNAL_ID,
+      scope: "personal",
+      status: "completed",
+    })
+    .onConflictDoNothing({
+      target: [sources.userId, sources.type, sources.externalId],
+    })
+    .returning({ id: sources.id });
+  if (inserted) return inserted.id;
+
+  const [existing] = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(
+      and(
+        eq(sources.userId, userId),
+        eq(sources.type, "rollup"),
+        eq(sources.externalId, ROLLUP_EXTERNAL_ID),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error(`Failed to ensure rollup source for user ${userId}`);
+  }
+  return existing.id;
+}

--- a/src/lib/rollup/summarize-period.test.ts
+++ b/src/lib/rollup/summarize-period.test.ts
@@ -1,5 +1,6 @@
 import { ensureRollupSource } from "./source";
 import { summarizePeriod } from "./summarize-period";
+import { ROLLUP_TEST_TABLES_SQL, stubLlm } from "./test-helpers";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -11,7 +12,6 @@ import {
   resetTestOverrides,
   setExtractionClientOverride,
   setSkipEmbeddingPersistence,
-  type StubCompletionClient,
 } from "~/utils/test-overrides";
 
 const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
@@ -38,103 +38,6 @@ async function isServerReachable(): Promise<boolean> {
 
 const SERVER_AVAILABLE = await isServerReachable();
 const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
-
-/** All tables the rollup write path touches (embeddings are skipped). */
-export const ROLLUP_TEST_TABLES_SQL = `
-  CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
-  CREATE TABLE "nodes" (
-    "id" text PRIMARY KEY NOT NULL,
-    "user_id" text NOT NULL REFERENCES "users"("id"),
-    "node_type" varchar(50) NOT NULL,
-    "created_at" timestamp with time zone DEFAULT now() NOT NULL
-  );
-  CREATE TABLE "node_metadata" (
-    "id" text PRIMARY KEY NOT NULL,
-    "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
-    "label" text,
-    "canonical_label" text,
-    "description" text,
-    "additional_data" jsonb,
-    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
-  );
-  CREATE TABLE "sources" (
-    "id" text PRIMARY KEY NOT NULL,
-    "user_id" text NOT NULL REFERENCES "users"("id"),
-    "type" varchar(50) NOT NULL,
-    "external_id" text NOT NULL,
-    "parent_source" text,
-    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
-    "metadata" jsonb,
-    "last_ingested_at" timestamp with time zone,
-    "status" varchar(20) DEFAULT 'pending',
-    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
-    "deleted_at" timestamp with time zone,
-    "content_type" varchar(100),
-    "content_length" integer,
-    CONSTRAINT "sources_user_type_external_unique"
-      UNIQUE ("user_id", "type", "external_id")
-  );
-  CREATE TABLE "claims" (
-    "id" text PRIMARY KEY NOT NULL,
-    "user_id" text NOT NULL REFERENCES "users"("id"),
-    "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
-    "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
-    "object_value" text,
-    "predicate" varchar(80) NOT NULL,
-    "statement" text NOT NULL,
-    "description" text,
-    "metadata" jsonb,
-    "object_instant" timestamp with time zone,
-    "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
-    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
-    "asserted_by_kind" varchar(24) NOT NULL,
-    "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
-    "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
-    "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
-    "stated_at" timestamp with time zone NOT NULL,
-    "valid_from" timestamp with time zone,
-    "valid_to" timestamp with time zone,
-    "status" varchar(30) DEFAULT 'active' NOT NULL,
-    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
-    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
-  );
-  CREATE TABLE "rollup_state" (
-    "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id"),
-    "watermark" timestamp with time zone,
-    "pending_periods" jsonb DEFAULT '[]' NOT NULL,
-    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
-  );
-`;
-
-/** Stub LLM client that records prompts and returns canned summaries. */
-export function stubLlm(): {
-  client: StubCompletionClient;
-  calls: string[];
-} {
-  const calls: string[] = [];
-  const client = {
-    chat: {
-      completions: {
-        parse: async (body: { messages: Array<{ content: string }> }) => {
-          const prompt = body.messages.map((m) => m.content).join("\n");
-          calls.push(prompt);
-          return {
-            choices: [
-              {
-                message: {
-                  parsed: { summary: `LLM summary #${calls.length}` },
-                },
-              },
-            ],
-            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-          };
-        },
-      },
-    },
-  } as unknown as StubCompletionClient;
-  return { client, calls };
-}
 
 describeIfServer("summarizePeriod", () => {
   const dbName = `memory_summarize_period_test_${Date.now()}_${Math.floor(

--- a/src/lib/rollup/summarize-period.test.ts
+++ b/src/lib/rollup/summarize-period.test.ts
@@ -1,0 +1,303 @@
+import { ensureRollupSource } from "./source";
+import { summarizePeriod } from "./summarize-period";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { createCompletionClient } from "~/lib/ai";
+import { ensurePeriodNode } from "~/lib/temporal";
+import { newTypeId } from "~/types/typeid";
+import {
+  resetTestOverrides,
+  setExtractionClientOverride,
+  setSkipEmbeddingPersistence,
+  type StubCompletionClient,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+/** All tables the rollup write path touches (embeddings are skipped). */
+export const ROLLUP_TEST_TABLES_SQL = `
+  CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+  CREATE TABLE "nodes" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "node_type" varchar(50) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "node_metadata" (
+    "id" text PRIMARY KEY NOT NULL,
+    "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "label" text,
+    "canonical_label" text,
+    "description" text,
+    "additional_data" jsonb,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+  );
+  CREATE TABLE "sources" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "type" varchar(50) NOT NULL,
+    "external_id" text NOT NULL,
+    "parent_source" text,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "metadata" jsonb,
+    "last_ingested_at" timestamp with time zone,
+    "status" varchar(20) DEFAULT 'pending',
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "deleted_at" timestamp with time zone,
+    "content_type" varchar(100),
+    "content_length" integer,
+    CONSTRAINT "sources_user_type_external_unique"
+      UNIQUE ("user_id", "type", "external_id")
+  );
+  CREATE TABLE "claims" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_value" text,
+    "predicate" varchar(80) NOT NULL,
+    "statement" text NOT NULL,
+    "description" text,
+    "metadata" jsonb,
+    "object_instant" timestamp with time zone,
+    "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "asserted_by_kind" varchar(24) NOT NULL,
+    "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+    "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "stated_at" timestamp with time zone NOT NULL,
+    "valid_from" timestamp with time zone,
+    "valid_to" timestamp with time zone,
+    "status" varchar(30) DEFAULT 'active' NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "rollup_state" (
+    "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id"),
+    "watermark" timestamp with time zone,
+    "pending_periods" jsonb DEFAULT '[]' NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+`;
+
+/** Stub LLM client that records prompts and returns canned summaries. */
+export function stubLlm(): {
+  client: StubCompletionClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const client = {
+    chat: {
+      completions: {
+        parse: async (body: {
+          messages: Array<{ content: string }>;
+        }) => {
+          const prompt = body.messages.map((m) => m.content).join("\n");
+          calls.push(prompt);
+          return {
+            choices: [
+              {
+                message: {
+                  parsed: { summary: `LLM summary #${calls.length}` },
+                },
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+        },
+      },
+    },
+  } as unknown as StubCompletionClient;
+  return { client, calls };
+}
+
+describeIfServer("summarizePeriod", () => {
+  const dbName = `memory_summarize_period_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  const userId = "user_sp";
+  let client: Client;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(ROLLUP_TEST_TABLES_SQL);
+    await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("skips a day with no linked content", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    const outcome = await summarizePeriod({
+      db,
+      userId,
+      periodKey: "2026-01-05",
+      client: openai,
+      rollupSourceId,
+    });
+    expect(outcome).toBe("skipped-empty");
+  });
+
+  it("summarizes a day with content, then fingerprint-skips a re-run", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    // Seed: a day node + one content node linked via OCCURRED_ON.
+    const dayNodeId = await ensurePeriodNode(db, userId, "2026-01-06");
+    const contentNodeId = newTypeId("node");
+    const contentSourceId = newTypeId("source");
+    await client.query(
+      `INSERT INTO "sources" ("id", "user_id", "type", "external_id")
+       VALUES ($1, $2, 'conversation', 'conv-1')`,
+      [contentSourceId, userId],
+    );
+    await client.query(
+      `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Conversation')`,
+      [contentNodeId, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata" ("id", "node_id", "label", "description")
+       VALUES ($1, $2, 'Standup', 'Talked about rollups with Sam.')`,
+      [newTypeId("node_metadata"), contentNodeId],
+    );
+    await client.query(
+      `INSERT INTO "claims" (
+        "id", "user_id", "subject_node_id", "object_node_id", "predicate",
+        "statement", "source_id", "asserted_by_kind", "stated_at"
+      ) VALUES ($1, $2, $3, $4, 'OCCURRED_ON', 'occurred', $5, 'system', now())`,
+      [newTypeId("claim"), userId, contentNodeId, dayNodeId, contentSourceId],
+    );
+
+    const params = {
+      db,
+      userId,
+      periodKey: "2026-01-06",
+      client: openai,
+      rollupSourceId,
+    };
+    expect(await summarizePeriod(params)).toBe("summarized");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("Standup");
+
+    const meta = await client.query(
+      `SELECT m."description", m."additional_data" FROM "node_metadata" m
+       WHERE m."node_id" = $1`,
+      [dayNodeId],
+    );
+    expect(meta.rows[0].description).toBe("LLM summary #1");
+    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+
+    // Unchanged input → no second LLM call.
+    expect(await summarizePeriod(params)).toBe("skipped-unchanged");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("summarizes a week from day summaries and ensures PART_OF claims idempotently", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm, calls } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    // 2026-01-06 already has a summarized day node from the previous test.
+    const params = {
+      db,
+      userId,
+      periodKey: "2026-W02", // Jan 5–11 2026
+      client: openai,
+      rollupSourceId,
+    };
+    expect(await summarizePeriod(params)).toBe("summarized");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("2026-01-06: LLM summary");
+    expect(calls[0]).toContain("(no summarized activity)");
+
+    const partOf = await client.query(
+      `SELECT c."statement" FROM "claims" c WHERE c."predicate" = 'PART_OF' AND c."user_id" = $1`,
+      [userId],
+    );
+    // Only the existing day node gets an edge (the other 6 days have no node).
+    expect(partOf.rowCount).toBe(1);
+    expect(partOf.rows[0].statement).toBe("2026-01-06 is part of 2026-W02");
+
+    // Re-run: fingerprint-skips, and does not duplicate the claim.
+    expect(await summarizePeriod(params)).toBe("skipped-unchanged");
+    const partOfAgain = await client.query(
+      `SELECT count(*)::int AS n FROM "claims" WHERE "predicate" = 'PART_OF' AND "user_id" = $1`,
+      [userId],
+    );
+    expect(partOfAgain.rows[0].n).toBe(1);
+  });
+
+  it("skips a week whose days have no summaries", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const { client: llm } = stubLlm();
+    setExtractionClientOverride(llm);
+    const rollupSourceId = await ensureRollupSource(db, userId);
+    const openai = await createCompletionClient(userId);
+
+    expect(
+      await summarizePeriod({
+        db,
+        userId,
+        periodKey: "2026-W30",
+        client: openai,
+        rollupSourceId,
+      }),
+    ).toBe("skipped-empty");
+  });
+});

--- a/src/lib/rollup/summarize-period.test.ts
+++ b/src/lib/rollup/summarize-period.test.ts
@@ -116,9 +116,7 @@ export function stubLlm(): {
   const client = {
     chat: {
       completions: {
-        parse: async (body: {
-          messages: Array<{ content: string }>;
-        }) => {
+        parse: async (body: { messages: Array<{ content: string }> }) => {
           const prompt = body.messages.map((m) => m.content).join("\n");
           calls.push(prompt);
           return {
@@ -239,7 +237,9 @@ describeIfServer("summarizePeriod", () => {
       [dayNodeId],
     );
     expect(meta.rows[0].description).toBe("LLM summary #1");
-    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(meta.rows[0].additional_data.rollup.fingerprint).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
 
     // Unchanged input → no second LLM call.
     expect(await summarizePeriod(params)).toBe("skipped-unchanged");

--- a/src/lib/rollup/summarize-period.ts
+++ b/src/lib/rollup/summarize-period.ts
@@ -6,11 +6,7 @@
  * `nodeMetadata.description` (+ `additionalData.rollup` marker) and the
  * refreshed embedding.
  */
-import {
-  collectPeriodInput,
-  fingerprintOf,
-  readRollupMeta,
-} from "./collect";
+import { collectPeriodInput, fingerprintOf, readRollupMeta } from "./collect";
 import { periodLevelOf, type PeriodLevel } from "./period";
 import { and, eq, inArray } from "drizzle-orm";
 import type OpenAI from "openai";
@@ -159,9 +155,7 @@ export async function summarizePeriod({
       })
       .where(eq(nodeMetadata.nodeId, nodeId));
     if (embedding) {
-      await tx
-        .delete(nodeEmbeddings)
-        .where(eq(nodeEmbeddings.nodeId, nodeId));
+      await tx.delete(nodeEmbeddings).where(eq(nodeEmbeddings.nodeId, nodeId));
       await tx.insert(nodeEmbeddings).values({
         nodeId,
         embedding,

--- a/src/lib/rollup/summarize-period.ts
+++ b/src/lib/rollup/summarize-period.ts
@@ -1,0 +1,223 @@
+/**
+ * Summarize a single rollup period: deterministic input collection →
+ * idempotent PART_OF containment claims (before the fingerprint gate, so
+ * re-runs repair interrupted sweeps) → fingerprint gate → one structured
+ * LLM completion → embedding generation → atomic write of the summary to
+ * `nodeMetadata.description` (+ `additionalData.rollup` marker) and the
+ * refreshed embedding.
+ */
+import {
+  collectPeriodInput,
+  fingerprintOf,
+  readRollupMeta,
+} from "./collect";
+import { periodLevelOf, type PeriodLevel } from "./period";
+import { and, eq, inArray } from "drizzle-orm";
+import type OpenAI from "openai";
+import { zodResponseFormat } from "openai/helpers/zod.mjs";
+import { z } from "zod";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeEmbeddings, nodeMetadata } from "~/db/schema";
+import { parseStructuredCompletion } from "~/lib/ai";
+import { generateEmbeddings } from "~/lib/embeddings";
+import { ensurePeriodNode } from "~/lib/temporal";
+import type { TypeId } from "~/types/typeid";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
+import { shouldSkipEmbeddingPersistence } from "~/utils/test-overrides";
+
+const LEVEL_PROMPT_INTRO: Record<PeriodLevel, string> = {
+  day: `You are summarizing one day of a person's life from entries in their personal memory graph (conversations, documents, events).
+
+Write a concise narrative summary of the day. Be concrete and specific: name the people, projects, places, decisions, and outcomes involved. Use past tense. Skip meta-commentary and filler; if entries are sparse, keep the summary proportionally short.`,
+  week: `You are summarizing one week of a person's life from their daily summaries.
+
+Write a narrative summary of the week's arc: key events, recurring themes, progress on projects, notable people, decisions, and changes. Synthesize across days rather than listing day-by-day. Use past tense; be concrete and specific. Days marked "(no summarized activity)" simply have no recorded data — don't speculate about them.`,
+  month: `You are summarizing one month of a person's life from weekly summaries. Boundary weeks may only partially overlap the month — weigh only the overlapping days.
+
+Write a narrative summary of the month: dominant themes, milestones, project progress, important relationships, and notable shifts. Use past tense; be concrete and specific.`,
+  year: `You are summarizing one year of a person's life from monthly summaries.
+
+Write a narrative summary of the year: major arcs, milestones, turning points, recurring themes, and how things changed from beginning to end. Use past tense; be concrete and specific.`,
+};
+
+const periodSummarySchema = z.object({
+  summary: z
+    .string()
+    .describe(
+      "Narrative summary of the period; concrete, specific, past tense",
+    ),
+});
+
+export type SummarizePeriodOutcome =
+  | "summarized"
+  | "skipped-unchanged"
+  | "skipped-empty";
+
+export interface SummarizePeriodParams {
+  db: DrizzleDB;
+  userId: string;
+  periodKey: string;
+  /** Completion client created once per sweep (task: temporal_summary). */
+  client: OpenAI;
+  /** Per-user synthetic rollup source backing PART_OF claims. */
+  rollupSourceId: TypeId<"source">;
+}
+
+export async function summarizePeriod({
+  db,
+  userId,
+  periodKey,
+  client,
+  rollupSourceId,
+}: SummarizePeriodParams): Promise<SummarizePeriodOutcome> {
+  const level = periodLevelOf(periodKey);
+
+  const collected = await collectPeriodInput(db, userId, periodKey, level);
+  if (!collected) return "skipped-empty";
+
+  const nodeId = await ensurePeriodNode(db, userId, periodKey);
+
+  // Containment edges first (and on every run) so a previously interrupted
+  // run is repaired even when the summary itself fingerprint-skips.
+  await ensurePartOfClaims(
+    db,
+    userId,
+    collected.childNodeIds,
+    nodeId,
+    periodKey,
+    rollupSourceId,
+  );
+
+  const fingerprint = fingerprintOf(collected.inputText);
+  const [meta] = await db
+    .select({
+      description: nodeMetadata.description,
+      additionalData: nodeMetadata.additionalData,
+    })
+    .from(nodeMetadata)
+    .where(eq(nodeMetadata.nodeId, nodeId))
+    .limit(1);
+  if (!meta) {
+    throw new Error(`Period node ${periodKey} (${nodeId}) has no metadata row`);
+  }
+  if (readRollupMeta(meta.additionalData)?.fingerprint === fingerprint) {
+    return "skipped-unchanged";
+  }
+
+  const completion = await parseStructuredCompletion(
+    client,
+    {
+      messages: [
+        {
+          role: "user",
+          content: `${LEVEL_PROMPT_INTRO[level]}\n\n${collected.inputText}`,
+        },
+      ],
+      model: modelForTask("temporal_summary"),
+      max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+      response_format: zodResponseFormat(periodSummarySchema, "period_summary"),
+    },
+    { task: "temporal_summary", userId },
+  );
+  const parsed = completion.choices[0]?.message.parsed;
+  if (!parsed) {
+    throw new Error(`Failed to parse period summary for ${periodKey}`);
+  }
+
+  // Generate the embedding BEFORE any write: committing the fingerprint
+  // first would make a retry after an embedding failure fingerprint-skip,
+  // leaving the embedding stale forever.
+  let embedding: number[] | null = null;
+  if (!shouldSkipEmbeddingPersistence()) {
+    const embResponse = await generateEmbeddings({
+      model: "jina-embeddings-v3",
+      task: "retrieval.passage",
+      input: [`${periodKey}: ${parsed.summary}`],
+      truncate: true,
+    });
+    embedding = embResponse.data[0]?.embedding ?? null;
+    if (!embedding) {
+      throw new Error(`Failed to generate embedding for period ${periodKey}`);
+    }
+  }
+
+  const existingData =
+    meta.additionalData &&
+    typeof meta.additionalData === "object" &&
+    !Array.isArray(meta.additionalData)
+      ? (meta.additionalData as Record<string, unknown>)
+      : {};
+  await db.transaction(async (tx) => {
+    await tx
+      .update(nodeMetadata)
+      .set({
+        description: parsed.summary,
+        additionalData: {
+          ...existingData,
+          rollup: { fingerprint, summarizedAt: new Date().toISOString() },
+        },
+      })
+      .where(eq(nodeMetadata.nodeId, nodeId));
+    if (embedding) {
+      await tx
+        .delete(nodeEmbeddings)
+        .where(eq(nodeEmbeddings.nodeId, nodeId));
+      await tx.insert(nodeEmbeddings).values({
+        nodeId,
+        embedding,
+        modelName: "jina-embeddings-v3",
+      });
+    }
+  });
+
+  return "summarized";
+}
+
+/** Child PART_OF parent claims for every existing child node, idempotent. */
+async function ensurePartOfClaims(
+  db: DrizzleDB,
+  userId: string,
+  childNodeIds: TypeId<"node">[],
+  parentNodeId: TypeId<"node">,
+  parentKey: string,
+  rollupSourceId: TypeId<"source">,
+): Promise<void> {
+  if (childNodeIds.length === 0) return;
+
+  const existing = await db
+    .select({ subjectNodeId: claims.subjectNodeId })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.objectNodeId, parentNodeId),
+        eq(claims.predicate, "PART_OF"),
+        eq(claims.status, "active"),
+        inArray(claims.subjectNodeId, childNodeIds),
+      ),
+    );
+  const linked = new Set(existing.map((c) => c.subjectNodeId));
+  const missing = childNodeIds.filter((id) => !linked.has(id));
+  if (missing.length === 0) return;
+
+  const labels = await db
+    .select({ nodeId: nodeMetadata.nodeId, label: nodeMetadata.label })
+    .from(nodeMetadata)
+    .where(inArray(nodeMetadata.nodeId, missing));
+  const labelOf = new Map(labels.map((l) => [l.nodeId, l.label]));
+
+  await db.insert(claims).values(
+    missing.map((childNodeId) => ({
+      userId,
+      predicate: "PART_OF" as const,
+      subjectNodeId: childNodeId,
+      objectNodeId: parentNodeId,
+      statement: `${labelOf.get(childNodeId) ?? childNodeId} is part of ${parentKey}`,
+      sourceId: rollupSourceId,
+      scope: "personal" as const,
+      assertedByKind: "system" as const,
+      statedAt: new Date(),
+      status: "active" as const,
+    })),
+  );
+}

--- a/src/lib/rollup/test-helpers.ts
+++ b/src/lib/rollup/test-helpers.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared fixtures for the rollup integration tests (summarize-period,
+ * jobs/rollup). A plain module — NOT a .test file — so importing it never
+ * re-registers another suite's tests.
+ */
+import type { StubCompletionClient } from "~/utils/test-overrides";
+
+/** All tables the rollup write path touches (embeddings are skipped). */
+export const ROLLUP_TEST_TABLES_SQL = `
+  CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+  CREATE TABLE "nodes" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "node_type" varchar(50) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "node_metadata" (
+    "id" text PRIMARY KEY NOT NULL,
+    "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "label" text,
+    "canonical_label" text,
+    "description" text,
+    "additional_data" jsonb,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+  );
+  CREATE TABLE "sources" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "type" varchar(50) NOT NULL,
+    "external_id" text NOT NULL,
+    "parent_source" text,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "metadata" jsonb,
+    "last_ingested_at" timestamp with time zone,
+    "status" varchar(20) DEFAULT 'pending',
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "deleted_at" timestamp with time zone,
+    "content_type" varchar(100),
+    "content_length" integer,
+    CONSTRAINT "sources_user_type_external_unique"
+      UNIQUE ("user_id", "type", "external_id")
+  );
+  CREATE TABLE "claims" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id"),
+    "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+    "object_value" text,
+    "predicate" varchar(80) NOT NULL,
+    "statement" text NOT NULL,
+    "description" text,
+    "metadata" jsonb,
+    "object_instant" timestamp with time zone,
+    "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+    "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+    "asserted_by_kind" varchar(24) NOT NULL,
+    "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+    "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+    "stated_at" timestamp with time zone NOT NULL,
+    "valid_from" timestamp with time zone,
+    "valid_to" timestamp with time zone,
+    "status" varchar(30) DEFAULT 'active' NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+  CREATE TABLE "rollup_state" (
+    "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id"),
+    "watermark" timestamp with time zone,
+    "pending_periods" jsonb DEFAULT '[]' NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+`;
+
+/** Stub LLM client that records prompts and returns canned summaries. */
+export function stubLlm(): {
+  client: StubCompletionClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const client = {
+    chat: {
+      completions: {
+        parse: async (body: { messages: Array<{ content: string }> }) => {
+          const prompt = body.messages.map((m) => m.content).join("\n");
+          calls.push(prompt);
+          return {
+            choices: [
+              {
+                message: {
+                  parsed: { summary: `LLM summary #${calls.length}` },
+                },
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+        },
+      },
+    },
+  } as unknown as StubCompletionClient;
+  return { client, calls };
+}

--- a/src/lib/schemas/rollup.ts
+++ b/src/lib/schemas/rollup.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const rollupRequestSchema = z.object({
+  userId: z.string().min(1),
+  /** Hard cap on LLM calls this sweep; leftovers resume on the next call. */
+  maxLlmCalls: z.number().int().positive().max(500).default(50),
+  /**
+   * History floor (yyyy-MM-dd). Periods ending before this are excluded
+   * outright — never summarized, purged from pending. Prevents a first
+   * sweep over a backlogged account from paying for ancient history.
+   */
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "startDate must be yyyy-MM-dd")
+    .optional(),
+});
+
+export type RollupRequest = z.infer<typeof rollupRequestSchema>;
+
+export const rollupResponseSchema = z.object({
+  message: z.string(),
+  enqueued: z.boolean(),
+});
+
+export type RollupResponse = z.infer<typeof rollupResponseSchema>;

--- a/src/lib/schemas/rollup.ts
+++ b/src/lib/schemas/rollup.ts
@@ -15,7 +15,7 @@ export const rollupRequestSchema = z.object({
     .optional(),
 });
 
-export type RollupRequest = z.infer<typeof rollupRequestSchema>;
+export type RollupRequest = z.input<typeof rollupRequestSchema>;
 
 export const rollupResponseSchema = z.object({
   message: z.string(),

--- a/src/lib/temporal.test.ts
+++ b/src/lib/temporal.test.ts
@@ -1,0 +1,133 @@
+import { ensureDayNode, ensurePeriodNode } from "./temporal";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import {
+  resetTestOverrides,
+  setSkipEmbeddingPersistence,
+} from "~/utils/test-overrides";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("ensurePeriodNode", () => {
+  const dbName = `memory_temporal_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+  let client: Client;
+
+  beforeAll(async () => {
+    setSkipEmbeddingPersistence(true);
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    await client.query(`
+      CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE "nodes" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "node_type" varchar(50) NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+      CREATE TABLE "node_metadata" (
+        "id" text PRIMARY KEY NOT NULL,
+        "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "label" text,
+        "canonical_label" text,
+        "description" text,
+        "additional_data" jsonb,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+      );
+    `);
+    await client.query(`INSERT INTO "users" ("id") VALUES ('user_t')`);
+  });
+
+  afterAll(async () => {
+    resetTestOverrides();
+    await client.end();
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("creates a Temporal node per period key and is idempotent", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    const weekId = await ensurePeriodNode(db, "user_t", "2026-W24");
+    const weekIdAgain = await ensurePeriodNode(db, "user_t", "2026-W24");
+    expect(weekIdAgain).toBe(weekId);
+
+    const monthId = await ensurePeriodNode(db, "user_t", "2026-06");
+    const yearId = await ensurePeriodNode(db, "user_t", "2026");
+    expect(new Set([weekId, monthId, yearId]).size).toBe(3);
+
+    const rows = await client.query(
+      `SELECT m."label", m."description", n."node_type"
+       FROM "node_metadata" m JOIN "nodes" n ON n."id" = m."node_id"
+       WHERE n."user_id" = 'user_t' ORDER BY m."label"`,
+    );
+    expect(rows.rows).toEqual([
+      {
+        label: "2026",
+        description: "Represents the year 2026",
+        node_type: "Temporal",
+      },
+      {
+        label: "2026-06",
+        description: "Represents the month 2026-06",
+        node_type: "Temporal",
+      },
+      {
+        label: "2026-W24",
+        description: "Represents the week 2026-W24",
+        node_type: "Temporal",
+      },
+    ]);
+  });
+
+  it("ensureDayNode delegates and stays label-compatible", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    const viaDate = await ensureDayNode(db, "user_t", new Date(2026, 5, 8));
+    const viaKey = await ensurePeriodNode(db, "user_t", "2026-06-08");
+    expect(viaKey).toBe(viaDate);
+  });
+
+  it("rejects malformed period keys", async () => {
+    const db = drizzle(client, { schema, casing: "snake_case" });
+    await expect(ensurePeriodNode(db, "user_t", "junk")).rejects.toThrow();
+  });
+});

--- a/src/lib/temporal.ts
+++ b/src/lib/temporal.ts
@@ -1,4 +1,5 @@
 import { generateEmbeddings } from "./embeddings";
+import { periodLevelOf, type PeriodLevel } from "./rollup/period";
 import { format } from "date-fns";
 import { and, eq } from "drizzle-orm";
 import { type NodePgDatabase } from "drizzle-orm/node-postgres";
@@ -10,26 +11,42 @@ import { shouldSkipEmbeddingPersistence } from "~/utils/test-overrides";
 
 type Database = NodePgDatabase<typeof schema>;
 
+const PERIOD_DESCRIPTION: Record<PeriodLevel, (key: string) => string> = {
+  day: (key) => `Represents the day ${key}`,
+  week: (key) => `Represents the week ${key}`,
+  month: (key) => `Represents the month ${key}`,
+  year: (key) => `Represents the year ${key}`,
+};
+
 /**
  * Ensures a Temporal node representing the given date exists for the user,
  * creating one if necessary.
- * Finds the node based on the metadata label (YYYY-MM-DD) for robustness.
  *
- * @param db The Drizzle database instance.
- * @param userId The ID of the user.
- * @param targetDate The date for which to ensure a node exists (defaults to today).
  * @returns The TypeId of the existing or newly created day node.
- * @throws Error if embedding generation fails or database insertion fails.
  */
 export async function ensureDayNode(
   db: Database,
   userId: string,
   targetDate: Date = new Date(),
 ): Promise<TypeId<"node">> {
-  const dateLabel = format(targetDate, "yyyy-MM-dd");
+  return ensurePeriodNode(db, userId, format(targetDate, "yyyy-MM-dd"));
+}
 
-  // --- Find existing day node by LABEL, not just timestamp ---
-  const [existingDayNode] = await db
+/**
+ * Ensures a Temporal node for any rollup period key (day `yyyy-MM-dd`,
+ * week `yyyy-Www`, month `yyyy-MM`, year `yyyy`) exists for the user.
+ * Lookup is by `nodeMetadata.label` — the period key IS the label.
+ *
+ * @throws Error on a malformed key, embedding failure, or insert failure.
+ */
+export async function ensurePeriodNode(
+  db: Database,
+  userId: string,
+  periodKey: string,
+): Promise<TypeId<"node">> {
+  const level = periodLevelOf(periodKey);
+
+  const [existingNode] = await db
     .select({ id: nodes.id })
     .from(nodes)
     .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
@@ -37,22 +54,21 @@ export async function ensureDayNode(
       and(
         eq(nodes.userId, userId),
         eq(nodes.nodeType, NodeTypeEnum.enum.Temporal),
-        eq(nodeMetadata.label, dateLabel),
+        eq(nodeMetadata.label, periodKey),
       ),
     )
     .limit(1);
-  // --- End Label-based check ---
 
-  if (existingDayNode) {
-    return existingDayNode.id;
+  if (existingNode) {
+    return existingNode.id;
   }
 
-  const nodeDescription = `Represents the day ${dateLabel}`;
+  const nodeDescription = PERIOD_DESCRIPTION[level](periodKey);
   const skipEmbedding = shouldSkipEmbeddingPersistence();
 
   const nodeEmbedding = skipEmbedding
     ? null
-    : await generateDayNodeEmbedding(dateLabel, nodeDescription);
+    : await generatePeriodNodeEmbedding(periodKey, nodeDescription);
 
   try {
     const [insertedNode] = await db
@@ -65,7 +81,7 @@ export async function ensureDayNode(
 
     if (!insertedNode) {
       throw new Error(
-        `Failed to retrieve ID after inserting day node: ${dateLabel}`,
+        `Failed to retrieve ID after inserting period node: ${periodKey}`,
       );
     }
 
@@ -74,7 +90,7 @@ export async function ensureDayNode(
     await db.transaction(async (tx) => {
       await tx.insert(nodeMetadata).values({
         nodeId: actualNodeId,
-        label: dateLabel,
+        label: periodKey,
         description: nodeDescription,
       });
       if (nodeEmbedding) {
@@ -88,16 +104,16 @@ export async function ensureDayNode(
 
     return actualNodeId;
   } catch (error) {
-    console.error(`Failed to create day node ${dateLabel}:`, error);
-    throw new Error(`Database operation failed for day node ${dateLabel}`);
+    console.error(`Failed to create period node ${periodKey}:`, error);
+    throw new Error(`Database operation failed for period node ${periodKey}`);
   }
 }
 
-async function generateDayNodeEmbedding(
-  dateLabel: string,
+async function generatePeriodNodeEmbedding(
+  periodKey: string,
   nodeDescription: string,
 ): Promise<number[]> {
-  const embeddingContent = `${dateLabel}: ${nodeDescription}`;
+  const embeddingContent = `${periodKey}: ${nodeDescription}`;
   const embeddingsResult = await generateEmbeddings({
     input: [embeddingContent],
     model: "jina-embeddings-v3",
@@ -107,7 +123,7 @@ async function generateDayNodeEmbedding(
   const embedding = embeddingsResult?.data?.[0]?.embedding;
   if (!embedding) {
     throw new Error(
-      `Failed to generate valid embedding for day node: ${dateLabel}`,
+      `Failed to generate valid embedding for period node: ${periodKey}`,
     );
   }
   return embedding;

--- a/src/rollup-route.test.ts
+++ b/src/rollup-route.test.ts
@@ -1,0 +1,97 @@
+import handler from "./routes/rollup.post";
+import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const queueMocks = vi.hoisted(() => ({
+  getJob: vi.fn(),
+  add: vi.fn(),
+}));
+
+vi.mock("~/lib/queues", () => ({
+  batchQueue: { getJob: queueMocks.getJob, add: queueMocks.add },
+  ROLLUP_JOB_OPTIONS: {
+    attempts: 3,
+    backoff: { type: "exponential", delay: 1_000 },
+    removeOnComplete: true,
+    removeOnFail: 100,
+  },
+}));
+
+describe("POST /rollup", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("applies defaults and enqueues with a deterministic jobId", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    queueMocks.getJob.mockResolvedValue(undefined);
+    queueMocks.add.mockResolvedValue({});
+
+    const response = await handler({} as H3Event);
+
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      "rollup",
+      { userId: "user_r", maxLlmCalls: 50 },
+      expect.objectContaining({ jobId: "rollup:user_r", attempts: 3 }),
+    );
+    expect(response).toMatchObject({ enqueued: true });
+  });
+
+  it("passes startDate and maxLlmCalls through", async () => {
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_r",
+      maxLlmCalls: 10,
+      startDate: "2026-01-01",
+    }));
+    queueMocks.getJob.mockResolvedValue(undefined);
+    queueMocks.add.mockResolvedValue({});
+
+    await handler({} as H3Event);
+
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      "rollup",
+      { userId: "user_r", maxLlmCalls: 10, startDate: "2026-01-01" },
+      expect.objectContaining({ jobId: "rollup:user_r" }),
+    );
+  });
+
+  it("does not double-enqueue while a sweep is queued or running", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    queueMocks.getJob.mockResolvedValue({
+      getState: async () => "waiting",
+      remove: vi.fn(),
+    });
+
+    const response = await handler({} as H3Event);
+
+    expect(queueMocks.add).not.toHaveBeenCalled();
+    expect(response).toMatchObject({ enqueued: false });
+  });
+
+  it("removes a finished job with the same id, then re-enqueues", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "user_r" }));
+    const remove = vi.fn();
+    queueMocks.getJob.mockResolvedValue({
+      getState: async () => "failed",
+      remove,
+    });
+    queueMocks.add.mockResolvedValue({});
+
+    const response = await handler({} as H3Event);
+
+    expect(remove).toHaveBeenCalled();
+    expect(queueMocks.add).toHaveBeenCalled();
+    expect(response).toMatchObject({ enqueued: true });
+  });
+
+  it("rejects a malformed startDate before enqueueing", async () => {
+    vi.stubGlobal("readBody", async () => ({
+      userId: "user_r",
+      startDate: "Jan 1",
+    }));
+
+    await expect(handler({} as H3Event)).rejects.toThrow();
+    expect(queueMocks.add).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/rollup.post.ts
+++ b/src/routes/rollup.post.ts
@@ -1,0 +1,45 @@
+/**
+ * `POST /rollup` — enqueue a temporal-rollup catch-up sweep for a user.
+ *
+ * Fire-and-forget: the sweep runs as a BullMQ job. A deterministic
+ * `rollup:<userId>` jobId collapses concurrent triggers for the same user
+ * into one queued sweep. Cost control belongs to the caller: `maxLlmCalls`
+ * caps this sweep, `startDate` floors how far back history is summarized.
+ */
+// `readBody` is deliberately NOT imported: Nitro auto-imports it globally
+// (same as src/routes/digest.post.ts), which is what lets the route test
+// stub it via vi.stubGlobal.
+import { defineEventHandler } from "h3";
+import { batchQueue, ROLLUP_JOB_OPTIONS } from "~/lib/queues";
+import {
+  rollupRequestSchema,
+  rollupResponseSchema,
+} from "~/lib/schemas/rollup";
+
+export default defineEventHandler(async (event) => {
+  const params = rollupRequestSchema.parse(await readBody(event));
+  const jobId = `rollup:${params.userId}`;
+
+  const existing = await batchQueue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state === "active" || state === "waiting" || state === "delayed") {
+      return rollupResponseSchema.parse({
+        message: `Rollup already queued for user ${params.userId}.`,
+        enqueued: false,
+      });
+    }
+    // Completed/failed leftovers block re-use of the deterministic jobId.
+    await existing.remove();
+  }
+
+  // The getState/remove/add sequence above is not atomic, but BullMQ's add
+  // is: a concurrent add with the same jobId is dropped as a duplicate.
+  await batchQueue.add("rollup", params, { ...ROLLUP_JOB_OPTIONS, jobId });
+  console.log(`Enqueued 'rollup' job for user: ${params.userId}`);
+
+  return rollupResponseSchema.parse({
+    message: `Rollup job for user ${params.userId} enqueued successfully.`,
+    enqueued: true,
+  });
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -24,6 +24,7 @@ export * from "../lib/schemas/query-recent-changes.js";
 export * from "../lib/schemas/query-graph.js";
 export * from "../lib/schemas/messages.js";
 export * from "../lib/schemas/summarize.js";
+export * from "../lib/schemas/rollup.js";
 export * from "../lib/schemas/cleanup.js";
 export * from "../lib/schemas/cleanup-placeholders.js";
 export * from "../lib/schemas/open-commitments.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -218,6 +218,11 @@ import {
   type ResolveCitationsResponse,
 } from "../lib/schemas/resolve-citations.js";
 import {
+  rollupResponseSchema,
+  type RollupRequest,
+  type RollupResponse,
+} from "../lib/schemas/rollup.js";
+import {
   ScratchpadReadRequest,
   ScratchpadWriteRequest,
   ScratchpadEditRequest,
@@ -646,6 +651,15 @@ export class MemoryClient {
 
   async summarize(payload: SummarizeRequest): Promise<SummarizeResponse> {
     return this._fetch("POST", "/summarize", summarizeResponseSchema, payload);
+  }
+
+  /**
+   * Trigger a temporal-rollup catch-up sweep (day/week/month/year summary
+   * nodes). Fire-and-forget; `maxLlmCalls` caps the sweep's LLM spend and
+   * `startDate` floors how far back history is summarized.
+   */
+  async rollup(payload: RollupRequest): Promise<RollupResponse> {
+    return this._fetch("POST", "/rollup", rollupResponseSchema, payload);
   }
 
   async cleanup(payload: CleanupRequest): Promise<CleanupResponse> {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -180,7 +180,8 @@ export type SourceType =
   | "meeting_transcript"
   | "external_conversation"
   | "metric_push"
-  | "metric_manual";
+  | "metric_manual"
+  | "rollup";
 
 export type SourceStatus =
   | "pending"

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -22,6 +22,7 @@ const envSchema = z.object({
   MODEL_ID_PROFILE_SYNTHESIS: z.string().min(1).optional(),
   MODEL_ID_DREAM: z.string().min(1).optional(),
   MODEL_ID_DEEP_RESEARCH: z.string().min(1).optional(),
+  MODEL_ID_TEMPORAL_SUMMARY: z.string().min(1).optional(),
 
   // Hard ceiling on output tokens per completion. Bounds a runaway
   // generation (providers can emit up to 128k); set well above the observed

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -17,7 +17,8 @@ export type ModelTask =
   | "atlas"
   | "profile_synthesis"
   | "dream"
-  | "deep_research";
+  | "deep_research"
+  | "temporal_summary";
 
 /**
  * Per-task overrides. An undefined entry (the default for every task) means
@@ -33,6 +34,7 @@ const TASK_MODEL_OVERRIDES: Record<ModelTask, string | undefined> = {
   profile_synthesis: env.MODEL_ID_PROFILE_SYNTHESIS,
   dream: env.MODEL_ID_DREAM,
   deep_research: env.MODEL_ID_DEEP_RESEARCH,
+  temporal_summary: env.MODEL_ID_TEMPORAL_SUMMARY,
 };
 
 /**


### PR DESCRIPTION
## What and why

SDK-triggered catch-up sweep that builds a recursive summary hierarchy over Temporal nodes: day (`2026-06-08`) → ISO week (`2026-W24`) → month (`2026-06`) → year (`2026`). Retrieval can now answer "what happened in March?", and the graph carries durable, vector-searchable period narratives.

The trigger is external only (`POST /rollup` → BullMQ, SDK `rollup()` method) — never internally scheduled — so the consumer (Petals) controls exactly when and how much LLM spend each user incurs.

**Cost model:**
- A period costs one LLM call ever, unless its input genuinely changes (sha256 input fingerprints; unchanged → free skip).
- A sweep with nothing stale costs zero LLM calls.
- `maxLlmCalls` hard-caps each sweep (failed calls count too); leftovers resume via `pendingPeriods`.
- `startDate` floors history depth so a first sweep over a backlogged account doesn't pay for ancient periods.

**Mechanics:**
- Per-user watermark (max `claims.createdAt` seen) + `pendingPeriods` in new `rollup_state` table; watermark always advances, pending carries deferred/failed/incomplete work.
- Recovered failures and deferred periods re-stale their ancestors, so week/month/year summaries can never be stranded stale.
- ISO weeks don't nest in months: months consume all overlapping weeks with in-month day annotations; boundary weeks get `PART_OF` edges to both months.
- `PART_OF` containment claims backed by a per-user synthetic `rollup` source; summaries written to `nodeMetadata.description` + re-embedded atomically.
- Helicone spend attribution via new `temporal_summary` ModelTask (`MODEL_ID_TEMPORAL_SUMMARY` override, falls back to graph extraction model).

Spec: `docs/superpowers/specs/2026-06-12-temporal-rollup-design.md` · Plan: `docs/superpowers/plans/2026-06-12-temporal-rollup.md`

## How to test

CI does not run vitest — run locally with the test Postgres up:

```bash
docker compose up -d
pnpm run test -- --run   # 86 files / 436 tests; rollup suites must RUN, not skip
pnpm run build:check && pnpm run lint && pnpm run build-sdk
```

Key scenarios covered by integration tests (real Postgres, production LLM/embedding seams): full hierarchy build with open-period deferral, zero-cost no-op re-sweep, completed-year rollup, backfill cascade, budget defer/resume, `startDate` exclude+purge, failure recovery cascading upward, failed-call budget accounting.

## Checklist

- [x] Build (`build:check`, `build-sdk`) clean
- [x] Lint clean
- [x] Prettier clean on all touched files (2 pre-existing warnings in screenpipe docs exist on main)
- [x] Tests: 436/436 locally against Postgres :5431, zero skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)