### PR TITLE
docs: note downstream Petals/n8n consumers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# assistant-memory
+
+Guidance for working in this repository.
+
+## Downstream consumers
+
+When adding an end-user-relevant SDK/MCP ingestion or metrics capability,
+consider the hosted consumers that surface it: the Petals product
+(`petals.chat`) proxies these endpoints and ships an n8n node
+(`n8n-nodes-petals`). End-user-facing additions usually warrant a matching proxy
+endpoint and node operation so automation users get them too.


### PR DESCRIPTION
## What & why
Adds a brief **Downstream consumers** note to `CLAUDE.md` so contributors remember that end-user-relevant SDK/MCP ingestion or metrics capabilities are surfaced by the hosted Petals product (`petals.chat`) and its n8n node (`n8n-nodes-petals`) — and usually warrant a matching proxy endpoint + node operation so automation users get them too.

## How to test
Docs-only; no code changes.