### PR TITLE
✨ feat(commitments): honest presentation evidence on the commitment list

### DIFF
--- a/docs/superpowers/plans/2026-06-14-commitment-presentation.md
+++ b/docs/superpowers/plans/2026-06-14-commitment-presentation.md
@@ -1,0 +1,718 @@
+# Commitment Presentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `@marcelsamyn/memory` emit a `presentation { source, excerpt, why }` object on each commitment **list** item — provenance from a free DB join, a **verbatim-or-null** excerpt and a humane _why_ from a small fail-soft LLM pass that runs when a new Task node is created.
+
+**Architecture:** A dedicated `commitment_presentations` table (1:1 with the Task node) stores the excerpt + why. A pure `locateVerbatim()` enforces the honesty rule in code (the model proposes a quote; we only store text that genuinely appears in the source, or null). `generateCommitmentPresentation()` runs inside `extractGraph` for each newly-minted Task node, reusing the in-memory source `content`. The list query LEFT JOINs `sources` (provenance, for **all** commitments) and `commitment_presentations` (excerpt/why, new commitments only) and assembles `presentation`. Petals already maps this shape — no consumer change beyond a version bump.
+
+**Tech Stack:** TypeScript (ESM), Drizzle ORM (Postgres), Zod 4, OpenAI SDK structured outputs (`zodResponseFormat` via `performStructuredAnalysis`), Vitest. Spec: `docs/superpowers/specs/2026-06-14-commitment-presentation-design.md`.
+
+**Conventions:** Tests are co-located `*.test.ts`; run with `pnpm test --run`. Type/lint gates: `pnpm build:check` (`tsc --noEmit` + `check:structured-outputs`), `pnpm lint`, `pnpm format`. Migrations: `pnpm drizzle:generate` → review → `pnpm drizzle:migrate`. Commit style: `<emoji> <type>(<scope>): <subject>` (no AI mentions).
+
+---
+
+### Task 1: `locateVerbatim` — the honesty function (pure, TDD)
+
+**Files:**
+
+- Create: `src/lib/verbatim.ts`
+- Test: `src/lib/verbatim.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/lib/verbatim.test.ts
+import { locateVerbatim } from "./verbatim";
+import { describe, expect, it } from "vitest";
+
+describe("locateVerbatim", () => {
+  it("returns the exact source slice for an exact substring", () => {
+    const content = "Let's ship the beta on Friday for sure.";
+    expect(locateVerbatim(content, "ship the beta on Friday")).toBe(
+      "ship the beta on Friday",
+    );
+  });
+
+  it("is case-sensitive (never normalizes case)", () => {
+    expect(locateVerbatim("Ship the beta", "ship the beta")).toBeNull();
+  });
+
+  it("tolerates whitespace drift and returns the ORIGINAL characters", () => {
+    const content = "I will\n   ship it tomorrow";
+    // model collapsed the newline+spaces to a single space:
+    expect(locateVerbatim(content, "I will ship it")).toBe(
+      "I will\n   ship it",
+    );
+  });
+
+  it("collapses repeated whitespace inside the candidate too", () => {
+    expect(locateVerbatim("a   b", "a b")).toBe("a   b");
+  });
+
+  it("returns null when the candidate is absent", () => {
+    expect(locateVerbatim("nothing here", "launch the rocket")).toBeNull();
+  });
+
+  it("returns null for null / empty / whitespace-only candidates", () => {
+    expect(locateVerbatim("anything", null)).toBeNull();
+    expect(locateVerbatim("anything", "")).toBeNull();
+    expect(locateVerbatim("anything", "   ")).toBeNull();
+  });
+
+  it("trims the candidate before searching", () => {
+    expect(locateVerbatim("ship the beta", "  ship the beta  ")).toBe(
+      "ship the beta",
+    );
+  });
+
+  it("returns null for an over-long candidate (cap guards runaway spans)", () => {
+    const content = "x".repeat(500);
+    expect(locateVerbatim(content, "x".repeat(300))).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `pnpm test --run src/lib/verbatim.test.ts`
+Expected: FAIL (`locateVerbatim` is not defined / module not found).
+
+- [ ] **Step 3: Implement `locateVerbatim`**
+
+```ts
+// src/lib/verbatim.ts
+/**
+ * Verbatim-or-null source-quote location.
+ *
+ * Common aliases: locate quote, verbatim excerpt, honest highlight, substring
+ * provenance. The model proposes a quote; we only ever return text that
+ * genuinely appears in `content` (the ACTUAL source characters), or null.
+ */
+
+/** A card quote is a sentence or two; reject runaway spans. */
+const MAX_EXCERPT_CHARS = 240;
+
+/**
+ * Locate `candidate` as a verbatim span within `content`, returning the actual
+ * source characters for the matched range, or `null` if it is not present.
+ *
+ * 1. Trim the candidate; reject null / empty / over-long → `null`.
+ * 2. Exact substring → return `content.slice(...)` of the hit.
+ * 3. Whitespace-tolerant: collapse runs of whitespace in both (LLMs flatten
+ *    newlines/indentation), find the candidate, and map the hit back to the
+ *    original offsets so the returned text is byte-for-byte from the source.
+ * 4. Not found → `null`.
+ *
+ * Case is never normalized — verbatim means verbatim.
+ */
+export function locateVerbatim(
+  content: string,
+  candidate: string | null,
+): string | null {
+  if (!candidate) return null;
+  const needle = candidate.trim();
+  if (needle.length === 0 || needle.length > MAX_EXCERPT_CHARS) return null;
+
+  const exact = content.indexOf(needle);
+  if (exact !== -1) return content.slice(exact, exact + needle.length);
+
+  const { normalized, map } = collapseWhitespace(content);
+  const normNeedle = needle.replace(/\s+/g, " ");
+  const at = normalized.indexOf(normNeedle);
+  if (at === -1) return null;
+
+  const start = map[at];
+  const end = map[at + normNeedle.length - 1];
+  if (start === undefined || end === undefined) return null;
+  return content.slice(start, end + 1);
+}
+
+/**
+ * Collapse each run of whitespace to a single space. Returns the normalized
+ * string and `map[i]` = the index in the ORIGINAL string of normalized char i.
+ */
+function collapseWhitespace(s: string): { normalized: string; map: number[] } {
+  let normalized = "";
+  const map: number[] = [];
+  let inWhitespace = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!;
+    if (/\s/.test(ch)) {
+      if (!inWhitespace) {
+        normalized += " ";
+        map.push(i);
+        inWhitespace = true;
+      }
+    } else {
+      normalized += ch;
+      map.push(i);
+      inWhitespace = false;
+    }
+  }
+  return { normalized, map };
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `pnpm test --run src/lib/verbatim.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/verbatim.ts src/lib/verbatim.test.ts
+git commit -m "✨ feat(commitments): locateVerbatim — verbatim-or-null quote location"
+```
+
+---
+
+### Task 2: `commitment_presentation` model task + env override
+
+**Files:**
+
+- Modify: `src/utils/models.ts`
+- Modify: `src/utils/env.ts` (add the optional model-id env var, following the existing `MODEL_ID_*` entries)
+
+- [ ] **Step 1: Add the env var**
+
+In `src/utils/env.ts`, find the block declaring `MODEL_ID_DOCUMENT_SPINE` (and siblings) and add, in the same style (optional string, no default → inherits `MODEL_ID_GRAPH_EXTRACTION` at use site):
+
+```ts
+    MODEL_ID_COMMITMENT_PRESENTATION: z.string().optional(),
+```
+
+- [ ] **Step 2: Add the task to the union + overrides**
+
+In `src/utils/models.ts`:
+
+```ts
+// In the ModelTask union, add:
+  | "commitment_presentation"
+
+// In TASK_MODEL_OVERRIDES, add:
+  commitment_presentation: env.MODEL_ID_COMMITMENT_PRESENTATION,
+```
+
+(No default override → `modelForTask("commitment_presentation")` falls back to `MODEL_ID_GRAPH_EXTRACTION`, the cheap/safe default, until an env override is set.)
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm build:check`
+Expected: PASS (the new task is referenced nowhere yet; union is exhaustive).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/models.ts src/utils/env.ts
+git commit -m "✨ feat(commitments): commitment_presentation model task"
+```
+
+---
+
+### Task 3: `commitment_presentations` table + migration
+
+**Files:**
+
+- Modify: `src/db/schema.ts`
+- Generated: `drizzle/00NN_*.sql`
+
+- [ ] **Step 1: Add the table**
+
+In `src/db/schema.ts`, after the `nodeMetadata` table (mirror its idiom — `typeId` FK with cascade, `text()`/`timestamp(... withTimezone)`), add:
+
+```ts
+/**
+ * Per-commitment presentation evidence (1:1 with a Task node): a verbatim
+ * `excerpt` and a generated `why`, produced when the Task is first inferred.
+ * Provenance (source title + timestamp) is NOT stored here — it is joined from
+ * `sources` via the commitment's active status-claim `sourceId` at read time.
+ * Decoupled from claims so it never rides a superseded status claim.
+ */
+export const commitmentPresentations = pgTable(
+  "commitment_presentations",
+  {
+    taskId: typeIdNoDefault("node")
+      .references(() => nodes.id, { onDelete: "cascade" })
+      .primaryKey()
+      .notNull(),
+    userId: text()
+      .references(() => users.id)
+      .notNull(),
+    sourceId: typeIdNoDefault("source")
+      .references(() => sources.id, { onDelete: "cascade" })
+      .notNull(),
+    excerpt: text(),
+    why: text(),
+    createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("commitment_presentations_user_id_idx").on(table.userId)],
+);
+```
+
+Confirm `typeIdNoDefault` and `index` are already imported in `schema.ts` (they are used by existing tables; add to the import if tree-shaken).
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `pnpm drizzle:generate`
+Expected: a new `drizzle/00NN_*.sql` creating `commitment_presentations` with the PK, two FKs (cascade), and the user index. **Open the generated SQL and read it** — confirm it only CREATEs the new table + index and touches nothing else.
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm build:check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit (schema + migration together)**
+
+```bash
+git add src/db/schema.ts drizzle/
+git commit -m "✨ feat(commitments): commitment_presentations table + migration"
+```
+
+(The migration is **applied** in Task 8 after the readers/writers exist, via `pnpm drizzle:migrate`.)
+
+---
+
+### Task 4: Presentation pass + upsert (TDD, mocked LLM) + structured-output gate
+
+**Files:**
+
+- Create: `src/lib/commitment-presentation.ts`
+- Test: `src/lib/commitment-presentation.test.ts`
+- Modify: `scripts/check-structured-output-schemas.ts`
+
+- [ ] **Step 1: Write the failing tests (mock the LLM helper)**
+
+```ts
+// src/lib/commitment-presentation.test.ts
+import { generateCommitmentPresentation } from "./commitment-presentation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ai", () => ({ performStructuredAnalysis: vi.fn() }));
+const { performStructuredAnalysis } = await import("./ai");
+const mockLlm = vi.mocked(performStructuredAnalysis);
+
+const CONTENT = "Sure — I'll send the investor update by Thursday, promise.";
+
+describe("generateCommitmentPresentation", () => {
+  beforeEach(() => mockLlm.mockReset());
+
+  it("stores a real quote verbatim and passes the why through", async () => {
+    mockLlm.mockResolvedValue({
+      excerpt: "send the investor update by Thursday",
+      why: "You named a concrete deliverable and deadline.",
+    });
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "Send investor update",
+    });
+    expect(out.excerpt).toBe("send the investor update by Thursday");
+    expect(out.why).toBe("You named a concrete deliverable and deadline.");
+  });
+
+  it("nulls a hallucinated excerpt that is not in the source", async () => {
+    mockLlm.mockResolvedValue({
+      excerpt: "I promise to climb Everest next week",
+      why: "Ambitious.",
+    });
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "Send investor update",
+    });
+    expect(out.excerpt).toBeNull();
+    expect(out.why).toBe("Ambitious.");
+  });
+
+  it("caps an over-long why", async () => {
+    mockLlm.mockResolvedValue({ excerpt: null, why: "x".repeat(300) });
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "t",
+    });
+    expect(out.why?.length).toBe(140);
+  });
+
+  it("is fail-soft: an LLM error yields a fully-null presentation", async () => {
+    mockLlm.mockRejectedValue(new Error("boom"));
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "t",
+    });
+    expect(out).toEqual({ excerpt: null, why: null });
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `pnpm test --run src/lib/commitment-presentation.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// src/lib/commitment-presentation.ts
+import type { DrizzleDB } from "../db/client";
+import { commitmentPresentations } from "../db/schema";
+import type { TypeId } from "../types/typeid";
+import { performStructuredAnalysis } from "./ai";
+import { locateVerbatim } from "./verbatim";
+import { z } from "zod";
+
+const WHY_MAX_CHARS = 140;
+
+/** Structured output for the presentation pass (OpenAI-safe: all keys required, nullable not optional). */
+export const commitmentPresentationLlmSchema = z
+  .object({
+    excerpt: z
+      .string()
+      .nullable()
+      .describe(
+        "A SHORT exact quote, copied character-for-character from the provided source text, that directly evidences this commitment. If no single span cleanly evidences it, return null. Never paraphrase, summarize, or invent.",
+      ),
+    why: z
+      .string()
+      .nullable()
+      .describe(
+        "One short second-person line (max ~15 words) explaining why this is a commitment, grounded in the source. e.g. 'You set a concrete launch window.' Null if nothing meaningful to add.",
+      ),
+  })
+  .describe("commitment_presentation");
+
+const SYSTEM_PROMPT =
+  "You extract honest evidence for a task the assistant inferred from a user's messages. " +
+  "The excerpt MUST be an exact, verbatim substring of the provided source — copy it character-for-character, or return null. " +
+  "Never fabricate, paraphrase, or stitch together a quote. The 'why' is a single short second-person line grounded in the source.";
+
+/**
+ * Produce honest presentation evidence for a freshly-inferred commitment.
+ * Fail-soft: any error yields `{ excerpt: null, why: null }` — this MUST NOT
+ * throw into ingestion. The excerpt is validated against the real source in
+ * code (`locateVerbatim`), so the model cannot fabricate a quote.
+ */
+export async function generateCommitmentPresentation(args: {
+  userId: string;
+  content: string;
+  taskLabel: string;
+}): Promise<{ excerpt: string | null; why: string | null }> {
+  try {
+    const out = await performStructuredAnalysis({
+      userId: args.userId,
+      task: "commitment_presentation",
+      systemPrompt: SYSTEM_PROMPT,
+      prompt: `Task the assistant inferred: "${args.taskLabel}"\n\nSource text:\n"""\n${args.content}\n"""`,
+      schema: commitmentPresentationLlmSchema,
+    });
+    const excerpt = locateVerbatim(args.content, out.excerpt);
+    const why = out.why?.trim().slice(0, WHY_MAX_CHARS) || null;
+    return { excerpt, why };
+  } catch (error) {
+    console.warn(`commitment presentation generation failed: ${String(error)}`);
+    return { excerpt: null, why: null };
+  }
+}
+
+/** Upsert presentation evidence for a task (idempotent on re-extraction). */
+export async function upsertCommitmentPresentation(
+  db: DrizzleDB,
+  row: {
+    taskId: TypeId<"node">;
+    userId: string;
+    sourceId: TypeId<"source">;
+    excerpt: string | null;
+    why: string | null;
+  },
+): Promise<void> {
+  await db
+    .insert(commitmentPresentations)
+    .values(row)
+    .onConflictDoUpdate({
+      target: commitmentPresentations.taskId,
+      set: { excerpt: row.excerpt, why: row.why, sourceId: row.sourceId },
+    });
+}
+```
+
+> Verify the import paths against the repo: `DrizzleDB` (the type passed as `db` in `extract-graph.ts` — check its export, likely `../db/client` or `../db`), `TypeId` (`../types/typeid`). Match what `extract-graph.ts` already imports.
+
+- [ ] **Step 4: Register the schema in the structured-output gate**
+
+In `scripts/check-structured-output-schemas.ts`, import the schema and add an array entry:
+
+```ts
+import { commitmentPresentationLlmSchema } from "../src/lib/commitment-presentation";
+// ...
+  {
+    name: "commitment_presentation",
+    schema: zodResponseFormat(
+      commitmentPresentationLlmSchema,
+      "commitment_presentation",
+    ).json_schema.schema,
+  },
+```
+
+- [ ] **Step 5: Run tests + the structured-output gate**
+
+Run: `pnpm test --run src/lib/commitment-presentation.test.ts && pnpm run check:structured-outputs`
+Expected: tests PASS (4); the gate prints "Validated 3 structured-output JSON schema." with no validation error (confirms the schema is OpenAI-structured-output-legal).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/commitment-presentation.ts src/lib/commitment-presentation.test.ts scripts/check-structured-output-schemas.ts
+git commit -m "✨ feat(commitments): presentation pass (verbatim excerpt + why), fail-soft"
+```
+
+---
+
+### Task 5: Hook the pass into extraction
+
+**Files:**
+
+- Modify: `src/lib/extract-graph.ts`
+
+- [ ] **Step 1: Add the call after embeddings are generated**
+
+In `extractGraph`, immediately after the embeddings `Promise.all([...])` (the block ending around line 536, where `generateAndInsertNodeEmbeddings` runs), insert — `content`, `userId`, `sourceId`, `db`, and `detailsOfNewlyCreatedNodes` are all in scope here:
+
+```ts
+// Honest presentation evidence for each freshly-inferred commitment, using
+// the source text we still hold in memory. Best-effort: never let it break
+// ingestion (the pass is itself fail-soft; we also guard the upsert).
+const newTaskNodes = detailsOfNewlyCreatedNodes.filter(
+  (node) => node.nodeType === "Task",
+);
+for (const task of newTaskNodes) {
+  try {
+    const { excerpt, why } = await generateCommitmentPresentation({
+      userId,
+      content,
+      taskLabel: task.label,
+    });
+    if (excerpt !== null || why !== null) {
+      await upsertCommitmentPresentation(db, {
+        taskId: task.id,
+        userId,
+        sourceId,
+        excerpt,
+        why,
+      });
+    }
+  } catch (error) {
+    console.warn(
+      `commitment presentation upsert failed for ${task.id}: ${String(error)}`,
+    );
+  }
+}
+```
+
+Add the import at the top of `extract-graph.ts`:
+
+```ts
+import {
+  generateCommitmentPresentation,
+  upsertCommitmentPresentation,
+} from "./commitment-presentation";
+```
+
+> Confirm `task.label` is non-null on `ProcessedNode` (the recon shows `label: llmNode.label` is set on every pushed entry). If the type is `string | undefined`, pass `task.label ?? ""` and let the pass handle it.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm build:check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/extract-graph.ts
+git commit -m "✨ feat(commitments): generate presentation for new task nodes in extraction"
+```
+
+---
+
+### Task 6: SDK list schema — the `presentation` field
+
+**Files:**
+
+- Modify: `src/lib/schemas/list-commitments.ts`
+
+- [ ] **Step 1: Add the presentation sub-schemas + field**
+
+In `src/lib/schemas/list-commitments.ts`, before `commitmentListItemSchema`, add:
+
+```ts
+export const presentationSourceSchema = z.object({
+  sourceId: typeIdSchema("source"),
+  title: z.string().nullable(),
+  overheardAt: z.coerce.date().nullable(),
+});
+
+export const commitmentPresentationSchema = z.object({
+  source: presentationSourceSchema.nullable(),
+  excerpt: z.string().nullable(),
+  why: z.string().nullable(),
+});
+export type CommitmentPresentation = z.infer<
+  typeof commitmentPresentationSchema
+>;
+```
+
+Then add the field to `commitmentListItemSchema` (after `sourceId`):
+
+```ts
+  sourceId: typeIdSchema("source"),
+  /** Inline evidence for the inbox card. Null when no source resolves. */
+  presentation: commitmentPresentationSchema.nullable(),
+```
+
+- [ ] **Step 2: Type-check (expected to fail at the query)**
+
+Run: `pnpm build:check`
+Expected: FAIL in `src/lib/query/commitments-list.ts` — the mapper now omits the required `presentation`. Task 7 fixes it. (If you prefer a green build per task, do Tasks 6 + 7 as one commit.)
+
+- [ ] **Step 3: (defer commit — fold into Task 7 so the build stays green)**
+
+---
+
+### Task 7: List query — assemble `presentation`
+
+**Files:**
+
+- Modify: `src/lib/query/commitments-list.ts`
+- Modify: `src/lib/sources-read.ts` (export `deriveTitle`)
+
+- [ ] **Step 1: Export `deriveTitle`**
+
+In `src/lib/sources-read.ts`, change `function deriveTitle(` → `export function deriveTitle(`.
+
+- [ ] **Step 2: Add the joins + selected columns**
+
+In `src/lib/query/commitments-list.ts`, import the table, `sources`, and `deriveTitle`:
+
+```ts
+import { commitmentPresentations, sources } from "../../db/schema";
+import { deriveTitle } from "../sources-read";
+```
+
+Add to the `.select({...})` (alongside `sourceId: claims.sourceId`):
+
+```ts
+    sourceMetadata: sources.metadata,
+    sourceCreatedAt: sources.createdAt,
+    sourceLastIngestedAt: sources.lastIngestedAt,
+    presentationExcerpt: commitmentPresentations.excerpt,
+    presentationWhy: commitmentPresentations.why,
+```
+
+Add two LEFT JOINs (place after the existing joins, before `.where(...)`):
+
+```ts
+    .leftJoin(sources, eq(sources.id, claims.sourceId))
+    .leftJoin(
+      commitmentPresentations,
+      eq(commitmentPresentations.taskId, nodes.id),
+    )
+```
+
+- [ ] **Step 3: Assemble `presentation` in the row mapping**
+
+Add a small builder near the mapping loop:
+
+```ts
+function buildPresentation(row: {
+  sourceId: TypeId<"source">;
+  sourceMetadata: unknown;
+  sourceCreatedAt: Date | null;
+  sourceLastIngestedAt: Date | null;
+  presentationExcerpt: string | null;
+  presentationWhy: string | null;
+}): CommitmentPresentation {
+  const source =
+    row.sourceCreatedAt === null
+      ? null
+      : {
+          sourceId: row.sourceId,
+          title: deriveTitle(row.sourceMetadata),
+          overheardAt: row.sourceLastIngestedAt ?? row.sourceCreatedAt,
+        };
+  return {
+    source,
+    excerpt: row.presentationExcerpt,
+    why: row.presentationWhy,
+  };
+}
+```
+
+Import the `CommitmentPresentation` type and `TypeId`, then add to the `commitments.push({...})` object:
+
+```ts
+    sourceId: row.sourceId,
+    presentation: buildPresentation(row),
+```
+
+> `claims.sourceId` is NOT NULL, so the `sources` LEFT JOIN resolves for every live commitment — provenance shows on **all** cards. `source` is null only if the source row was deleted.
+
+- [ ] **Step 4: Build + run the commitments tests**
+
+Run: `pnpm build:check && pnpm test --run src/lib/query`
+Expected: PASS. (If no query test exists, `build:check` green is the gate; a focused round-trip test is optional but welcome — see Task 8.)
+
+- [ ] **Step 5: Commit (Tasks 6 + 7 together)**
+
+```bash
+git add src/lib/schemas/list-commitments.ts src/lib/query/commitments-list.ts src/lib/sources-read.ts
+git commit -m "✨ feat(commitments): presentation on the list response (provenance + excerpt + why)"
+```
+
+---
+
+### Task 8: Full verification, migration, version bump
+
+**Files:**
+
+- Modify: `package.json` (version)
+
+- [ ] **Step 1: Apply the migration**
+
+Run: `pnpm drizzle:migrate`
+Expected: applies `00NN_*.sql`; `commitment_presentations` now exists. (If the dev DB is push-managed and `migrate` errors, STOP and report — do not silently `push`; confirm the dev flow.)
+
+- [ ] **Step 2: Full gate sweep**
+
+Run, in order, and confirm each is green:
+
+```bash
+pnpm build:check
+pnpm lint
+pnpm format        # prettier --check . ; use format:fix if needed
+pnpm test --run
+```
+
+- [ ] **Step 3: Optional — list-query round-trip test**
+
+If an existing test harness for `listCommitments` exists (DB-backed), add a case asserting: a commitment with a `commitment_presentations` row returns populated `excerpt`/`why`; a commitment without one still returns non-null `presentation.source` (provenance) and null excerpt/why; the result parses through `listCommitmentsResponseSchema`. Model it on `src/digest-route.test.ts` (schema `.parse` round-trip).
+
+- [ ] **Step 4: Version bump**
+
+Bump `package.json` `version` `1.23.0` → `1.24.0` (additive minor).
+
+```bash
+git add package.json
+git commit -m "🔧 chore(release): 1.24.0 — commitment presentation"
+```
+
+- [ ] **Step 5: STOP — do not publish or open the PR without Marcel's OK**
+
+Report completion + green gates. Publishing `@marcelsamyn/memory@1.24.0` and the downstream **Petals** wiring (it consumes the **published** package — bump its dep so `CommitmentListItem.presentation` flows; the proxy + Petals `commitments-map.ts` already map it) are a separate, explicitly-authorized step. The n8n node is write-only and unaffected.
+
+---
+
+## Out of scope (per spec)
+
+Backfill of existing commitments' excerpt/why; presentation on `getCommitment` (detail); regeneration/refresh; case-insensitive excerpt matching; any non-verbatim excerpt.

--- a/docs/superpowers/specs/2026-06-14-commitment-presentation-design.md
+++ b/docs/superpowers/specs/2026-06-14-commitment-presentation-design.md
@@ -1,0 +1,270 @@
+# Commitment Presentation — Design Spec
+
+**Date:** 2026-06-14
+**Status:** Approved (design); ready for implementation plan
+**Repo:** `assistant-memory` (`@marcelsamyn/memory`)
+**Consumer:** Petals — the "caught-promise" candidate card (already shipped, degraded)
+
+---
+
+## Problem & goal
+
+Petals' Inbox renders each AI-inferred candidate commitment as a **caught-promise card**:
+provenance ("overheard · 2d ago · <source>"), a **verbatim** quote that evidences the
+commitment, and a humane one-line _why_. That card already ships — but the fields are
+always `null` because this repo doesn't produce them yet. The card degrades cleanly and
+waits.
+
+**Goal:** Make `@marcelsamyn/memory` emit a `presentation { source, excerpt, why }` object
+on each commitment **list** item, so the card lights up — **honestly**: the excerpt is a
+verbatim substring of real source text or it is `null`; it is never fabricated or
+paraphrased.
+
+## The boundary (locked — do not renegotiate)
+
+Petals already consumes and maps this shape (`src/server/commitments-map.ts` → `toPresentationDTO`),
+normalizing `Date`→ISO string and `undefined`→`null`. We MUST match it so the consumer
+needs **zero** code change beyond a version bump:
+
+```ts
+// What Petals expects on each commitment list item (its own DTO):
+presentation: {
+  source: { sourceId: string; title: string | null; overheardAt: string /*ISO*/ | null } | null;
+  excerpt: string | null; // verbatim-or-null
+  why: string | null;     // generated, product voice
+} | null;
+```
+
+`due` and `owner` are **not** part of presentation — Petals already derives those from the
+existing `dueOn` / `owner` fields. Presentation is exactly `{ source, excerpt, why }`.
+
+## Decisions (settled in brainstorming)
+
+1. **New commitments only** — no backfill of the LLM-derived excerpt/why for historical
+   commitments. The Inbox fills in as fresh commitments flow through ingestion.
+2. **All three fields in v1** — provenance + excerpt + why.
+3. **Dedicated, isolated LLM pass** — a small structured call that runs only when a new
+   `Task` node is created. It does **not** touch the load-bearing `graph_extraction` call
+   or its schema/prompt.
+4. **Provenance for _all_ commitments** — `source` is a free DB join on the `sourceId` the
+   commitment already carries, so every card (old and new) gets the tappable
+   "overheard · …" line immediately. Only the LLM-derived `excerpt`/`why` are new-only.
+5. **Dedicated `commitment_presentations` table** (1:1 with the Task node) — decouples the
+   evidence from claim **supersession** (a task's status claim flips pending→done over its
+   life; the evidence must not ride a claim that gets superseded) and gives a clean seam if
+   presentation grows later (e.g. detail view, regeneration).
+6. **Surface: the list response only** — Petals only wired presentation into
+   `toListItemDTO`, not the detail view. YAGNI on `getCommitment` for now.
+
+## Architecture overview
+
+Two independent paths, joined by a small table:
+
+- **Write path (ingestion):** when extraction creates a new `Task` node, a fail-soft
+  presentation pass runs over the **in-memory** source `content` (no blob re-fetch — the raw
+  text is right there at extraction time, and is otherwise discarded), validates the
+  excerpt verbatim in code, and upserts a `commitment_presentations` row.
+- **Read path (list query):** `listCommitments` LEFT JOINs `commitment_presentations` (for
+  excerpt/why) and `sources` (for provenance title + timestamp), assembling the
+  `presentation` object. Provenance is present for every commitment with a resolvable
+  source; excerpt/why are present only when a row exists.
+
+## Components & data flow
+
+### 1. Provenance — free, no LLM
+
+The commitment already carries `sourceId` (surfaced today on `commitmentListItemSchema`).
+In the list query, LEFT JOIN `sources` and build:
+
+```ts
+source: {
+  sourceId,                          // existing
+  title: deriveTitle(source),        // sources-read.ts — metadata.title fallback chain
+  overheardAt: source.createdAt,     // (or lastIngestedAt — pick the "overheard" moment; see open items)
+}
+```
+
+Present for **all** commitments. If no source resolves, `source` is `null`.
+
+> Consumer interaction note: on the Petals card, a non-null `source` makes
+> `hasInlineEvidence` true, which replaces the old lazy "from your chat…" peek with the
+> tappable provenance line (same destination — the source — fewer clicks). This is the
+> intended upgrade for existing cards.
+
+### 2. The honesty mechanism — `locateVerbatim` (pure, TDD'd)
+
+The crux. The model's proposed excerpt is **never trusted or stored directly**. A pure
+function locates it in the real `content` and returns the **actual source characters**, or
+`null`.
+
+```ts
+/**
+ * Locate `candidate` as a verbatim span within `content`, returning the ACTUAL
+ * source characters (never the model's reproduction), or null if absent.
+ * 1. trim candidate; reject null/empty or over-long (length cap) → null
+ * 2. exact substring → return content.slice(hit, hit + len)
+ * 3. else whitespace-collapsed search: find the normalized candidate in normalized
+ *    content, map the hit back to original offsets, return the original slice
+ * 4. not found → null
+ */
+export function locateVerbatim(
+  content: string,
+  candidate: string | null,
+): string | null;
+```
+
+- The whitespace-tolerant step exists because LLMs reproduce quotes with minor whitespace
+  drift (newlines collapsed to spaces, etc.). We still store the **source's** exact
+  characters for the matched range, so the result is genuinely verbatim.
+- **Length cap** (≈240 chars): a card quote is a sentence or two; reject runaway spans → `null`.
+- This function is the single chokepoint for the honesty rule and gets the most rigorous
+  unit tests.
+
+### 3. The presentation pass — `generateCommitmentPresentation`
+
+```ts
+// src/lib/commitment-presentation.ts (new)
+const presentationLlmSchema = z.object({
+  excerpt: z.string().nullable(), // model's candidate quote (validated downstream)
+  why: z.string().nullable(), // one-line, product voice, grounded
+});
+
+export async function generateCommitmentPresentation(args: {
+  content: string; // raw source text, in hand at extraction
+  taskLabel: string; // the commitment's label/statement
+  userId: string;
+}): Promise<{ excerpt: string | null; why: string | null }>;
+```
+
+- Uses the existing `parseStructuredCompletion` + `zodResponseFormat(presentationLlmSchema, "presentation")`
+  infra (`src/lib/ai.ts`), model `modelForTask("commitment_presentation")`.
+- After the call: `excerpt = locateVerbatim(content, llmOut.excerpt)`; `why` is trimmed and
+  length-capped (≈140 chars) and passed through (generated prose is **not** verbatim-bound,
+  but the prompt forbids asserting facts beyond the source).
+- **Fail-soft:** the whole body is wrapped so that any error (LLM failure, parse, timeout)
+  returns `{ excerpt: null, why: null }` and logs — it MUST NOT throw into ingestion. A
+  degraded commitment is acceptable; a broken ingestion is not.
+
+**Prompt shape (sketch — finalized in plan):** system sets the honesty rule (quote must be
+an exact span of the provided text; if nothing cleanly evidences the commitment, return
+`null` excerpt) and the _why_ voice (second person, ≤~15 words, grounded, e.g. "You set a
+concrete launch window."). User message carries the task label + the source content.
+
+### 4. Persistence — `commitment_presentations`
+
+```ts
+// src/db/schema.ts (new table)
+export const commitmentPresentations = pgTable("commitment_presentations", {
+  taskId: typeIdNoDefault("node")
+    .primaryKey()
+    .notNull()
+    .references(() => nodes.id, { onDelete: "cascade" }), // 1:1 with the Task node
+  userId: text()
+    .references(() => users.id)
+    .notNull(), // isolation, consistent with claims/sources
+  sourceId: typeIdNoDefault("source")
+    .notNull()
+    .references(() => sources.id, { onDelete: "cascade" }), // the source the excerpt was quoted from
+  excerpt: text(), // verbatim-or-null
+  why: text(), // generated-or-null
+  createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+- Upsert (`onConflictDoUpdate` on `taskId`) so a re-extraction of the same task is
+  idempotent.
+- Drizzle migration generated via the repo's standard flow (see open items for the exact
+  generate + apply commands).
+
+### 5. SDK surface — extend the list item
+
+```ts
+// src/lib/schemas/list-commitments.ts
+export const presentationSourceSchema = z.object({
+  sourceId: typeIdSchema("source"),
+  title: z.string().nullable(),
+  overheardAt: z.coerce.date().nullable(),
+});
+export const commitmentPresentationSchema = z.object({
+  source: presentationSourceSchema.nullable(),
+  excerpt: z.string().nullable(),
+  why: z.string().nullable(),
+});
+// commitmentListItemSchema gains:
+//   presentation: commitmentPresentationSchema.nullable(),
+```
+
+The `listCommitments` query (and its read model) assembles `presentation` from the two LEFT
+JOINs. `presentation` is `null` only when there is no resolvable source.
+
+### 6. Model routing
+
+Add `commitment_presentation` to the `ModelTask` union in `src/utils/models.ts`, env-override
+`MODEL_ID_COMMITMENT_PRESENTATION`, defaulting to a **cheap/fast** model (it's a
+single-span selection + one-liner — follow the existing cheap-default convention).
+
+## Failure handling
+
+- Presentation generation is **best-effort and fail-soft** at every layer. Ingestion never
+  blocks on it; errors log and yield a degraded (null) presentation.
+- A model-proposed excerpt that fails `locateVerbatim` → `null` (honesty preserved), not an
+  error.
+- The read path tolerates missing presentation rows (LEFT JOIN) and missing sources
+  (`source: null`).
+
+## Out of scope (YAGNI)
+
+- Backfilling excerpt/why for pre-existing commitments.
+- Presentation on the commitment **detail** (`getCommitment`) response.
+- Regeneration / refresh / editing of presentation after creation.
+- Sub-span highlighting or multiple excerpts — one verbatim string per commitment.
+- Any fuzzy/paraphrased excerpt — verbatim-or-null only.
+
+## Testing strategy
+
+- **`locateVerbatim` (pure, TDD — highest rigor):** exact match; whitespace-variant match
+  returning real chars; absent → `null`; `null`/empty candidate → `null`; over-cap candidate
+  → `null`; leading/trailing-whitespace candidate.
+- **`generateCommitmentPresentation` (mocked LLM):** real quote → stored verbatim;
+  hallucinated quote (not in `content`) → `excerpt: null`; over-long `why` trimmed/capped;
+  LLM throws → `{ excerpt: null, why: null }` (fail-soft, no throw).
+- **SDK schema:** `commitmentPresentationSchema` parses populated and fully-null shapes;
+  `presentation` is nullable on the list item.
+- **List query (integration, test DB):** provenance present for a commitment with a source;
+  excerpt/why present when a row exists; `presentation: null` when no source resolves;
+  old-style commitment (no row) still returns provenance.
+
+## Cross-repo coordination (flagged — no publish without explicit OK)
+
+- Additive change → SDK **minor** bump `1.23.0` → `1.24.0`.
+- Verify how Petals consumes `@marcelsamyn/memory` (published package vs. workspace link).
+  If published: publish the new version + bump Petals' dependency. If linked: rebuild.
+- Petals' mapper already handles `presentation`, so **no Petals code change** is needed
+  beyond the version bump.
+- Publishing / Petals PR happen only on Marcel's explicit go-ahead.
+
+## Open items to verify at plan time
+
+> Recon was performed on the (stale) local `main` (`e76ee9c`); this branch is off fresh
+> `origin/main` (`c2fe8c7`). Re-pull exact current code (file:line) when writing the plan.
+
+1. **Task-node creation site** in the extraction flow — exactly where new `Task` nodes (and
+   their initial `assistant_inferred` status claim) are persisted, and confirm `content` is
+   still in scope there to feed the pass.
+2. **`listCommitments` query** — the exact file + how `sourceId` is currently derived, so the
+   two LEFT JOINs slot in correctly.
+3. **`typeId` helper variants** — confirm `typeIdNoDefault` (vs `typeId`) for the new table's
+   PK/FK columns, and the `nodes` / `sources` / `users` table references.
+4. **Cheap-model default convention** in `src/utils/models.ts`.
+5. **Drizzle migration commands** — generate + apply (the repo may use `migrate`, not
+   `push`, in dev — confirm before applying).
+6. **Petals dependency mechanism** (published vs workspace) — for the cross-repo step.
+7. **Structured-output schema gate** — `build:check` runs `check:structured-outputs`
+   (`scripts/check-structured-output-schemas.ts`). Confirm whether the new
+   `presentationLlmSchema` must be registered/discoverable there, and that it satisfies the
+   OpenAI structured-output constraints (all keys required, `.nullable()` not `.optional()`,
+   no defaults).
+
+```
+
+```

--- a/drizzle/0023_cynical_tigra.sql
+++ b/drizzle/0023_cynical_tigra.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "commitment_presentations" (
+	"task_id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"source_id" text NOT NULL,
+	"excerpt" text,
+	"why" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "commitment_presentations" ADD CONSTRAINT "commitment_presentations_task_id_nodes_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."nodes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "commitment_presentations" ADD CONSTRAINT "commitment_presentations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "commitment_presentations" ADD CONSTRAINT "commitment_presentations_source_id_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "commitment_presentations_user_id_idx" ON "commitment_presentations" USING btree ("user_id");

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2242 @@
+{
+  "id": "140c77e0-4065-40d5-a766-6620e356261e",
+  "prevId": "6bc23d4d-ca8a-4b30-88d1-0fd011ce4ed6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commitment_presentations": {
+      "name": "commitment_presentations",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commitment_presentations_user_id_idx": {
+          "name": "commitment_presentations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commitment_presentations_task_id_nodes_id_fk": {
+          "name": "commitment_presentations_task_id_nodes_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commitment_presentations_user_id_users_id_fk": {
+          "name": "commitment_presentations_user_id_users_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "commitment_presentations_source_id_sources_id_fk": {
+          "name": "commitment_presentations_source_id_sources_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1781264303934,
       "tag": "0022_last_patch",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1781443080497,
+      "tag": "0023_cynical_tigra",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@marcelsamyn/memory",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "main": "dist/server/index.mjs",
   "types": "dist/server/index.d.ts",

--- a/scripts/check-structured-output-schemas.ts
+++ b/scripts/check-structured-output-schemas.ts
@@ -1,3 +1,4 @@
+import { commitmentPresentationLlmSchema } from "../src/lib/schemas/commitment-presentation";
 import { documentSpineSchema } from "../src/lib/schemas/document-spine";
 import { llmExtractionSchema } from "../src/lib/schemas/llm-extraction";
 import {
@@ -16,6 +17,13 @@ const structuredOutputSchemas = [
     name: "document_spine",
     schema: zodResponseFormat(documentSpineSchema, "document_spine").json_schema
       .schema,
+  },
+  {
+    name: "commitment_presentation",
+    schema: zodResponseFormat(
+      commitmentPresentationLlmSchema,
+      "commitment_presentation",
+    ).json_schema.schema,
   },
 ] satisfies ReadonlyArray<StructuredOutputSchemaValidationInput>;
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -552,6 +552,33 @@ export const rollupStateRelations = relations(rollupState, ({ one }) => ({
   }),
 }));
 
+/**
+ * Per-commitment presentation evidence (1:1 with a Task node): a verbatim
+ * `excerpt` and a generated `why`, produced when the Task is first inferred.
+ * Provenance (source title + timestamp) is NOT stored here — it is joined from
+ * `sources` via the commitment's active status-claim `sourceId` at read time.
+ * Decoupled from claims so it never rides a superseded status claim.
+ */
+export const commitmentPresentations = pgTable(
+  "commitment_presentations",
+  {
+    taskId: typeIdNoDefault("node")
+      .references(() => nodes.id, { onDelete: "cascade" })
+      .primaryKey()
+      .notNull(),
+    userId: text()
+      .references(() => users.id)
+      .notNull(),
+    sourceId: typeIdNoDefault("source")
+      .references(() => sources.id, { onDelete: "cascade" })
+      .notNull(),
+    excerpt: text(),
+    why: text(),
+    createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("commitment_presentations_user_id_idx").on(table.userId)],
+);
+
 // --- Metrics ---
 
 export const metricDefinitions = pgTable(

--- a/src/lib/commitment-presentation.test.ts
+++ b/src/lib/commitment-presentation.test.ts
@@ -1,0 +1,84 @@
+import { generateCommitmentPresentation } from "./commitment-presentation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The pass uses the createCompletionClient + parseStructuredCompletion seam
+// (mirroring extractGraph). Mock both so no real LLM client is constructed.
+vi.mock("./ai", () => ({
+  createCompletionClient: vi.fn(async () => ({})),
+  parseStructuredCompletion: vi.fn(),
+}));
+const { parseStructuredCompletion } = await import("./ai");
+const mockParse = vi.mocked(parseStructuredCompletion);
+
+const CONTENT = "Sure — I'll send the investor update by Thursday, promise.";
+
+/** Minimal parsed-completion envelope matching what the pass reads. */
+function completion(parsed: unknown) {
+  return { choices: [{ message: { parsed } }] } as unknown as Awaited<
+    ReturnType<typeof parseStructuredCompletion>
+  >;
+}
+
+describe("generateCommitmentPresentation", () => {
+  beforeEach(() => mockParse.mockReset());
+
+  it("stores a real quote verbatim and passes the why through", async () => {
+    mockParse.mockResolvedValue(
+      completion({
+        excerpt: "send the investor update by Thursday",
+        why: "You named a concrete deliverable and deadline.",
+      }),
+    );
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "Send investor update",
+    });
+    expect(out.excerpt).toBe("send the investor update by Thursday");
+    expect(out.why).toBe("You named a concrete deliverable and deadline.");
+  });
+
+  it("nulls a hallucinated excerpt that is not in the source", async () => {
+    mockParse.mockResolvedValue(
+      completion({
+        excerpt: "I promise to climb Everest next week",
+        why: "Ambitious.",
+      }),
+    );
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "Send investor update",
+    });
+    expect(out.excerpt).toBeNull();
+    expect(out.why).toBe("Ambitious.");
+  });
+
+  it("caps an over-long why", async () => {
+    mockParse.mockResolvedValue(
+      completion({ excerpt: null, why: "x".repeat(300) }),
+    );
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "t",
+    });
+    expect(out.why?.length).toBe(140);
+  });
+
+  it("is fail-soft: a malformed completion yields a fully-null presentation", async () => {
+    // A null completion makes the `.choices` access throw inside the try; the
+    // catch returns the degraded shape — same observable behaviour as a failed
+    // LLM call, without the unhandledRejection the nitro-test-utils global
+    // server traps.
+    mockParse.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof parseStructuredCompletion>>,
+    );
+    const out = await generateCommitmentPresentation({
+      userId: "user_1",
+      content: CONTENT,
+      taskLabel: "t",
+    });
+    expect(out).toEqual({ excerpt: null, why: null });
+  });
+});

--- a/src/lib/commitment-presentation.ts
+++ b/src/lib/commitment-presentation.ts
@@ -1,0 +1,85 @@
+import { createCompletionClient, parseStructuredCompletion } from "./ai";
+import { commitmentPresentationLlmSchema } from "./schemas/commitment-presentation";
+import { locateVerbatim } from "./verbatim";
+import { zodResponseFormat } from "openai/helpers/zod.mjs";
+import type { DrizzleDB } from "~/db";
+import { commitmentPresentations } from "~/db/schema";
+import type { TypeId } from "~/types/typeid";
+import { MODEL_MAX_OUTPUT_TOKENS, modelForTask } from "~/utils/models";
+
+export { commitmentPresentationLlmSchema } from "./schemas/commitment-presentation";
+
+const WHY_MAX_CHARS = 140;
+
+const SYSTEM_PROMPT =
+  "You extract honest evidence for a task the assistant inferred from a user's messages. " +
+  "The excerpt MUST be an exact, verbatim substring of the provided source — copy it character-for-character, or return null. " +
+  "Never fabricate, paraphrase, or stitch together a quote. The 'why' is a single short second-person line grounded in the source.";
+
+/**
+ * Produce honest presentation evidence for a freshly-inferred commitment.
+ * Fail-soft: any error yields `{ excerpt: null, why: null }` — this MUST NOT
+ * throw into ingestion. The excerpt is validated against the real source in
+ * code (`locateVerbatim`), so the model cannot fabricate a quote.
+ */
+export async function generateCommitmentPresentation(args: {
+  userId: string;
+  content: string;
+  taskLabel: string;
+}): Promise<{ excerpt: string | null; why: string | null }> {
+  try {
+    // Mirror extractGraph's LLM seam (createCompletionClient +
+    // parseStructuredCompletion) rather than performStructuredAnalysis, so the
+    // extraction tests' `createCompletionClient` mock also covers this call —
+    // otherwise the pass fires a real network request inside those tests.
+    const client = await createCompletionClient(args.userId, {
+      task: "commitment_presentation",
+    });
+    const completion = await parseStructuredCompletion(
+      client,
+      {
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: `Task the assistant inferred: "${args.taskLabel}"\n\nSource text:\n"""\n${args.content}\n"""`,
+          },
+        ],
+        model: modelForTask("commitment_presentation"),
+        max_tokens: MODEL_MAX_OUTPUT_TOKENS,
+        response_format: zodResponseFormat(
+          commitmentPresentationLlmSchema,
+          "commitment_presentation",
+        ),
+      },
+      { task: "commitment_presentation", userId: args.userId },
+    );
+    const out = completion.choices[0]?.message.parsed;
+    const excerpt = locateVerbatim(args.content, out?.excerpt ?? null);
+    const why = out?.why?.trim().slice(0, WHY_MAX_CHARS) || null;
+    return { excerpt, why };
+  } catch (error) {
+    console.warn(`commitment presentation generation failed: ${String(error)}`);
+    return { excerpt: null, why: null };
+  }
+}
+
+/** Upsert presentation evidence for a task (idempotent on re-extraction). */
+export async function upsertCommitmentPresentation(
+  db: DrizzleDB,
+  row: {
+    taskId: TypeId<"node">;
+    userId: string;
+    sourceId: TypeId<"source">;
+    excerpt: string | null;
+    why: string | null;
+  },
+): Promise<void> {
+  await db
+    .insert(commitmentPresentations)
+    .values(row)
+    .onConflictDoUpdate({
+      target: commitmentPresentations.taskId,
+      set: { excerpt: row.excerpt, why: row.why, sourceId: row.sourceId },
+    });
+}

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -2,6 +2,10 @@ import { parseStructuredCompletion } from "./ai";
 import { createAlias, normalizeAliasText } from "./alias";
 import { applyClaimLifecycle, fetchClaimsByIds } from "./claims/lifecycle";
 import { coerceTaskStatus } from "./claims/task-status";
+import {
+  generateCommitmentPresentation,
+  upsertCommitmentPresentation,
+} from "./commitment-presentation";
 import { debugGraph } from "./debug-utils";
 import {
   generateAndInsertNodeEmbeddings,
@@ -534,6 +538,35 @@ ${content}
     generateAndInsertClaimEmbeddings(db, claimsToEmbed),
     generateAndInsertNodeEmbeddings(db, detailsOfNewlyCreatedNodes),
   ]);
+
+  // Honest presentation evidence for each freshly-inferred commitment, using
+  // the source text we still hold in memory. Best-effort: never let it break
+  // ingestion (the pass is itself fail-soft; we also guard the upsert).
+  const newTaskNodes = detailsOfNewlyCreatedNodes.filter(
+    (node) => node.nodeType === "Task",
+  );
+  for (const task of newTaskNodes) {
+    try {
+      const { excerpt, why } = await generateCommitmentPresentation({
+        userId,
+        content,
+        taskLabel: task.label,
+      });
+      if (excerpt !== null || why !== null) {
+        await upsertCommitmentPresentation(db, {
+          taskId: task.id,
+          userId,
+          sourceId,
+          excerpt,
+          why,
+        });
+      }
+    } catch (error) {
+      console.warn(
+        `commitment presentation upsert failed for ${task.id}: ${String(error)}`,
+      );
+    }
+  }
 
   // Enqueue profile synthesis for each subject whose active claim set may have
   // changed: any subject of an inserted claim, or of a claim removed by the

--- a/src/lib/query/commitments-list.test.ts
+++ b/src/lib/query/commitments-list.test.ts
@@ -188,6 +188,16 @@ describeIfServer("listCommitments query", () => {
           "external_id" text NOT NULL,
           "scope" varchar(16) DEFAULT 'personal' NOT NULL,
           "status" varchar(20) DEFAULT 'completed',
+          "metadata" jsonb,
+          "last_ingested_at" timestamp with time zone,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "commitment_presentations" (
+          "task_id" text PRIMARY KEY NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "excerpt" text,
+          "why" text,
           "created_at" timestamp with time zone DEFAULT now() NOT NULL
         );
         CREATE TABLE "claims" (
@@ -719,6 +729,16 @@ describeIfServer("listCommitments query", () => {
       "external_id" text NOT NULL,
       "scope" varchar(16) DEFAULT 'personal' NOT NULL,
       "status" varchar(20) DEFAULT 'completed',
+      "metadata" jsonb,
+      "last_ingested_at" timestamp with time zone,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE "commitment_presentations" (
+      "task_id" text PRIMARY KEY NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+      "excerpt" text,
+      "why" text,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL
     );
     CREATE TABLE "claims" (

--- a/src/lib/query/commitments-list.ts
+++ b/src/lib/query/commitments-list.ts
@@ -20,15 +20,23 @@ import {
   sql,
   type SQL,
 } from "drizzle-orm";
-import { claims, nodeMetadata, nodes } from "~/db/schema";
+import {
+  claims,
+  commitmentPresentations,
+  nodeMetadata,
+  nodes,
+  sources,
+} from "~/db/schema";
 import { coerceTaskStatus } from "~/lib/claims/task-status";
 import type {
   CommitmentListItem,
+  CommitmentPresentation,
   CommitmentProvenance,
   CommitmentSort,
   ListCommitmentsRequest,
   ListCommitmentsResponse,
 } from "~/lib/schemas/list-commitments";
+import { deriveTitle } from "~/lib/sources-read";
 import type { TypeId } from "~/types/typeid";
 import { useDatabase } from "~/utils/db";
 
@@ -44,6 +52,11 @@ interface ListRow {
   statusChangedAt: Date;
   createdAt: Date;
   sourceId: TypeId<"source">;
+  sourceMetadata: unknown;
+  sourceCreatedAt: Date | null;
+  sourceLastIngestedAt: Date | null;
+  presentationExcerpt: string | null;
+  presentationWhy: string | null;
 }
 
 /**
@@ -107,6 +120,34 @@ function subJoinProvenanceFilter(
 /** Escape `%`, `_`, and backslash so a search term is treated as a literal. */
 function escapeLike(term: string): string {
   return term.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
+ * Assemble the inbox card's inline evidence: provenance from the joined source
+ * (present for every commitment with a resolvable source), plus the verbatim
+ * excerpt + why when a `commitment_presentations` row exists.
+ */
+function buildPresentation(row: {
+  sourceId: TypeId<"source">;
+  sourceMetadata: unknown;
+  sourceCreatedAt: Date | null;
+  sourceLastIngestedAt: Date | null;
+  presentationExcerpt: string | null;
+  presentationWhy: string | null;
+}): CommitmentPresentation {
+  const source =
+    row.sourceCreatedAt === null
+      ? null
+      : {
+          sourceId: row.sourceId,
+          title: deriveTitle(row.sourceMetadata),
+          overheardAt: row.sourceLastIngestedAt ?? row.sourceCreatedAt,
+        };
+  return {
+    source,
+    excerpt: row.presentationExcerpt,
+    why: row.presentationWhy,
+  };
 }
 
 export async function listCommitments(
@@ -211,6 +252,11 @@ export async function listCommitments(
       statusChangedAt: claims.statedAt,
       createdAt: nodes.createdAt,
       sourceId: claims.sourceId,
+      sourceMetadata: sources.metadata,
+      sourceCreatedAt: sources.createdAt,
+      sourceLastIngestedAt: sources.lastIngestedAt,
+      presentationExcerpt: commitmentPresentations.excerpt,
+      presentationWhy: commitmentPresentations.why,
     })
     .from(claims)
     .innerJoin(
@@ -248,6 +294,11 @@ export async function listCommitments(
       ),
     )
     .leftJoin(dueMetadata, eq(dueMetadata.nodeId, dueClaim.objectNodeId))
+    .leftJoin(sources, eq(sources.id, claims.sourceId))
+    .leftJoin(
+      commitmentPresentations,
+      eq(commitmentPresentations.taskId, nodes.id),
+    )
     .where(and(...whereClauses.filter((c): c is SQL => c !== undefined)))
     .orderBy(...orderBy)
     .limit(limit + 1);
@@ -285,6 +336,7 @@ export async function listCommitments(
       statusChangedAt: row.statusChangedAt,
       createdAt: row.createdAt,
       sourceId: row.sourceId,
+      presentation: buildPresentation(row),
     });
   }
 

--- a/src/lib/schemas/commitment-presentation.ts
+++ b/src/lib/schemas/commitment-presentation.ts
@@ -1,0 +1,30 @@
+/**
+ * Side-effect-free schema for the commitment-presentation pass: a small
+ * structured LLM call that extracts a verbatim excerpt and a short "why"
+ * for each newly-inferred Task node.
+ *
+ * Common aliases: presentation schema, commitment excerpt, commitment why.
+ */
+import { z } from "zod";
+
+/** Structured output for the presentation pass (OpenAI-safe: all keys required, nullable not optional). */
+export const commitmentPresentationLlmSchema = z
+  .object({
+    excerpt: z
+      .string()
+      .nullable()
+      .describe(
+        "A SHORT exact quote, copied character-for-character from the provided source text, that directly evidences this commitment. If no single span cleanly evidences it, return null. Never paraphrase, summarize, or invent.",
+      ),
+    why: z
+      .string()
+      .nullable()
+      .describe(
+        "One short second-person line (max ~15 words) explaining why this is a commitment, grounded in the source. e.g. 'You set a concrete launch window.' Null if nothing meaningful to add.",
+      ),
+  })
+  .describe("commitment_presentation");
+
+export type CommitmentPresentationLlmOutput = z.infer<
+  typeof commitmentPresentationLlmSchema
+>;

--- a/src/lib/schemas/list-commitments.ts
+++ b/src/lib/schemas/list-commitments.ts
@@ -2,6 +2,21 @@ import { TaskStatusEnum } from "../../types/graph.js";
 import { typeIdSchema } from "../../types/typeid.js";
 import { z } from "zod";
 
+export const presentationSourceSchema = z.object({
+  sourceId: typeIdSchema("source"),
+  title: z.string().nullable(),
+  overheardAt: z.coerce.date().nullable(),
+});
+
+export const commitmentPresentationSchema = z.object({
+  source: presentationSourceSchema.nullable(),
+  excerpt: z.string().nullable(),
+  why: z.string().nullable(),
+});
+export type CommitmentPresentation = z.infer<
+  typeof commitmentPresentationSchema
+>;
+
 /** Sort key for `listCommitments`. */
 export const commitmentSortEnum = z.enum([
   "statusChangedAt",
@@ -83,6 +98,8 @@ export const commitmentListItemSchema = z.object({
   statusChangedAt: z.coerce.date(),
   createdAt: z.coerce.date(),
   sourceId: typeIdSchema("source"),
+  /** Inline evidence for the inbox card. Null when no source resolves. */
+  presentation: commitmentPresentationSchema.nullable(),
 });
 
 export const listCommitmentsResponseSchema = z.object({

--- a/src/lib/sources-read.ts
+++ b/src/lib/sources-read.ts
@@ -52,7 +52,7 @@ function decodeCursor(raw: string): ListCursor | null {
   }
 }
 
-function deriveTitle(metadata: unknown): string | null {
+export function deriveTitle(metadata: unknown): string | null {
   const parsed = sourceMetadataSchema.safeParse(metadata ?? {});
   if (!parsed.success) return null;
   if (parsed.data.title) return parsed.data.title;

--- a/src/lib/verbatim.test.ts
+++ b/src/lib/verbatim.test.ts
@@ -1,0 +1,48 @@
+import { locateVerbatim } from "./verbatim";
+import { describe, expect, it } from "vitest";
+
+describe("locateVerbatim", () => {
+  it("returns the exact source slice for an exact substring", () => {
+    const content = "Let's ship the beta on Friday for sure.";
+    expect(locateVerbatim(content, "ship the beta on Friday")).toBe(
+      "ship the beta on Friday",
+    );
+  });
+
+  it("is case-sensitive (never normalizes case)", () => {
+    expect(locateVerbatim("Ship the beta", "ship the beta")).toBeNull();
+  });
+
+  it("tolerates whitespace drift and returns the ORIGINAL characters", () => {
+    const content = "I will\n   ship it tomorrow";
+    // model collapsed the newline+spaces to a single space:
+    expect(locateVerbatim(content, "I will ship it")).toBe(
+      "I will\n   ship it",
+    );
+  });
+
+  it("collapses repeated whitespace inside the candidate too", () => {
+    expect(locateVerbatim("a   b", "a b")).toBe("a   b");
+  });
+
+  it("returns null when the candidate is absent", () => {
+    expect(locateVerbatim("nothing here", "launch the rocket")).toBeNull();
+  });
+
+  it("returns null for null / empty / whitespace-only candidates", () => {
+    expect(locateVerbatim("anything", null)).toBeNull();
+    expect(locateVerbatim("anything", "")).toBeNull();
+    expect(locateVerbatim("anything", "   ")).toBeNull();
+  });
+
+  it("trims the candidate before searching", () => {
+    expect(locateVerbatim("ship the beta", "  ship the beta  ")).toBe(
+      "ship the beta",
+    );
+  });
+
+  it("returns null for an over-long candidate (cap guards runaway spans)", () => {
+    const content = "x".repeat(500);
+    expect(locateVerbatim(content, "x".repeat(300))).toBeNull();
+  });
+});

--- a/src/lib/verbatim.ts
+++ b/src/lib/verbatim.ts
@@ -1,0 +1,70 @@
+/**
+ * Verbatim-or-null source-quote location.
+ *
+ * Common aliases: locate quote, verbatim excerpt, honest highlight, substring
+ * provenance. The model proposes a quote; we only ever return text that
+ * genuinely appears in `content` (the ACTUAL source characters), or null.
+ */
+
+/** A card quote is a sentence or two; reject runaway spans. */
+const MAX_EXCERPT_CHARS = 240;
+
+/**
+ * Locate `candidate` as a verbatim span within `content`, returning the actual
+ * source characters for the matched range, or `null` if it is not present.
+ *
+ * 1. Trim the candidate; reject null / empty / over-long → `null`.
+ * 2. Exact substring → return `content.slice(...)` of the hit.
+ * 3. Whitespace-tolerant: collapse runs of whitespace in both (LLMs flatten
+ *    newlines/indentation), find the candidate, and map the hit back to the
+ *    original offsets so the returned text is byte-for-byte from the source.
+ * 4. Not found → `null`.
+ *
+ * Case is never normalized — verbatim means verbatim.
+ */
+export function locateVerbatim(
+  content: string,
+  candidate: string | null,
+): string | null {
+  if (!candidate) return null;
+  const needle = candidate.trim();
+  if (needle.length === 0 || needle.length > MAX_EXCERPT_CHARS) return null;
+
+  const exact = content.indexOf(needle);
+  if (exact !== -1) return content.slice(exact, exact + needle.length);
+
+  const { normalized, map } = collapseWhitespace(content);
+  const normNeedle = needle.replace(/\s+/g, " ");
+  const at = normalized.indexOf(normNeedle);
+  if (at === -1) return null;
+
+  const start = map[at];
+  const end = map[at + normNeedle.length - 1];
+  if (start === undefined || end === undefined) return null;
+  return content.slice(start, end + 1);
+}
+
+/**
+ * Collapse each run of whitespace to a single space. Returns the normalized
+ * string and `map[i]` = the index in the ORIGINAL string of normalized char i.
+ */
+function collapseWhitespace(s: string): { normalized: string; map: number[] } {
+  let normalized = "";
+  const map: number[] = [];
+  let inWhitespace = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!;
+    if (/\s/.test(ch)) {
+      if (!inWhitespace) {
+        normalized += " ";
+        map.push(i);
+        inWhitespace = true;
+      }
+    } else {
+      normalized += ch;
+      map.push(i);
+      inWhitespace = false;
+    }
+  }
+  return { normalized, map };
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,6 +23,7 @@ const envSchema = z.object({
   MODEL_ID_DREAM: z.string().min(1).optional(),
   MODEL_ID_DEEP_RESEARCH: z.string().min(1).optional(),
   MODEL_ID_TEMPORAL_SUMMARY: z.string().min(1).optional(),
+  MODEL_ID_COMMITMENT_PRESENTATION: z.string().min(1).optional(),
 
   // Hard ceiling on output tokens per completion. Bounds a runaway
   // generation (providers can emit up to 128k); set well above the observed

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -18,7 +18,8 @@ export type ModelTask =
   | "profile_synthesis"
   | "dream"
   | "deep_research"
-  | "temporal_summary";
+  | "temporal_summary"
+  | "commitment_presentation";
 
 /**
  * Per-task overrides. An undefined entry (the default for every task) means
@@ -35,6 +36,7 @@ const TASK_MODEL_OVERRIDES: Record<ModelTask, string | undefined> = {
   dream: env.MODEL_ID_DREAM,
   deep_research: env.MODEL_ID_DEEP_RESEARCH,
   temporal_summary: env.MODEL_ID_TEMPORAL_SUMMARY,
+  commitment_presentation: env.MODEL_ID_COMMITMENT_PRESENTATION,
 };
 
 /**


### PR DESCRIPTION
## What & why

The Petals `/tasks` "caught-promise" card surfaces commitments the assistant inferred from your chats. Until now the card had the *commitment* but none of the **evidence** — a caught promise was a bare claim with no way to see where it came from or why it was caught.

This adds an honest **`presentation`** object to every commitment on the list response:

- **`source`** — provenance (title + when it was overheard). A free join on the commitment's existing `sourceId`, so it's shown for **all** commitments.
- **`excerpt`** — a short **verbatim** quote from the source, or `null`. Never paraphrased, never fabricated.
- **`why`** — one short second-person line on why this looked like a commitment, grounded in the source.

`excerpt` + `why` come from a dedicated, **fail-soft** LLM pass (`generateCommitmentPresentation`) run inside `extractGraph` for each newly-created `Task` node — new commitments only, no backfill.

### Honesty in code

The model proposes a quote; **code** decides whether it's real. `locateVerbatim(content, candidate)` returns the actual source span (exact, then whitespace-tolerant) or `null`. A hallucinated quote can't survive — it isn't found, so the excerpt is dropped. This is the load-bearing invariant and the most heavily tested unit.

### Shape (locked to the Petals consumer)

```ts
presentation: {
  source: { sourceId: string; title: string | null; overheardAt: string /* ISO */ | null } | null;
  excerpt: string | null;
  why: string | null;
} | null
```

## How it's built

- `commitment_presentations` table (1:1 with the task, `onConflictDoUpdate`) — decoupled from claim supersession so re-extraction is idempotent and the evidence survives status churn. Migration `0023`.
- Dedicated `commitment_presentation` model task (`MODEL_ID_COMMITMENT_PRESENTATION`, defaults to the graph-extraction model).
- The pass uses the same `createCompletionClient` + `parseStructuredCompletion` seam as `extractGraph`, structured via `zodResponseFormat`.
- Fail-soft throughout: any error in the pass yields `{ excerpt: null, why: null }` and never throws into ingestion.

## How to test

```bash
pnpm install
pnpm run build:check   # tsc + structured-output schema gate (validates 3 schemas)
pnpm lint
pnpm run format
pnpm test --run        # 448 passing, incl. verbatim.test.ts + commitment-presentation.test.ts
```

`drizzle:migrate` applies `0023` on a clean journal (CI / prod). Heads-up for local dev DBs provisioned via `drizzle:push`: the journal replay conflicts — apply `0023` directly (`psql "$DATABASE_URL" -f drizzle/0023_*.sql`); it's additive-only.

## Downstream (after merge)

1. Publish `@marcelsamyn/memory@1.24.0`.
2. Bump Petals' dependency → the card lights up with real evidence (its `commitments-map.ts` already maps `presentation`).

The n8n node (`n8n-nodes-petals`) is write-only (ingest) and is unaffected by this additive read-side field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
