### PR TITLE
✨ feat(search): hybrid explicit search (lexical + vector) via POST /search

### DIFF
--- a/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
+++ b/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
@@ -15,6 +15,7 @@
 ## File Structure
 
 **Memory repo (this plan):**
+
 - `src/db/schema.ts` — MODIFY: add a `tsvector` customType, generated `search_tsv` columns on `claims` + `node_metadata`, GIN (tsvector) + GIN (trgm) indexes.
 - `drizzle/0024_hybrid_search_indexes.sql` — CREATE: migration (generated + extension prepended).
 - `src/lib/search/fusion.ts` — CREATE: pure RRF.
@@ -38,6 +39,7 @@
 Start with the pure function — no DB, no network.
 
 **Files:**
+
 - Create: `src/lib/search/fusion.ts`
 - Test: `src/lib/search/fusion.test.ts`
 
@@ -45,8 +47,8 @@ Start with the pure function — no DB, no network.
 
 ```typescript
 // src/lib/search/fusion.test.ts
-import { describe, expect, it } from "vitest";
 import { reciprocalRankFusion, RRF_K } from "./fusion";
+import { describe, expect, it } from "vitest";
 
 describe("reciprocalRankFusion", () => {
   it("sums 1/(k+rank) across rankings and sorts descending", () => {
@@ -150,6 +152,7 @@ git commit -m "✨ feat(search): reciprocal rank fusion helper"
 Declare the lexical indexes in the schema, generate the migration, and prepend the extension.
 
 **Files:**
+
 - Modify: `src/db/schema.ts` (imports; `claims` and `nodeMetadata` table bodies)
 - Create: `drizzle/0024_hybrid_search_indexes.sql`
 
@@ -242,11 +245,13 @@ Expected: PASS (tsc clean — confirms the schema typechecks with the new column
 Then sanity-apply against a throwaway DB:
 
 Run:
+
 ```bash
 psql "postgres://postgres:postgres@localhost:5431/postgres" -c 'CREATE DATABASE mig_smoke_0024;'
 RUN_MIGRATIONS=true DATABASE_URL="postgres://postgres:postgres@localhost:5431/mig_smoke_0024" pnpm tsx -e "import('./src/utils/db').then(m=>m.useDatabase()).then(()=>{console.log('migrated ok');process.exit(0)})"
 psql "postgres://postgres:postgres@localhost:5431/postgres" -c 'DROP DATABASE mig_smoke_0024;'
 ```
+
 Expected: prints `migrated ok` with no error.
 
 - [ ] **Step 7: Commit**
@@ -263,6 +268,7 @@ git commit -m "✨ feat(search): tsvector + pg_trgm indexes for hybrid search"
 A reusable helper that creates a fresh DB, runs all migrations (so `search_tsv` + `pg_trgm` exist), and wires it into `useDatabase()` via the existing `setTestDatabase` seam.
 
 **Files:**
+
 - Create: `src/lib/search/test-db.ts`
 
 - [ ] **Step 1: Write the helper**
@@ -277,12 +283,12 @@ A reusable helper that creates a fresh DB, runs all migrations (so `search_tsv` 
  * Common aliases: createMigratedTestDb, search test database, hybrid search
  * test setup.
  */
-import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
+import pg from "pg";
+import type { DrizzleDB } from "~/db";
 import * as schema from "~/db/schema";
 import { setTestDatabase } from "~/utils/db";
-import type { DrizzleDB } from "~/db";
 
 const HOST = process.env["TEST_PG_HOST"] ?? "localhost";
 const PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
@@ -366,6 +372,7 @@ git commit -m "✅ test(search): migrated test-db helper"
 Add lexical node/claim retrieval to `graph.ts`, plus the two new filters the facets need (`includeNodeTypes`, `statedBetween`). Export `generateTextEmbedding` for the pipeline.
 
 **Files:**
+
 - Modify: `src/lib/graph.ts`
 - Test: `src/lib/search/lexical.test.ts`
 
@@ -373,12 +380,12 @@ Add lexical node/claim retrieval to `graph.ts`, plus the two new filters the fac
 
 ```typescript
 // src/lib/search/lexical.test.ts
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMigratedTestDb, isServerReachable } from "./test-db";
-import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
-import { nodes, nodeMetadata, claims, sources, users } from "~/db/schema";
-import { newTypeId } from "~/types/typeid";
 import type { MigratedTestDb } from "./test-db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { nodes, nodeMetadata, claims, sources, users } from "~/db/schema";
+import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
+import { newTypeId } from "~/types/typeid";
 
 const SERVER = await isServerReachable();
 const d = SERVER ? describe : describe.skip;
@@ -440,7 +447,11 @@ d("lexical retrieval", () => {
   });
 
   it("matches an exact keyword and returns a highlight", async () => {
-    const rows = await findClaimsByLexical({ userId, query: "Boox", limit: 10 });
+    const rows = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      limit: 10,
+    });
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0]!.statement).toContain("Boox");
     expect(rows[0]!.highlight).toMatch(/<mark>|Boox/);
@@ -455,13 +466,19 @@ d("lexical retrieval", () => {
     const inRange = await findClaimsByLexical({
       userId,
       query: "Boox",
-      statedBetween: { from: new Date("2026-05-01Z"), to: new Date("2026-05-31Z") },
+      statedBetween: {
+        from: new Date("2026-05-01Z"),
+        to: new Date("2026-05-31Z"),
+      },
     });
     expect(inRange.length).toBeGreaterThan(0);
     const outOfRange = await findClaimsByLexical({
       userId,
       query: "Boox",
-      statedBetween: { from: new Date("2026-01-01Z"), to: new Date("2026-02-01Z") },
+      statedBetween: {
+        from: new Date("2026-01-01Z"),
+        to: new Date("2026-02-01Z"),
+      },
     });
     expect(outOfRange.length).toBe(0);
   });
@@ -570,12 +587,12 @@ with one that honours an explicit single scope (takes precedence):
 Then after the existing `excludeNodeTypes` block, add the include-filter:
 
 ```typescript
-  if (includeNodeTypes && includeNodeTypes.length > 0) {
-    whereCondition = and(
-      whereCondition,
-      inArray(nodes.nodeType, includeNodeTypes),
-    );
-  }
+if (includeNodeTypes && includeNodeTypes.length > 0) {
+  whereCondition = and(
+    whereCondition,
+    inArray(nodes.nodeType, includeNodeTypes),
+  );
+}
 ```
 
 **`findSimilarClaims`** — also destructure `statedBetween` and `scope` from opts.
@@ -599,18 +616,18 @@ Then, after the `inArray(claims.status, statuses)` / validity conditions are
 built, add the range filter:
 
 ```typescript
-  if (statedBetween?.from) {
-    whereCondition = and(
-      whereCondition,
-      sql`${claims.statedAt} >= ${statedBetween.from}`,
-    );
-  }
-  if (statedBetween?.to) {
-    whereCondition = and(
-      whereCondition,
-      sql`${claims.statedAt} <= ${statedBetween.to}`,
-    );
-  }
+if (statedBetween?.from) {
+  whereCondition = and(
+    whereCondition,
+    sql`${claims.statedAt} >= ${statedBetween.from}`,
+  );
+}
+if (statedBetween?.to) {
+  whereCondition = and(
+    whereCondition,
+    sql`${claims.statedAt} <= ${statedBetween.to}`,
+  );
+}
 ```
 
 - [ ] **Step 6: Implement `findNodesByLexical`**
@@ -781,21 +798,24 @@ git commit -m "✨ feat(search): lexical node/claim retrieval with facet filters
 ## Task 5: Search schemas
 
 **Files:**
+
 - Create: `src/lib/schemas/search.ts`
 
 - [ ] **Step 1: Write the failing test**
 
 ```typescript
 // src/lib/schemas/search.test.ts
-import { describe, expect, it } from "vitest";
 import { searchRequestSchema, searchResponseSchema } from "./search";
+import { describe, expect, it } from "vitest";
 
 describe("search schemas", () => {
   it("applies defaults and rejects empty query", () => {
     const parsed = searchRequestSchema.parse({ userId: "u", query: "boox" });
     expect(parsed.limit).toBe(20);
     expect(parsed.scope).toBe("personal");
-    expect(() => searchRequestSchema.parse({ userId: "u", query: "" })).toThrow();
+    expect(() =>
+      searchRequestSchema.parse({ userId: "u", query: "" }),
+    ).toThrow();
   });
 
   it("accepts entityTypes and statedBetween filters", () => {
@@ -928,6 +948,7 @@ git commit -m "✨ feat(search): request/response schemas for /search"
 Assemble the two legs (vector + lexical) for nodes and claims, fuse per id space, merge into one ranked `SearchHit[]`, and hydrate source provenance.
 
 **Files:**
+
 - Create: `src/lib/search/explicit-search.ts`
 - Test: `src/lib/search/explicit-search.test.ts`
 
@@ -937,6 +958,7 @@ This test mocks the four retrieval functions and the embedding call (so it needs
 
 ```typescript
 // src/lib/search/explicit-search.test.ts
+import { explicitSearch } from "./explicit-search";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -955,8 +977,6 @@ vi.mock("~/lib/graph", () => ({
   findClaimsByLexical: mocks.findClaimsByLexical,
 }));
 
-import { explicitSearch } from "./explicit-search";
-
 // Stub hydrator: maps src_1 -> a manual source. Injected so the pipeline never
 // touches the DB in this unit test.
 const stubHydrate = async (ids: string[]) =>
@@ -968,19 +988,46 @@ describe("explicitSearch", () => {
   it("fuses legs, builds hits, and orders by fused score", async () => {
     mocks.generateTextEmbedding.mockResolvedValue([0.1, 0.2]);
     mocks.findSimilarNodes.mockResolvedValue([
-      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 0.9 },
+      {
+        id: "node_1",
+        type: "Object",
+        label: "Boox",
+        description: null,
+        timestamp: new Date(),
+        similarity: 0.9,
+      },
     ]);
     mocks.findNodesByLexical.mockResolvedValue([
-      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 1, highlight: "<mark>Boox</mark>" },
+      {
+        id: "node_1",
+        type: "Object",
+        label: "Boox",
+        description: null,
+        timestamp: new Date(),
+        similarity: 1,
+        highlight: "<mark>Boox</mark>",
+      },
     ]);
     mocks.findSimilarClaims.mockResolvedValue([]);
     mocks.findClaimsByLexical.mockResolvedValue([
       {
-        id: "claim_1", subjectNodeId: "node_1", objectNodeId: null, objectValue: "v",
-        subjectLabel: "Boox", objectLabel: null, predicate: "HAS_ATTRIBUTE",
-        statement: "Boox syncs", description: null, sourceId: "src_1", scope: "personal",
-        assertedByKind: "user", assertedByNodeId: null, status: "active",
-        statedAt: new Date("2026-05-10Z"), timestamp: new Date(), similarity: 1,
+        id: "claim_1",
+        subjectNodeId: "node_1",
+        objectNodeId: null,
+        objectValue: "v",
+        subjectLabel: "Boox",
+        objectLabel: null,
+        predicate: "HAS_ATTRIBUTE",
+        statement: "Boox syncs",
+        description: null,
+        sourceId: "src_1",
+        scope: "personal",
+        assertedByKind: "user",
+        assertedByNodeId: null,
+        status: "active",
+        statedAt: new Date("2026-05-10Z"),
+        timestamp: new Date(),
+        similarity: 1,
         highlight: "<mark>Boox</mark> syncs",
       },
     ]);
@@ -1041,7 +1088,10 @@ Source hydration needs the DB. To keep the unit test hermetic, the pipeline acce
  *
  * Common aliases: hybrid search, explicit search, search pipeline, runSearch.
  */
+import { reciprocalRankFusion } from "./fusion";
 import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { sources } from "~/db/schema";
 import {
   generateTextEmbedding,
   findSimilarNodes,
@@ -1053,13 +1103,10 @@ import {
   type NodeSearchResult,
   type ClaimSearchResult,
 } from "~/lib/graph";
-import { reciprocalRankFusion } from "./fusion";
-import { sources } from "~/db/schema";
-import { useDatabase } from "~/utils/db";
-import type { NodeType, Scope, SourceType } from "~/types/graph";
 import type { SearchHit, SearchResponse } from "~/lib/schemas/search";
+import type { NodeType, Scope, SourceType } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
-import { z } from "zod";
+import { useDatabase } from "~/utils/db";
 
 export interface ExplicitSearchParams {
   userId: string;
@@ -1252,6 +1299,7 @@ git commit -m "✨ feat(search): hybrid retrieval pipeline with RRF and hit hydr
 ## Task 7: The `POST /search` route
 
 **Files:**
+
 - Create: `src/routes/search.post.ts`
 - Test: `src/search-route.test.ts`
 
@@ -1259,16 +1307,15 @@ git commit -m "✨ feat(search): hybrid retrieval pipeline with RRF and hit hydr
 
 ```typescript
 // src/search-route.test.ts
-import { afterEach, describe, expect, it, vi } from "vitest";
+import handler from "./routes/search.post";
 import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { searchResponseSchema } from "~/lib/schemas/search";
 
 const mocks = vi.hoisted(() => ({ explicitSearch: vi.fn() }));
 vi.mock("~/lib/search/explicit-search", () => ({
   explicitSearch: mocks.explicitSearch,
 }));
-
-import handler from "./routes/search.post";
-import { searchResponseSchema } from "~/lib/schemas/search";
 
 describe("POST /search", () => {
   afterEach(() => {
@@ -1298,7 +1345,12 @@ describe("POST /search", () => {
     expect(response.hits).toHaveLength(1);
     // Defaults applied by the request schema reached the pipeline.
     expect(mocks.explicitSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "u", query: "Boox", limit: 20, scope: "personal" }),
+      expect.objectContaining({
+        userId: "u",
+        query: "Boox",
+        limit: 20,
+        scope: "personal",
+      }),
     );
   });
 
@@ -1329,11 +1381,11 @@ Expected: FAIL — cannot find module `./routes/search.post`.
  * background context) and the legacy `POST /query/search` (raw graph for
  * visualization). See docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md.
  */
-import { explicitSearch } from "~/lib/search/explicit-search";
 import {
   searchRequestSchema,
   searchResponseSchema,
 } from "~/lib/schemas/search";
+import { explicitSearch } from "~/lib/search/explicit-search";
 
 export default defineEventHandler(async (event) => {
   const { userId, query, limit, scope, filters } = searchRequestSchema.parse(
@@ -1363,14 +1415,15 @@ git commit -m "✨ feat(search): POST /search hybrid explicit-search route"
 ## Task 8: SDK `search()` method
 
 **Files:**
+
 - Modify: `src/sdk/memory-client.ts`
 
 - [ ] **Step 1: Write the failing test**
 
 ```typescript
 // src/sdk/memory-client-search.test.ts
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryClient } from "./memory-client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("MemoryClient.search", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
+++ b/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
@@ -1,0 +1,1491 @@
+# Hybrid Explicit Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated hybrid (lexical + vector) explicit-search endpoint `POST /search` to the memory service, returning ranked hits with highlights, with entity-type and time-range facets.
+
+**Architecture:** A new Postgres lexical layer (`tsvector` + GIN for keyword/phrase, `pg_trgm` for fuzzy/prefix) runs alongside the existing pgvector HNSW semantic layer. The two rankings are fused with Reciprocal Rank Fusion (RRF). Background context injection (`/context/search`) and graph visualization (`/query/search`) are untouched — hybrid lives only on the new explicit-search surface.
+
+**Tech Stack:** TypeScript, Nitro (file-based routes), Drizzle ORM, PostgreSQL (pgvector + pg_trgm), Zod, Vitest. Test DB on `:5431` (CI runs lint/format/build only — run vitest locally).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md`
+
+---
+
+## File Structure
+
+**Memory repo (this plan):**
+- `src/db/schema.ts` — MODIFY: add a `tsvector` customType, generated `search_tsv` columns on `claims` + `node_metadata`, GIN (tsvector) + GIN (trgm) indexes.
+- `drizzle/0024_hybrid_search_indexes.sql` — CREATE: migration (generated + extension prepended).
+- `src/lib/search/fusion.ts` — CREATE: pure RRF.
+- `src/lib/search/fusion.test.ts` — CREATE.
+- `src/lib/graph.ts` — MODIFY: export `generateTextEmbedding`; add `includeNodeTypes` + `statedBetween` filters; add `findNodesByLexical` / `findClaimsByLexical`.
+- `src/lib/search/lexical.test.ts` — CREATE: lexical retrieval tests (real DB).
+- `src/lib/search/explicit-search.ts` — CREATE: the hybrid pipeline + `SearchHit` hydration.
+- `src/lib/search/explicit-search.test.ts` — CREATE.
+- `src/lib/search/test-db.ts` — CREATE: shared migrated-test-DB helper (NOT a `.test.ts`, safe to export from).
+- `src/lib/schemas/search.ts` — CREATE: request/response + `SearchHit` schemas.
+- `src/routes/search.post.ts` — CREATE: the endpoint.
+- `src/search-route.test.ts` — CREATE: handler-level test.
+- `src/sdk/memory-client.ts` — MODIFY: add `search()` method.
+
+**Deferred to a follow-on plan (cross-repo, own worktree):** Petals explorer migration, `n8n-nodes-petals` operation, Petals proxy endpoint, and the optional assistant MCP `search_text` tool. Out of scope here so this plan ships working, testable software on its own.
+
+---
+
+## Task 1: Fusion (pure RRF)
+
+Start with the pure function — no DB, no network.
+
+**Files:**
+- Create: `src/lib/search/fusion.ts`
+- Test: `src/lib/search/fusion.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/search/fusion.test.ts
+import { describe, expect, it } from "vitest";
+import { reciprocalRankFusion, RRF_K } from "./fusion";
+
+describe("reciprocalRankFusion", () => {
+  it("sums 1/(k+rank) across rankings and sorts descending", () => {
+    // id "a": rank 0 in list1, rank 1 in list2
+    // id "b": rank 1 in list1, rank 0 in list2
+    // both symmetric -> equal scores; tie broken by id ascending
+    const fused = reciprocalRankFusion([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+    expect(fused.map((f) => f.id)).toEqual(["a", "b"]);
+    const expectedScore = 1 / (RRF_K + 0) + 1 / (RRF_K + 1);
+    expect(fused[0]!.score).toBeCloseTo(expectedScore, 10);
+  });
+
+  it("ranks an id appearing high in both lists above a single-list id", () => {
+    const fused = reciprocalRankFusion([
+      ["x", "y", "z"],
+      ["x", "w"],
+    ]);
+    expect(fused[0]!.id).toBe("x");
+  });
+
+  it("handles empty rankings", () => {
+    expect(reciprocalRankFusion([])).toEqual([]);
+    expect(reciprocalRankFusion([[], []])).toEqual([]);
+  });
+
+  it("deduplicates ids within a single ranking by best (first) rank", () => {
+    const fused = reciprocalRankFusion([["a", "a", "b"]]);
+    const a = fused.find((f) => f.id === "a")!;
+    expect(a.score).toBeCloseTo(1 / (RRF_K + 0), 10);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/search/fusion.test.ts`
+Expected: FAIL — cannot find module `./fusion`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/lib/search/fusion.ts
+/**
+ * Reciprocal Rank Fusion (RRF) — merges several independent rankings of the
+ * same id space into one ranking without normalising heterogeneous scores.
+ * Each id scores Σ 1/(k + rank) over the lists it appears in.
+ *
+ * Common aliases: rrf, rank fusion, hybrid search fusion, mergeRankings.
+ */
+
+/** Standard RRF constant; dampens the contribution of low ranks. */
+export const RRF_K = 60;
+
+export interface FusedResult {
+  id: string;
+  score: number;
+}
+
+/**
+ * @param rankings Ordered id lists (index 0 = best). An id repeated within a
+ *   single list contributes only its first (best) rank.
+ */
+export function reciprocalRankFusion(
+  rankings: readonly (readonly string[])[],
+  k: number = RRF_K,
+): FusedResult[] {
+  const scores = new Map<string, number>();
+  for (const ranking of rankings) {
+    const seen = new Set<string>();
+    ranking.forEach((id, rank) => {
+      if (seen.has(id)) return;
+      seen.add(id);
+      scores.set(id, (scores.get(id) ?? 0) + 1 / (k + rank));
+    });
+  }
+  return [...scores.entries()]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : 1));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/lib/search/fusion.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/search/fusion.ts src/lib/search/fusion.test.ts
+git commit -m "✨ feat(search): reciprocal rank fusion helper"
+```
+
+---
+
+## Task 2: Migration — tsvector + pg_trgm indexes
+
+Declare the lexical indexes in the schema, generate the migration, and prepend the extension.
+
+**Files:**
+- Modify: `src/db/schema.ts` (imports; `claims` and `nodeMetadata` table bodies)
+- Create: `drizzle/0024_hybrid_search_indexes.sql`
+
+- [ ] **Step 1: Add the `tsvector` customType and `sql` usage to schema imports**
+
+In `src/db/schema.ts`, the top import from `drizzle-orm/pg-core` already includes `index`, `text`, etc. Add `customType` to that import list. `sql` is already imported from `drizzle-orm`. After the imports block (before the first `pgTable`), add:
+
+```typescript
+/**
+ * Postgres `tsvector` column type for full-text search. Drizzle has no native
+ * tsvector type; this customType lets us declare GENERATED ALWAYS AS (...)
+ * STORED columns and GIN-index them.
+ */
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
+```
+
+- [ ] **Step 2: Add the generated column + indexes to `node_metadata`**
+
+In the `nodeMetadata` table, add a column after `description`:
+
+```typescript
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      sql`to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))`,
+    ),
+```
+
+And in its index array (after `node_metadata_canonical_label_idx`), add:
+
+```typescript
+    index("node_metadata_search_tsv_idx").using("gin", table.searchTsv),
+    index("node_metadata_label_trgm_idx").using(
+      "gin",
+      table.label.op("gin_trgm_ops"),
+    ),
+```
+
+- [ ] **Step 3: Add the generated column + indexes to `claims`**
+
+In the `claims` table, add a column after `description` (the existing `description: text(),` line):
+
+```typescript
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      sql`to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))`,
+    ),
+```
+
+And in its index array (after `claims_source_id_idx`), add:
+
+```typescript
+    index("claims_search_tsv_idx").using("gin", table.searchTsv),
+    index("claims_statement_trgm_idx").using(
+      "gin",
+      table.statement.op("gin_trgm_ops"),
+    ),
+```
+
+- [ ] **Step 4: Generate the migration**
+
+Run: `pnpm drizzle:generate --name hybrid_search_indexes`
+Expected: creates `drizzle/0024_hybrid_search_indexes.sql` and adds an entry to `drizzle/meta/_journal.json`. The SQL should contain `ADD COLUMN "search_tsv" ... GENERATED ALWAYS AS (...) STORED` for both tables and four `CREATE INDEX ... USING gin (...)` statements.
+
+- [ ] **Step 5: Prepend the extension to the generated migration**
+
+`drizzle-kit` does not emit `CREATE EXTENSION` (the same was true for `vector` in `0000`). Open `drizzle/0024_hybrid_search_indexes.sql` and add as the very first line:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+```
+
+If the generator did **not** emit the generated columns/indexes correctly, replace the file body with this exact target SQL (after the extension line above):
+
+```sql
+ALTER TABLE "node_metadata" ADD COLUMN "search_tsv" tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
+ALTER TABLE "claims" ADD COLUMN "search_tsv" tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
+CREATE INDEX "node_metadata_search_tsv_idx" ON "node_metadata" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "node_metadata_label_trgm_idx" ON "node_metadata" USING gin ("label" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "claims_search_tsv_idx" ON "claims" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "claims_statement_trgm_idx" ON "claims" USING gin ("statement" gin_trgm_ops);
+```
+
+- [ ] **Step 6: Verify the migration applies and builds**
+
+Run: `pnpm run build:check`
+Expected: PASS (tsc clean — confirms the schema typechecks with the new columns).
+
+Then sanity-apply against a throwaway DB:
+
+Run:
+```bash
+psql "postgres://postgres:postgres@localhost:5431/postgres" -c 'CREATE DATABASE mig_smoke_0024;'
+RUN_MIGRATIONS=true DATABASE_URL="postgres://postgres:postgres@localhost:5431/mig_smoke_0024" pnpm tsx -e "import('./src/utils/db').then(m=>m.useDatabase()).then(()=>{console.log('migrated ok');process.exit(0)})"
+psql "postgres://postgres:postgres@localhost:5431/postgres" -c 'DROP DATABASE mig_smoke_0024;'
+```
+Expected: prints `migrated ok` with no error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/db/schema.ts drizzle/0024_hybrid_search_indexes.sql drizzle/meta
+git commit -m "✨ feat(search): tsvector + pg_trgm indexes for hybrid search"
+```
+
+---
+
+## Task 3: Shared migrated-test-DB helper
+
+A reusable helper that creates a fresh DB, runs all migrations (so `search_tsv` + `pg_trgm` exist), and wires it into `useDatabase()` via the existing `setTestDatabase` seam.
+
+**Files:**
+- Create: `src/lib/search/test-db.ts`
+
+- [ ] **Step 1: Write the helper**
+
+```typescript
+// src/lib/search/test-db.ts
+/**
+ * Test-only helper: provision a fresh Postgres database, run all Drizzle
+ * migrations against it (so generated tsvector columns and pg_trgm indexes
+ * exist exactly as in production), and register it as the global db handle.
+ *
+ * Common aliases: createMigratedTestDb, search test database, hybrid search
+ * test setup.
+ */
+import pg from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import * as schema from "~/db/schema";
+import { setTestDatabase } from "~/utils/db";
+import type { DrizzleDB } from "~/db";
+
+const HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const USER = process.env["TEST_PG_USER"] ?? "postgres";
+const PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+export const adminDsn = (): string =>
+  `postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${ADMIN_DB}`;
+const dsnFor = (db: string): string =>
+  `postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${db}`;
+
+export interface MigratedTestDb {
+  db: DrizzleDB;
+  client: pg.Client;
+  drop: () => Promise<void>;
+}
+
+export async function isServerReachable(): Promise<boolean> {
+  const client = new pg.Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function createMigratedTestDb(
+  dbName: string,
+): Promise<MigratedTestDb> {
+  const admin = new pg.Client({ connectionString: adminDsn() });
+  await admin.connect();
+  await admin.query(`CREATE DATABASE "${dbName}"`);
+  await admin.end();
+
+  const client = new pg.Client({ connectionString: dsnFor(dbName) });
+  await client.connect();
+  const db = drizzle(client, {
+    schema,
+    casing: "snake_case",
+  }) as unknown as DrizzleDB;
+  await migrate(db, { migrationsFolder: "./drizzle" });
+  setTestDatabase(db);
+
+  const drop = async (): Promise<void> => {
+    setTestDatabase(null);
+    await client.end();
+    const a = new pg.Client({ connectionString: adminDsn() });
+    await a.connect();
+    await a.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await a.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await a.end();
+  };
+
+  return { db, client, drop };
+}
+```
+
+- [ ] **Step 2: Verify it typechecks**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/search/test-db.ts
+git commit -m "✅ test(search): migrated test-db helper"
+```
+
+---
+
+## Task 4: Lexical retrieval functions
+
+Add lexical node/claim retrieval to `graph.ts`, plus the two new filters the facets need (`includeNodeTypes`, `statedBetween`). Export `generateTextEmbedding` for the pipeline.
+
+**Files:**
+- Modify: `src/lib/graph.ts`
+- Test: `src/lib/search/lexical.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/search/lexical.test.ts
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createMigratedTestDb, isServerReachable } from "./test-db";
+import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
+import { nodes, nodeMetadata, claims, sources, users } from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+import type { MigratedTestDb } from "./test-db";
+
+const SERVER = await isServerReachable();
+const d = SERVER ? describe : describe.skip;
+
+d("lexical retrieval", () => {
+  let h: MigratedTestDb;
+  const userId = "user_lex";
+
+  beforeAll(async () => {
+    h = await createMigratedTestDb(
+      `memory_lex_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`,
+    );
+    const { db } = h;
+    await db.insert(users).values({ id: userId });
+
+    // Source for personal claims.
+    const srcId = newTypeId("src");
+    await db.insert(sources).values({
+      id: srcId,
+      userId,
+      type: "manual",
+      externalId: "ext_lex_1",
+      scope: "personal",
+    });
+
+    // Node "Boox Note Air" (personal via a claim referencing it).
+    const booxId = newTypeId("node");
+    await db.insert(nodes).values({
+      id: booxId,
+      userId,
+      nodeType: "Object",
+    });
+    await db.insert(nodeMetadata).values({
+      id: newTypeId("node_metadata"),
+      nodeId: booxId,
+      label: "Boox Note Air 4C",
+      canonicalLabel: "boox note air 4c",
+      description: "e-ink tablet",
+    });
+
+    // A claim mentioning Boox, stated 2026-05-10.
+    await db.insert(claims).values({
+      id: newTypeId("claim"),
+      userId,
+      subjectNodeId: booxId,
+      objectValue: "syncs handwriting to Drive",
+      predicate: "HAS_ATTRIBUTE",
+      statement: "The Boox Note Air syncs handwriting to Google Drive",
+      sourceId: srcId,
+      scope: "personal",
+      assertedByKind: "user",
+      statedAt: new Date("2026-05-10T00:00:00Z"),
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await h.drop();
+  });
+
+  it("matches an exact keyword and returns a highlight", async () => {
+    const rows = await findClaimsByLexical({ userId, query: "Boox", limit: 10 });
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]!.statement).toContain("Boox");
+    expect(rows[0]!.highlight).toMatch(/<mark>|Boox/);
+  });
+
+  it("matches a node label via trigram despite a typo", async () => {
+    const rows = await findNodesByLexical({ userId, query: "Boux", limit: 10 });
+    expect(rows.some((r) => r.label === "Boox Note Air 4C")).toBe(true);
+  });
+
+  it("filters claims by stated_at range", async () => {
+    const inRange = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      statedBetween: { from: new Date("2026-05-01Z"), to: new Date("2026-05-31Z") },
+    });
+    expect(inRange.length).toBeGreaterThan(0);
+    const outOfRange = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      statedBetween: { from: new Date("2026-01-01Z"), to: new Date("2026-02-01Z") },
+    });
+    expect(outOfRange.length).toBe(0);
+  });
+
+  it("does not return reference claims for a personal query", async () => {
+    const rows = await findClaimsByLexical({ userId, query: "Boox" });
+    expect(rows.every((r) => r.scope === "personal")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/search/lexical.test.ts`
+Expected: FAIL — `findClaimsByLexical` / `findNodesByLexical` are not exported.
+
+- [ ] **Step 3: Add new option fields and lexical result types to `graph.ts`**
+
+In `src/lib/graph.ts`, extend the option types:
+
+`Scope` is already imported in `graph.ts` (`type Scope` from `~/types/graph`).
+Change the two option aliases to add `includeNodeTypes`, `statedBetween`, and an
+explicit single-`scope` filter. **Why `scope` and not `includeReference`:** the
+existing `includeReference` boolean means "personal OR both" — it cannot express
+"reference only", so using it for `scope: "reference"` would blend scopes. When
+`scope` is provided it restricts to exactly that scope and takes precedence.
+
+```typescript
+export type FindSimilarNodesOptions = SimilaritySearchBase & {
+  excludeNodeTypes?: NodeType[];
+  /** When set, restrict to these node types (takes precedence over exclude). */
+  includeNodeTypes?: NodeType[];
+  includeReference?: boolean;
+  /** When set, restrict to exactly this scope (takes precedence over includeReference). */
+  scope?: Scope;
+};
+
+export type FindSimilarClaimsOptions = SimilaritySearchBase & {
+  statuses?: ClaimStatus[];
+  asOf?: Date;
+  /** Restrict to claims whose stated_at falls in this (inclusive) range. */
+  statedBetween?: { from?: Date; to?: Date };
+  includeReference?: boolean;
+  /** When set, restrict to exactly this scope (takes precedence over includeReference). */
+  scope?: Scope;
+  includeAssistantInferred?: boolean;
+};
+```
+
+Add lexical-specific param + result types near the other result interfaces:
+
+```typescript
+export interface LexicalSearchParams {
+  userId: string;
+  query: string;
+  limit?: number;
+  /** Single scope to restrict to. Defaults to "personal"; never blends. */
+  scope?: Scope;
+}
+
+export interface NodeLexicalParams extends LexicalSearchParams {
+  excludeNodeTypes?: NodeType[];
+  includeNodeTypes?: NodeType[];
+}
+
+export interface ClaimLexicalParams extends LexicalSearchParams {
+  statuses?: ClaimStatus[];
+  asOf?: Date;
+  statedBetween?: { from?: Date; to?: Date };
+  includeAssistantInferred?: boolean;
+}
+
+export interface NodeLexicalResult extends NodeSearchResult {
+  /** ts_headline snippet over the matched text. */
+  highlight: string;
+}
+
+export interface ClaimLexicalResult extends ClaimSearchResult {
+  highlight: string;
+}
+```
+
+- [ ] **Step 4: Export `generateTextEmbedding`**
+
+Change the declaration `async function generateTextEmbedding(` to `export async function generateTextEmbedding(` in `src/lib/graph.ts`.
+
+- [ ] **Step 5: Apply the new filters inside the vector functions**
+
+**`findSimilarNodes`** — also destructure `includeNodeTypes` and `scope` from
+opts. Replace the existing base scope clause:
+
+```typescript
+    includeReference ? undefined : nodeHasScopeSupport(userId, "personal"),
+```
+
+with one that honours an explicit single scope (takes precedence):
+
+```typescript
+    scope
+      ? nodeHasScopeSupport(userId, scope)
+      : includeReference
+        ? undefined
+        : nodeHasScopeSupport(userId, "personal"),
+```
+
+Then after the existing `excludeNodeTypes` block, add the include-filter:
+
+```typescript
+  if (includeNodeTypes && includeNodeTypes.length > 0) {
+    whereCondition = and(
+      whereCondition,
+      inArray(nodes.nodeType, includeNodeTypes),
+    );
+  }
+```
+
+**`findSimilarClaims`** — also destructure `statedBetween` and `scope` from opts.
+Replace the existing base scope clause:
+
+```typescript
+    includeReference ? undefined : eq(claims.scope, "personal"),
+```
+
+with:
+
+```typescript
+    scope
+      ? eq(claims.scope, scope)
+      : includeReference
+        ? undefined
+        : eq(claims.scope, "personal"),
+```
+
+Then, after the `inArray(claims.status, statuses)` / validity conditions are
+built, add the range filter:
+
+```typescript
+  if (statedBetween?.from) {
+    whereCondition = and(
+      whereCondition,
+      sql`${claims.statedAt} >= ${statedBetween.from}`,
+    );
+  }
+  if (statedBetween?.to) {
+    whereCondition = and(
+      whereCondition,
+      sql`${claims.statedAt} <= ${statedBetween.to}`,
+    );
+  }
+```
+
+- [ ] **Step 6: Implement `findNodesByLexical`**
+
+Add to `src/lib/graph.ts`:
+
+```typescript
+/**
+ * Lexical node retrieval: full-text match on the generated tsvector plus a
+ * pg_trgm fuzzy match on the label, ranked by ts_rank_cd. Used by the hybrid
+ * explicit-search pipeline (NOT background context injection).
+ */
+export async function findNodesByLexical(
+  params: NodeLexicalParams,
+): Promise<NodeLexicalResult[]> {
+  const {
+    userId,
+    query,
+    limit = 10,
+    scope = "personal",
+    excludeNodeTypes,
+    includeNodeTypes,
+  } = params;
+  const db = await useDatabase();
+
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const rank = sql<number>`ts_rank_cd(${nodeMetadata.searchTsv}, ${tsq})`;
+  const matched = sql`(${nodeMetadata.searchTsv} @@ ${tsq} OR similarity(${nodeMetadata.label}, ${query}) > 0.2)`;
+  const highlight = sql<string>`ts_headline('english', coalesce(${nodeMetadata.label}, '') || ' ' || coalesce(${nodeMetadata.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
+
+  let where = and(
+    eq(nodes.userId, userId),
+    nodeHasScopeSupport(userId, scope),
+    matched,
+  );
+  if (includeNodeTypes && includeNodeTypes.length > 0) {
+    where = and(where, inArray(nodes.nodeType, includeNodeTypes));
+  } else if (excludeNodeTypes && excludeNodeTypes.length > 0) {
+    where = and(where, notInArray(nodes.nodeType, excludeNodeTypes));
+  }
+
+  const rows = await db
+    .select({
+      id: nodes.id,
+      type: nodes.nodeType,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      timestamp: nodes.createdAt,
+      rank,
+      highlight,
+    })
+    .from(nodes)
+    .innerJoin(nodeMetadata, eq(nodes.id, nodeMetadata.nodeId))
+    .where(where)
+    .orderBy(desc(rank))
+    .limit(limit);
+
+  return rows.map((r) => ({ ...r, similarity: r.rank }));
+}
+```
+
+- [ ] **Step 7: Implement `findClaimsByLexical`**
+
+```typescript
+/**
+ * Lexical claim retrieval: full-text match on the generated tsvector plus a
+ * pg_trgm fuzzy match on the statement, ranked by ts_rank_cd. Honours the same
+ * status/validity/scope filters as findSimilarClaims, plus an optional
+ * stated_at range.
+ */
+export async function findClaimsByLexical(
+  params: ClaimLexicalParams,
+): Promise<ClaimLexicalResult[]> {
+  const {
+    userId,
+    query,
+    limit = 10,
+    scope = "personal",
+    statuses = ["active"],
+    asOf = new Date(),
+    statedBetween,
+    includeAssistantInferred = false,
+  } = params;
+  const db = await useDatabase();
+
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const rank = sql<number>`ts_rank_cd(${claims.searchTsv}, ${tsq})`;
+  const matched = sql`(${claims.searchTsv} @@ ${tsq} OR similarity(${claims.statement}, ${query}) > 0.2)`;
+  const highlight = sql<string>`ts_headline('english', coalesce(${claims.statement}, '') || ' ' || coalesce(${claims.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
+
+  const subjectNodeMetadata = aliasedTable(nodeMetadata, "subjectNodeMetadata");
+  const objectNodeMetadata = aliasedTable(nodeMetadata, "objectNodeMetadata");
+
+  let where = and(
+    eq(claims.userId, userId),
+    eq(claims.scope, scope),
+    includeAssistantInferred
+      ? undefined
+      : ne(claims.assertedByKind, "assistant_inferred"),
+    inArray(claims.status, statuses),
+    or(isNull(claims.validTo), gt(claims.validTo, asOf)),
+    matched,
+  );
+  if (statedBetween?.from) {
+    where = and(where, sql`${claims.statedAt} >= ${statedBetween.from}`);
+  }
+  if (statedBetween?.to) {
+    where = and(where, sql`${claims.statedAt} <= ${statedBetween.to}`);
+  }
+
+  const rows = await db
+    .select({
+      id: claims.id,
+      subjectNodeId: claims.subjectNodeId,
+      objectNodeId: claims.objectNodeId,
+      objectValue: claims.objectValue,
+      subjectLabel: subjectNodeMetadata.label,
+      objectLabel: objectNodeMetadata.label,
+      predicate: claims.predicate,
+      statement: claims.statement,
+      description: claims.description,
+      sourceId: claims.sourceId,
+      scope: claims.scope,
+      assertedByKind: claims.assertedByKind,
+      assertedByNodeId: claims.assertedByNodeId,
+      status: claims.status,
+      statedAt: claims.statedAt,
+      timestamp: claims.createdAt,
+      rank,
+      highlight,
+    })
+    .from(claims)
+    .leftJoin(
+      subjectNodeMetadata,
+      eq(subjectNodeMetadata.nodeId, claims.subjectNodeId),
+    )
+    .leftJoin(
+      objectNodeMetadata,
+      eq(objectNodeMetadata.nodeId, claims.objectNodeId),
+    )
+    .where(where)
+    .orderBy(desc(rank))
+    .limit(limit);
+
+  return rows.map((r) => ({ ...r, similarity: r.rank }));
+}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pnpm test src/lib/search/lexical.test.ts`
+Expected: PASS (4 tests). If the server on `:5431` is not running the suite skips — start it and re-run; do not leave it skipped.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/graph.ts src/lib/search/lexical.test.ts
+git commit -m "✨ feat(search): lexical node/claim retrieval with facet filters"
+```
+
+---
+
+## Task 5: Search schemas
+
+**Files:**
+- Create: `src/lib/schemas/search.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/schemas/search.test.ts
+import { describe, expect, it } from "vitest";
+import { searchRequestSchema, searchResponseSchema } from "./search";
+
+describe("search schemas", () => {
+  it("applies defaults and rejects empty query", () => {
+    const parsed = searchRequestSchema.parse({ userId: "u", query: "boox" });
+    expect(parsed.limit).toBe(20);
+    expect(parsed.scope).toBe("personal");
+    expect(() => searchRequestSchema.parse({ userId: "u", query: "" })).toThrow();
+  });
+
+  it("accepts entityTypes and statedBetween filters", () => {
+    const parsed = searchRequestSchema.parse({
+      userId: "u",
+      query: "x",
+      filters: {
+        entityTypes: ["Person", "Task"],
+        statedBetween: { from: "2026-05-01T00:00:00Z" },
+      },
+    });
+    expect(parsed.filters?.entityTypes).toEqual(["Person", "Task"]);
+    expect(parsed.filters?.statedBetween?.from).toBeInstanceOf(Date);
+  });
+
+  it("validates a hit-shaped response", () => {
+    const ok = searchResponseSchema.parse({
+      query: "x",
+      hits: [
+        {
+          kind: "claim",
+          nodeId: "node_abc",
+          claimId: "claim_abc",
+          text: "The Boox syncs to Drive",
+          highlight: "The <mark>Boox</mark> syncs to Drive",
+          score: 0.123,
+          source: { sourceId: "src_abc", type: "manual" },
+          statedAt: "2026-05-10T00:00:00Z",
+        },
+      ],
+    });
+    expect(ok.hits[0]!.kind).toBe("claim");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/schemas/search.test.ts`
+Expected: FAIL — cannot find module `./search`.
+
+- [ ] **Step 3: Write the schemas**
+
+```typescript
+// src/lib/schemas/search.ts
+/**
+ * Request/response schemas for the hybrid explicit-search route (`POST /search`).
+ * Distinct from `/context/search` (card-shaped, semantic background context):
+ * this surface returns ranked hits with highlights for intentional lookups.
+ *
+ * Common aliases: search schema, explicit search, hybrid search, SearchHit.
+ */
+import { z } from "zod";
+import { NodeTypeEnum } from "~/types/graph.js";
+
+export const searchRequestSchema = z.object({
+  userId: z.string(),
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(50).optional().default(20),
+  scope: z.enum(["personal", "reference"]).optional().default("personal"),
+  filters: z
+    .object({
+      /** Restrict hits to these entity (node) types. */
+      entityTypes: z.array(NodeTypeEnum).optional(),
+      /** Restrict claim hits to this stated_at range (inclusive). */
+      statedBetween: z
+        .object({
+          from: z.coerce.date().optional(),
+          to: z.coerce.date().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+export type SearchRequest = z.infer<typeof searchRequestSchema>;
+
+const sourceTypeEnum = z.enum([
+  "conversation",
+  "conversation_message",
+  "document",
+  "legacy_migration",
+  "manual",
+  "meeting_transcript",
+  "external_conversation",
+  "metric_push",
+  "metric_manual",
+  "rollup",
+]);
+
+export const searchHitSchema = z.object({
+  kind: z.enum(["node", "claim"]),
+  nodeId: z.string(),
+  claimId: z.string().optional(),
+  text: z.string(),
+  highlight: z.string(),
+  score: z.number(),
+  source: z.object({
+    sourceId: z.string(),
+    type: sourceTypeEnum,
+    title: z.string().nullish(),
+    author: z.string().nullish(),
+  }),
+  statedAt: z.coerce.date().optional(),
+});
+export type SearchHit = z.infer<typeof searchHitSchema>;
+
+export const searchResponseSchema = z.object({
+  query: z.string(),
+  hits: z.array(searchHitSchema),
+});
+export type SearchResponse = z.infer<typeof searchResponseSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/lib/schemas/search.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/schemas/search.ts src/lib/schemas/search.test.ts
+git commit -m "✨ feat(search): request/response schemas for /search"
+```
+
+---
+
+## Task 6: Hybrid pipeline + hit hydration
+
+Assemble the two legs (vector + lexical) for nodes and claims, fuse per id space, merge into one ranked `SearchHit[]`, and hydrate source provenance.
+
+**Files:**
+- Create: `src/lib/search/explicit-search.ts`
+- Test: `src/lib/search/explicit-search.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+This test mocks the four retrieval functions and the embedding call (so it needs no Jina key) and injects a stub `hydrate` (so it needs no DB), then asserts fusion ordering, hit shape, highlight passthrough, claim ownership, and that scope is forwarded to every leg.
+
+```typescript
+// src/lib/search/explicit-search.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  generateTextEmbedding: vi.fn(),
+  findSimilarNodes: vi.fn(),
+  findSimilarClaims: vi.fn(),
+  findNodesByLexical: vi.fn(),
+  findClaimsByLexical: vi.fn(),
+}));
+
+vi.mock("~/lib/graph", () => ({
+  generateTextEmbedding: mocks.generateTextEmbedding,
+  findSimilarNodes: mocks.findSimilarNodes,
+  findSimilarClaims: mocks.findSimilarClaims,
+  findNodesByLexical: mocks.findNodesByLexical,
+  findClaimsByLexical: mocks.findClaimsByLexical,
+}));
+
+import { explicitSearch } from "./explicit-search";
+
+// Stub hydrator: maps src_1 -> a manual source. Injected so the pipeline never
+// touches the DB in this unit test.
+const stubHydrate = async (ids: string[]) =>
+  new Map(ids.map((id) => [id, { sourceId: id, type: "manual" as const }]));
+
+describe("explicitSearch", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("fuses legs, builds hits, and orders by fused score", async () => {
+    mocks.generateTextEmbedding.mockResolvedValue([0.1, 0.2]);
+    mocks.findSimilarNodes.mockResolvedValue([
+      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 0.9 },
+    ]);
+    mocks.findNodesByLexical.mockResolvedValue([
+      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 1, highlight: "<mark>Boox</mark>" },
+    ]);
+    mocks.findSimilarClaims.mockResolvedValue([]);
+    mocks.findClaimsByLexical.mockResolvedValue([
+      {
+        id: "claim_1", subjectNodeId: "node_1", objectNodeId: null, objectValue: "v",
+        subjectLabel: "Boox", objectLabel: null, predicate: "HAS_ATTRIBUTE",
+        statement: "Boox syncs", description: null, sourceId: "src_1", scope: "personal",
+        assertedByKind: "user", assertedByNodeId: null, status: "active",
+        statedAt: new Date("2026-05-10Z"), timestamp: new Date(), similarity: 1,
+        highlight: "<mark>Boox</mark> syncs",
+      },
+    ]);
+
+    const result = await explicitSearch(
+      { userId: "u", query: "Boox", limit: 20, scope: "personal" },
+      stubHydrate,
+    );
+
+    // node_1 appears in both node legs (high fused score) -> first.
+    expect(result.hits[0]!.kind).toBe("node");
+    expect(result.hits[0]!.nodeId).toBe("node_1");
+    expect(result.hits[0]!.source).toBeDefined(); // node provenance is a placeholder in v1
+    const claimHit = result.hits.find((h) => h.kind === "claim")!;
+    expect(claimHit.nodeId).toBe("node_1"); // owning subject
+    expect(claimHit.claimId).toBe("claim_1");
+    expect(claimHit.highlight).toContain("<mark>");
+    expect(claimHit.source.type).toBe("manual"); // from stubHydrate
+  });
+
+  it("forwards scope to every retrieval leg", async () => {
+    mocks.generateTextEmbedding.mockResolvedValue([0.1]);
+    mocks.findSimilarNodes.mockResolvedValue([]);
+    mocks.findNodesByLexical.mockResolvedValue([]);
+    mocks.findSimilarClaims.mockResolvedValue([]);
+    mocks.findClaimsByLexical.mockResolvedValue([]);
+
+    await explicitSearch(
+      { userId: "u", query: "x", limit: 20, scope: "reference" },
+      stubHydrate,
+    );
+
+    expect(mocks.findSimilarClaims).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "reference" }),
+    );
+    expect(mocks.findNodesByLexical).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "reference" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/search/explicit-search.test.ts`
+Expected: FAIL — cannot find module `./explicit-search`.
+
+- [ ] **Step 3: Write the pipeline**
+
+Source hydration needs the DB. To keep the unit test hermetic, the pipeline accepts an optional `hydrate` injection (defaulting to the real DB-backed implementation); the test passes a stub. Implementation:
+
+```typescript
+// src/lib/search/explicit-search.ts
+/**
+ * Hybrid explicit-search pipeline: runs vector + lexical retrieval for nodes
+ * and claims in parallel, fuses each id space with RRF, merges into one ranked
+ * SearchHit list, and hydrates source provenance. Powers `POST /search`.
+ *
+ * Common aliases: hybrid search, explicit search, search pipeline, runSearch.
+ */
+import { inArray } from "drizzle-orm";
+import {
+  generateTextEmbedding,
+  findSimilarNodes,
+  findSimilarClaims,
+  findNodesByLexical,
+  findClaimsByLexical,
+  type NodeLexicalResult,
+  type ClaimLexicalResult,
+  type NodeSearchResult,
+  type ClaimSearchResult,
+} from "~/lib/graph";
+import { reciprocalRankFusion } from "./fusion";
+import { sources } from "~/db/schema";
+import { useDatabase } from "~/utils/db";
+import type { NodeType, Scope, SourceType } from "~/types/graph";
+import type { SearchHit, SearchResponse } from "~/lib/schemas/search";
+import type { TypeId } from "~/types/typeid";
+import { z } from "zod";
+
+export interface ExplicitSearchParams {
+  userId: string;
+  query: string;
+  limit: number;
+  scope: Scope;
+  filters?: {
+    entityTypes?: NodeType[];
+    statedBetween?: { from?: Date; to?: Date };
+  };
+}
+
+interface HitSource {
+  sourceId: string;
+  type: SourceType;
+  title?: string | null;
+  author?: string | null;
+}
+
+/** Document sources carry title/author in metadata; parse leniently. */
+const docMetaSchema = z
+  .object({ title: z.string().nullish(), author: z.string().nullish() })
+  .partial()
+  .passthrough();
+
+export type SourceHydrator = (
+  sourceIds: TypeId<"source">[],
+) => Promise<Map<string, HitSource>>;
+
+const dbHydrateSources: SourceHydrator = async (sourceIds) => {
+  const map = new Map<string, HitSource>();
+  if (sourceIds.length === 0) return map;
+  const db = await useDatabase();
+  const rows = await db
+    .select({
+      id: sources.id,
+      type: sources.type,
+      metadata: sources.metadata,
+    })
+    .from(sources)
+    .where(inArray(sources.id, sourceIds));
+  for (const row of rows) {
+    const meta = docMetaSchema.safeParse(row.metadata ?? {});
+    map.set(row.id, {
+      sourceId: row.id,
+      type: row.type,
+      title: meta.success ? meta.data.title : null,
+      author: meta.success ? meta.data.author : null,
+    });
+  }
+  return map;
+};
+
+export async function explicitSearch(
+  params: ExplicitSearchParams,
+  hydrate: SourceHydrator = dbHydrateSources,
+): Promise<SearchResponse> {
+  const { userId, query, limit, scope, filters } = params;
+  const includeNodeTypes = filters?.entityTypes;
+  const statedBetween = filters?.statedBetween;
+  const legLimit = Math.max(limit * 2, 20);
+
+  const embedding = await generateTextEmbedding(query);
+
+  const [vecNodes, lexNodes, vecClaims, lexClaims]: [
+    NodeSearchResult[],
+    NodeLexicalResult[],
+    ClaimSearchResult[],
+    ClaimLexicalResult[],
+  ] = await Promise.all([
+    findSimilarNodes({
+      userId,
+      embedding,
+      limit: legLimit,
+      scope,
+      includeNodeTypes,
+    }),
+    findNodesByLexical({
+      userId,
+      query,
+      limit: legLimit,
+      scope,
+      includeNodeTypes,
+    }),
+    findSimilarClaims({
+      userId,
+      embedding,
+      limit: legLimit,
+      scope,
+      statedBetween,
+    }),
+    findClaimsByLexical({
+      userId,
+      query,
+      limit: legLimit,
+      scope,
+      statedBetween,
+    }),
+  ]);
+
+  const nodeFusion = reciprocalRankFusion([
+    vecNodes.map((n) => n.id),
+    lexNodes.map((n) => n.id),
+  ]);
+  const claimFusion = reciprocalRankFusion([
+    vecClaims.map((c) => c.id),
+    lexClaims.map((c) => c.id),
+  ]);
+
+  // Index rows for hit assembly. Lexical rows carry highlights; prefer them.
+  const nodeById = new Map<string, NodeSearchResult | NodeLexicalResult>();
+  for (const n of vecNodes) nodeById.set(n.id, n);
+  for (const n of lexNodes) nodeById.set(n.id, n);
+  const nodeHighlight = new Map(lexNodes.map((n) => [n.id, n.highlight]));
+
+  const claimById = new Map<string, ClaimSearchResult | ClaimLexicalResult>();
+  for (const c of vecClaims) claimById.set(c.id, c);
+  for (const c of lexClaims) claimById.set(c.id, c);
+  const claimHighlight = new Map(lexClaims.map((c) => [c.id, c.highlight]));
+
+  const claimSourceIds = claimFusion
+    .map((f) => claimById.get(f.id)?.sourceId)
+    .filter((s): s is TypeId<"source"> => Boolean(s));
+  const sourceMap = await hydrate(claimSourceIds);
+
+  const nodeHits: SearchHit[] = nodeFusion.flatMap((f) => {
+    const row = nodeById.get(f.id);
+    if (!row) return [];
+    return [
+      {
+        kind: "node",
+        nodeId: row.id,
+        text: row.label ?? "",
+        highlight: nodeHighlight.get(row.id) ?? row.label ?? "",
+        score: f.score,
+        // Node provenance is a v1 placeholder (a node has many sources); the
+        // UI fetches full provenance via get_entity when needed.
+        source: { sourceId: "", type: "manual" },
+      },
+    ];
+  });
+
+  const claimHits: SearchHit[] = claimFusion.flatMap((f) => {
+    const row = claimById.get(f.id);
+    if (!row) return [];
+    const source: HitSource = sourceMap.get(row.sourceId) ?? {
+      sourceId: row.sourceId,
+      type: "manual",
+      title: null,
+      author: null,
+    };
+    return [
+      {
+        kind: "claim",
+        nodeId: row.subjectNodeId,
+        claimId: row.id,
+        text: row.statement,
+        highlight: claimHighlight.get(row.id) ?? row.statement,
+        score: f.score,
+        source,
+        statedAt: row.statedAt,
+      },
+    ];
+  });
+
+  const hits = [...nodeHits, ...claimHits]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return { query, hits };
+}
+```
+
+> **Node-hit source note:** a node has many sources, so node-hit `source` is a v1 placeholder (`{ sourceId: "", type: "manual" }`); the UI calls `get_entity` for full provenance. Real provenance is asserted on **claim** hits only.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/lib/search/explicit-search.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/search/explicit-search.ts src/lib/search/explicit-search.test.ts
+git commit -m "✨ feat(search): hybrid retrieval pipeline with RRF and hit hydration"
+```
+
+---
+
+## Task 7: The `POST /search` route
+
+**Files:**
+- Create: `src/routes/search.post.ts`
+- Test: `src/search-route.test.ts`
+
+- [ ] **Step 1: Write the failing test (handler-level, mirrors `src/digest-route.test.ts`)**
+
+```typescript
+// src/search-route.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+
+const mocks = vi.hoisted(() => ({ explicitSearch: vi.fn() }));
+vi.mock("~/lib/search/explicit-search", () => ({
+  explicitSearch: mocks.explicitSearch,
+}));
+
+import handler from "./routes/search.post";
+import { searchResponseSchema } from "~/lib/schemas/search";
+
+describe("POST /search", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("validates the request, calls the pipeline, and round-trips the response", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "u", query: "Boox" }));
+    mocks.explicitSearch.mockResolvedValue({
+      query: "Boox",
+      hits: [
+        {
+          kind: "claim",
+          nodeId: "node_1",
+          claimId: "claim_1",
+          text: "Boox syncs",
+          highlight: "<mark>Boox</mark> syncs",
+          score: 0.5,
+          source: { sourceId: "src_1", type: "manual" },
+          statedAt: new Date("2026-05-10Z"),
+        },
+      ],
+    });
+
+    const response = searchResponseSchema.parse(await handler({} as H3Event));
+    expect(response.hits).toHaveLength(1);
+    // Defaults applied by the request schema reached the pipeline.
+    expect(mocks.explicitSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u", query: "Boox", limit: 20, scope: "personal" }),
+    );
+  });
+
+  it("rejects an empty query", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "u", query: "" }));
+    await expect(handler({} as H3Event)).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/search-route.test.ts`
+Expected: FAIL — cannot find module `./routes/search.post`.
+
+- [ ] **Step 3: Write the route**
+
+```typescript
+// src/routes/search.post.ts
+/**
+ * `POST /search` — hybrid explicit-search route.
+ *
+ * The intentional-lookup surface: a human typing in a search box, or an
+ * assistant deliberately looking something up. Fuses lexical (tsvector +
+ * pg_trgm) and vector retrieval (RRF) and returns ranked hits with highlights.
+ *
+ * Distinct from `POST /context/search` (semantic, card-shaped, auto-injected
+ * background context) and the legacy `POST /query/search` (raw graph for
+ * visualization). See docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md.
+ */
+import { explicitSearch } from "~/lib/search/explicit-search";
+import {
+  searchRequestSchema,
+  searchResponseSchema,
+} from "~/lib/schemas/search";
+
+export default defineEventHandler(async (event) => {
+  const { userId, query, limit, scope, filters } = searchRequestSchema.parse(
+    await readBody(event),
+  );
+
+  const result = await explicitSearch({ userId, query, limit, scope, filters });
+
+  return searchResponseSchema.parse(result);
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/search-route.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/search.post.ts src/search-route.test.ts
+git commit -m "✨ feat(search): POST /search hybrid explicit-search route"
+```
+
+---
+
+## Task 8: SDK `search()` method
+
+**Files:**
+- Modify: `src/sdk/memory-client.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/sdk/memory-client-search.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryClient } from "./memory-client";
+
+describe("MemoryClient.search", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("POSTs to /search and parses the hit-shaped response", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        query: "Boox",
+        hits: [
+          {
+            kind: "node",
+            nodeId: "node_1",
+            text: "Boox",
+            highlight: "<mark>Boox</mark>",
+            score: 0.4,
+            source: { sourceId: "src_1", type: "manual" },
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new MemoryClient({ baseUrl: "http://memory.test" });
+    const res = await client.search({ userId: "u", query: "Boox" });
+
+    expect(res.hits[0]!.nodeId).toBe("node_1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://memory.test/search",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/sdk/memory-client-search.test.ts`
+Expected: FAIL — `client.search` is not a function.
+
+- [ ] **Step 3: Add imports and the method**
+
+At the top of `src/sdk/memory-client.ts`, add to the import block:
+
+```typescript
+import {
+  searchResponseSchema,
+  type SearchRequest,
+  type SearchResponse,
+} from "../lib/schemas/search.js";
+```
+
+Inside the `MemoryClient` class, after `contextSearch`, add:
+
+```typescript
+  /**
+   * Hybrid explicit search: lexical + vector retrieval fused with RRF, returning
+   * ranked hits with highlights. Use for intentional lookups (a search box, or
+   * the assistant deliberately looking something up) — not for automatic
+   * conversation context, which is `contextSearch`.
+   */
+  async search(payload: SearchRequest): Promise<SearchResponse> {
+    return this._fetch("POST", "/search", searchResponseSchema, payload);
+  }
+```
+
+- [ ] **Step 4: Run tests + SDK build**
+
+Run: `pnpm test src/sdk/memory-client-search.test.ts`
+Expected: PASS.
+
+Run: `pnpm run build-sdk`
+Expected: PASS (SDK compiles and the verify script is happy with the new export path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sdk/memory-client.ts src/sdk/memory-client-search.test.ts
+git commit -m "✨ feat(sdk): MemoryClient.search() for hybrid explicit search"
+```
+
+---
+
+## Task 9: Full verification gate
+
+- [ ] **Step 1: Typecheck + structured-output check**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 2: Lint + format**
+
+Run: `pnpm run lint && pnpm run format`
+Expected: PASS (run `pnpm run lint:fix` / `pnpm run format:fix` if needed, then re-run).
+
+- [ ] **Step 3: Full test suite (local, server on :5431 running)**
+
+Run: `pnpm test`
+Expected: PASS. Confirm the lexical suite did NOT skip (server reachable).
+
+- [ ] **Step 4: SDK build**
+
+Run: `pnpm run build-sdk`
+Expected: PASS.
+
+- [ ] **Step 5: Final commit if any fixups**
+
+```bash
+git add -A
+git commit -m "🔧 chore(search): lint/format/typecheck fixups"
+```
+
+---
+
+## Follow-on (separate plan, separate worktree)
+
+Not in this plan; track as next steps:
+
+1. **Petals manual explorer** (`~/code/petals`, `/memory/explore`): migrate `searchMemory` server fn from `querySearch` → `search()`; render ranked hits + highlights. Dedicated Petals worktree.
+2. **`n8n-nodes-petals`**: add a `search` operation.
+3. **Petals proxy endpoint** for `/search`.
+4. **Assistant MCP tool** `search_text` → `/search` (open decision from the spec — confirm whether to add it or leave explicit search host/UI-only).
+5. **Rerank toggle**: expose the off-by-default Jina rerank seam if relevance tuning needs it.

--- a/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
+++ b/docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md
@@ -638,7 +638,10 @@ export async function findNodesByLexical(
 
   const tsq = sql`websearch_to_tsquery('english', ${query})`;
   const rank = sql<number>`ts_rank_cd(${nodeMetadata.searchTsv}, ${tsq})`;
-  const matched = sql`(${nodeMetadata.searchTsv} @@ ${tsq} OR similarity(${nodeMetadata.label}, ${query}) > 0.2)`;
+  // word_similarity (not similarity): matches the query against the best-matching
+  // word in the label, so a short typo ("Boux") still matches a long label
+  // ("Boox Note Air 4C"). Full-string similarity() would score near-zero there.
+  const matched = sql`(${nodeMetadata.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${nodeMetadata.label}) > 0.3)`;
   const highlight = sql<string>`ts_headline('english', coalesce(${nodeMetadata.label}, '') || ' ' || coalesce(${nodeMetadata.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   let where = and(
@@ -698,7 +701,9 @@ export async function findClaimsByLexical(
 
   const tsq = sql`websearch_to_tsquery('english', ${query})`;
   const rank = sql<number>`ts_rank_cd(${claims.searchTsv}, ${tsq})`;
-  const matched = sql`(${claims.searchTsv} @@ ${tsq} OR similarity(${claims.statement}, ${query}) > 0.2)`;
+  // word_similarity matches the query against the best-matching word in the
+  // statement (handles typos against long statements; see findNodesByLexical).
+  const matched = sql`(${claims.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${claims.statement}) > 0.3)`;
   const highlight = sql<string>`ts_headline('english', coalesce(${claims.statement}, '') || ' ' || coalesce(${claims.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   const subjectNodeMetadata = aliasedTable(nodeMetadata, "subjectNodeMetadata");

--- a/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
@@ -18,16 +18,16 @@ looking something up:
 - Exact / rare tokens fail to rank: project codenames, acronyms, IDs, people's
   names, exact phrases. Embeddings smear these into nearest neighbours.
 - The `0.4` floor silently drops weak-but-only matches. Someone who types
-  "Boox" expects *everything* mentioning Boox, ranked — not "top-k above a
+  "Boox" expects _everything_ mentioning Boox, ranked — not "top-k above a
   magic cosine threshold".
 - No substring / prefix / typo tolerance, so type-ahead and half-remembered
   words don't work.
 - No facets. The graph is rich (entity type, time, source, scope) but search
   exposes almost none of it.
 
-Semantic recall is exactly right for the *background* context the system
+Semantic recall is exactly right for the _background_ context the system
 injects automatically each turn. It is wrong for retrieval a user or assistant
-asks for *on purpose*. This design adds a dedicated hybrid (lexical + vector)
+asks for _on purpose_. This design adds a dedicated hybrid (lexical + vector)
 explicit-search surface and draws a clear boundary between the two intents.
 
 ## Decisions (settled during brainstorming)
@@ -46,7 +46,7 @@ explicit-search surface and draws a clear boundary between the two intents.
    ranking, `pg_trgm` for fuzzy/typo/prefix. No ParadeDB / external search
    engine. `pgvector` is already present; only `pg_trgm` is newly required.
 4. **Ranked hits with highlights** as the result shape (not cards, not raw
-   graph). An ordered list of hits, each showing *why* it matched.
+   graph). An ordered list of hits, each showing _why_ it matched.
 5. **Reciprocal Rank Fusion (RRF)** to merge the lexical and vector rankings —
    no cross-engine score normalisation.
 6. **v1 facets: entity type + time range.** Scope stays single-valued (default
@@ -59,11 +59,11 @@ explicit-search surface and draws a clear boundary between the two intents.
 
 Three retrieval intents, separated by endpoint:
 
-| Intent | Endpoint | Engine | Result shape |
-| ------ | -------- | ------ | ------------ |
-| Background context (auto-injected each turn) | `POST /context/search` | semantic only | cards (`NodeCard[]` + evidence) — unchanged |
-| **Explicit search** (human types, or assistant looks up) | **`POST /search`** (new) | **hybrid** (lexical + vector, RRF) | ranked `SearchHit[]` + highlights |
-| Graph visualization | `POST /query/search` (legacy) | semantic | raw graph — unchanged |
+| Intent                                                   | Endpoint                      | Engine                             | Result shape                                |
+| -------------------------------------------------------- | ----------------------------- | ---------------------------------- | ------------------------------------------- |
+| Background context (auto-injected each turn)             | `POST /context/search`        | semantic only                      | cards (`NodeCard[]` + evidence) — unchanged |
+| **Explicit search** (human types, or assistant looks up) | **`POST /search`** (new)      | **hybrid** (lexical + vector, RRF) | ranked `SearchHit[]` + highlights           |
+| Graph visualization                                      | `POST /query/search` (legacy) | semantic                           | raw graph — unchanged                       |
 
 ## Data model & indexes
 
@@ -79,11 +79,15 @@ with the source text:
 - `node_metadata.search_tsv` = `to_tsvector('english', coalesce(label,'') || ' ' || coalesce(description,''))`,
   `STORED GENERATED`, GIN-indexed.
 
-Drizzle lacks first-class generated-`tsvector` support; the generated columns
-and GIN indexes are declared via `sql` in the migration and represented in
-`schema.ts` with `.generatedAlwaysAs(sql\`...\`)` where expressible, otherwise
-as a raw migration step with a matching column declaration for typing. (The
-plan resolves the exact Drizzle representation against the installed version.)
+**`search_tsv` is a migration-managed shadow column, intentionally NOT declared
+in `schema.ts`.** Declaring it on the Drizzle table would make Drizzle enumerate
+it in every `select`/`returning`, which breaks the many existing tests that
+build their DB from hand-written `CREATE TABLE` DDL (that DDL has no
+`search_tsv`). Instead the column + GIN indexes live only in a hand-written
+(`drizzle-kit generate --custom`) migration, and the lexical functions reference
+`search_tsv` via raw, table-qualified SQL. The ORM stays unaware of it; existing
+hand-rolled test schemas are unaffected. This is the standard Drizzle pattern for
+generated FTS columns.
 
 ### Fuzzy / prefix (pg_trgm + GIN)
 
@@ -108,8 +112,9 @@ they compose:
 
 - `findNodesByLexical(db, params)` — `websearch_to_tsquery('english', query)`
   against `node_metadata.search_tsv`, ranked by `ts_rank_cd`, unioned with a
-  `pg_trgm` `similarity()` match on `label` for fuzzy/prefix. Applies the same
-  SQL filters (`userId`, scope, `notInArray(nodeType, …)`).
+  `pg_trgm` `word_similarity(query, label) > 0.3` fuzzy match (word_similarity,
+  not similarity, so a short typo matches the best word in a long label).
+  Applies the same SQL filters (`userId`, scope, entity-type).
 - `findClaimsByLexical(db, params)` — same against `claims.search_tsv` /
   `claims.statement`, with the existing claim filters (status, validity,
   asserted-by-kind) plus the new time-range filter.
@@ -212,7 +217,7 @@ this path.
 
 The assistant currently has the MCP `search_memory` tool → `/context/search`
 (semantic cards) for "tell me about this entity". That stays. **Recommendation:**
-add a *second* MCP tool, `search_text` (working name), → `/search`, described
+add a _second_ MCP tool, `search_text` (working name), → `/search`, described
 for exact / keyword / "find where I mentioned X" lookups. Two tools with
 distinct intents rather than repointing the pinned `search_memory` contract
 (whose card shape suits entity recall and whose description is snapshot-pinned

--- a/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
@@ -182,12 +182,17 @@ Scope is a hard boundary as elsewhere: a `personal` request never surfaces
 `reference` material and vice versa. The time-range filter is a small addition
 to the claim query (today only an `asOf` cutoff exists, no range).
 
-**Time range and node hits.** `statedBetween` filters claim hits directly by
-`claims.stated_at`. Nodes have no intrinsic time, so when a range is set a node
-hit is kept only if the node has at least one active claim with `stated_at` in
-range (an `EXISTS` subquery, same shape as the existing `nodeHasScopeSupport`
-predicate). With no range set, node lexical/vector hits are unconstrained by
-time.
+**Time range and node hits.** `statedBetween` filters **claim** hits directly
+by `claims.stated_at`. Nodes (entities) have no intrinsic time and are treated
+as timeless: in v1 a time range narrows the claim hits but does not drop entity
+hits (you still want the "Boox" entity itself to surface for "Boox in May").
+Entity-level time gating is deferred.
+
+**Scope is single-valued and exact.** `scope: "personal"` returns only personal
+material; `scope: "reference"` returns only reference. This requires an explicit
+`scope` filter on the retrieval functions — the existing `includeReference`
+boolean means "personal OR both", which would blend scopes and is not used on
+this path.
 
 ## Surfaces & downstream consumers
 

--- a/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
+++ b/docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md
@@ -1,0 +1,254 @@
+# Hybrid Explicit Search: Lexical + Vector Retrieval for Memory
+
+**Date:** 2026-06-16
+**Status:** Design — pending plan
+
+## Problem
+
+Production retrieval is **purely semantic**: Jina v3 embeddings over
+`node_embeddings` / `claim_embeddings`, HNSW cosine, with a hardcoded `0.4`
+similarity floor (`src/lib/context/search-cards.ts`). There is a substring
+`LIKE` path in `src/lib/graph.ts` but it is an eval-only test seam, never
+wired into production.
+
+Pure embedding similarity is the wrong primary index for **explicit search** —
+a human typing into the Petals memory explorer, or an assistant deliberately
+looking something up:
+
+- Exact / rare tokens fail to rank: project codenames, acronyms, IDs, people's
+  names, exact phrases. Embeddings smear these into nearest neighbours.
+- The `0.4` floor silently drops weak-but-only matches. Someone who types
+  "Boox" expects *everything* mentioning Boox, ranked — not "top-k above a
+  magic cosine threshold".
+- No substring / prefix / typo tolerance, so type-ahead and half-remembered
+  words don't work.
+- No facets. The graph is rich (entity type, time, source, scope) but search
+  exposes almost none of it.
+
+Semantic recall is exactly right for the *background* context the system
+injects automatically each turn. It is wrong for retrieval a user or assistant
+asks for *on purpose*. This design adds a dedicated hybrid (lexical + vector)
+explicit-search surface and draws a clear boundary between the two intents.
+
+## Decisions (settled during brainstorming)
+
+1. **Separate explicit-search endpoint.** A new `POST /search`. Background
+   context injection keeps using `POST /context/search` (semantic only, cards,
+   unchanged). Graph visualization keeps using the legacy `POST /query/search`
+   (raw graph, unchanged). The stateable rule: **`/context/*` is what the
+   system pulls in automatically; `/search` is what someone asks for on
+   purpose.**
+2. **Hybrid is a property of explicit retrieval, not background injection.**
+   Background context is fed natural-language conversation text where semantic
+   similarity is right and keyword matching adds noise. Explicit search is
+   where exact names, IDs, quoted phrases, and typo-tolerance matter.
+3. **Native Postgres lexical engine.** `tsvector` + GIN for keyword/phrase
+   ranking, `pg_trgm` for fuzzy/typo/prefix. No ParadeDB / external search
+   engine. `pgvector` is already present; only `pg_trgm` is newly required.
+4. **Ranked hits with highlights** as the result shape (not cards, not raw
+   graph). An ordered list of hits, each showing *why* it matched.
+5. **Reciprocal Rank Fusion (RRF)** to merge the lexical and vector rankings —
+   no cross-engine score normalisation.
+6. **v1 facets: entity type + time range.** Scope stays single-valued (default
+   `personal`, never blended in one response). Source-type facet is deferred.
+7. **Reranking off by default** for v1. Keyword intent + RRF is strong, and a
+   semantic cross-encoder can fight exact-match queries. A seam is left to
+   enable Jina reranking later.
+
+## Conceptual model
+
+Three retrieval intents, separated by endpoint:
+
+| Intent | Endpoint | Engine | Result shape |
+| ------ | -------- | ------ | ------------ |
+| Background context (auto-injected each turn) | `POST /context/search` | semantic only | cards (`NodeCard[]` + evidence) — unchanged |
+| **Explicit search** (human types, or assistant looks up) | **`POST /search`** (new) | **hybrid** (lexical + vector, RRF) | ranked `SearchHit[]` + highlights |
+| Graph visualization | `POST /query/search` (legacy) | semantic | raw graph — unchanged |
+
+## Data model & indexes
+
+No table changes. Add generated columns + indexes via a Drizzle migration.
+
+### Lexical full-text (tsvector + GIN)
+
+Generated `tsvector` columns, so backfill is automatic and they stay in sync
+with the source text:
+
+- `claims.search_tsv` = `to_tsvector('english', coalesce(statement,'') || ' ' || coalesce(description,''))`,
+  `STORED GENERATED`, GIN-indexed.
+- `node_metadata.search_tsv` = `to_tsvector('english', coalesce(label,'') || ' ' || coalesce(description,''))`,
+  `STORED GENERATED`, GIN-indexed.
+
+Drizzle lacks first-class generated-`tsvector` support; the generated columns
+and GIN indexes are declared via `sql` in the migration and represented in
+`schema.ts` with `.generatedAlwaysAs(sql\`...\`)` where expressible, otherwise
+as a raw migration step with a matching column declaration for typing. (The
+plan resolves the exact Drizzle representation against the installed version.)
+
+### Fuzzy / prefix (pg_trgm + GIN)
+
+- `CREATE EXTENSION IF NOT EXISTS pg_trgm;`
+- GIN trigram index on `node_metadata.label` (`gin_trgm_ops`).
+- GIN trigram index on `claims.statement` (`gin_trgm_ops`).
+
+Trigram covers typo tolerance, substring, and prefix-as-you-type — promoting
+the eval-only `LIKE` path into a real indexed feature.
+
+### Vector (unchanged structurally)
+
+Existing HNSW cosine indexes on `node_embeddings` / `claim_embeddings`. The
+only behavioural change is **the `0.4` similarity floor is not applied on the
+`/search` path** (explicit search ranks rather than thresholds).
+
+## Retrieval core
+
+New shared retrieval functions in `src/lib/graph.ts` (alongside the existing
+`findSimilarNodes` / `findSimilarClaims`), each returning ranked id lists so
+they compose:
+
+- `findNodesByLexical(db, params)` — `websearch_to_tsquery('english', query)`
+  against `node_metadata.search_tsv`, ranked by `ts_rank_cd`, unioned with a
+  `pg_trgm` `similarity()` match on `label` for fuzzy/prefix. Applies the same
+  SQL filters (`userId`, scope, `notInArray(nodeType, …)`).
+- `findClaimsByLexical(db, params)` — same against `claims.search_tsv` /
+  `claims.statement`, with the existing claim filters (status, validity,
+  asserted-by-kind) plus the new time-range filter.
+- `ts_headline('english', text, query)` produces the highlight snippet for each
+  hit.
+
+### Fusion (pure, unit-tested)
+
+New `src/lib/search/fusion.ts`:
+
+```
+rrf(rankings: RankedId[][], k = 60): FusedId[]
+```
+
+Reciprocal Rank Fusion: each id's score is `Σ 1/(k + rank_in_list)` across the
+lexical and vector rankings, sorted descending. Pure function over id+rank
+lists — no DB, no embeddings, trivially testable. `k` is a named constant.
+
+### Pipeline (`src/lib/search/explicit-search.ts`)
+
+1. Embed the query (`retrieval.query`, existing `embeddings.ts`) **and** run
+   lexical retrieval, in parallel.
+2. Vector legs: `findSimilarNodes` / `findSimilarClaims` **with no similarity
+   floor**, returning ranked ids.
+3. Lexical legs: `findNodesByLexical` / `findClaimsByLexical`.
+4. Fuse node rankings and claim rankings via `rrf`.
+5. Hydrate the fused top-`limit` ids into `SearchHit`s (label/statement,
+   highlight, source provenance, `statedAt`, fused score).
+6. Optional rerank seam (default off): if enabled, pass hydrated hit texts
+   through `src/lib/rerank.ts` before the final cut.
+
+## The `/search` endpoint
+
+`src/routes/search.post.ts`. Request schema (`src/lib/schemas/search.ts`):
+
+```ts
+{
+  userId: string,
+  query: string,                // min length 1
+  limit?: number,               // default 20, max 50
+  scope?: "personal" | "reference", // default "personal"; never blended
+  filters?: {
+    entityTypes?: NodeType[],   // include-filter (inverse of excludeNodeTypes)
+    statedBetween?: { from?: Date, to?: Date }, // new claim time-range filter
+  },
+}
+```
+
+Response:
+
+```ts
+{
+  query: string,
+  hits: SearchHit[],            // ordered by fused score, descending
+}
+
+type SearchHit = {
+  kind: "node" | "claim",
+  nodeId: TypeId<"node">,       // owning entity (subject for claim hits)
+  claimId?: TypeId<"claim">,    // present when kind === "claim"
+  text: string,                 // label (node) or statement (claim)
+  highlight: string,            // ts_headline snippet
+  score: number,                // fused RRF score
+  source: { type: SourceType, title?: string, author?: string },
+  statedAt?: Date,              // for claim hits
+}
+```
+
+Scope is a hard boundary as elsewhere: a `personal` request never surfaces
+`reference` material and vice versa. The time-range filter is a small addition
+to the claim query (today only an `asOf` cutoff exists, no range).
+
+**Time range and node hits.** `statedBetween` filters claim hits directly by
+`claims.stated_at`. Nodes have no intrinsic time, so when a range is set a node
+hit is kept only if the node has at least one active claim with `stated_at` in
+range (an `EXISTS` subquery, same shape as the existing `nodeHasScopeSupport`
+predicate). With no range set, node lexical/vector hits are unconstrained by
+time.
+
+## Surfaces & downstream consumers
+
+- **SDK** (`src/sdk/memory-client.ts`): new `async search(payload): Promise<SearchResponse>`
+  → `POST /search`, validated by `searchResponseSchema`.
+- **Petals manual explorer** (`~/code/petals`, `/memory/explore`): migrate the
+  `searchMemory` server fn from `querySearch` → `search()`, and render ranked
+  hits with highlights (replacing the node/connection/edge card view). Done in
+  a dedicated Petals worktree.
+- **n8n node** (`n8n-nodes-petals`) + **Petals proxy endpoint**: add the
+  `search` operation so automation users get it, per the repo's
+  downstream-consumers convention (CLAUDE.md).
+- **Reranking:** Jina cross-encoder rerank is wired as an off-by-default seam in
+  the pipeline; not exposed in the API in v1.
+
+### Assistant search tool (recommended, open for spec review)
+
+The assistant currently has the MCP `search_memory` tool → `/context/search`
+(semantic cards) for "tell me about this entity". That stays. **Recommendation:**
+add a *second* MCP tool, `search_text` (working name), → `/search`, described
+for exact / keyword / "find where I mentioned X" lookups. Two tools with
+distinct intents rather than repointing the pinned `search_memory` contract
+(whose card shape suits entity recall and whose description is snapshot-pinned
+in `mcp-server.test.ts`).
+
+Alternative considered: repoint `search_memory` to `/search`. Rejected for v1 —
+it is a breaking shape change (cards → hits) to a load-bearing pinned tool, and
+the two genuinely serve different jobs. The new assistant tool can also be
+deferred to a fast-follow if we want v1 to be manual-UI-only; flagged for the
+review gate.
+
+## Testing strategy
+
+- **Fusion** (`fusion.test.ts`): pure RRF unit tests — ordering, tie-breaking,
+  `k` behaviour, empty inputs.
+- **Lexical retrieval**: tests on `:5431` (CI does not run vitest — run locally)
+  seeding realistic messy data: exact-token match, phrase via
+  `websearch_to_tsquery`, typo via trigram, prefix, scope isolation, entity-type
+  filter, time-range filter.
+- **Endpoint** (`search.post.test.ts`): hits real server, asserts hit ordering,
+  highlight presence, scope hard-boundary, error messages reach the client.
+- **MCP tool** (if included): snapshot-pin the new tool description like the
+  others; assert it calls `/search`.
+- **Migration**: verify generated columns backfill on existing rows and the GIN
+  indexes are used (EXPLAIN).
+
+## Non-goals (YAGNI)
+
+- No ParadeDB / Elasticsearch / external search engine.
+- No source-type facet in v1.
+- No blended-scope responses.
+- No changes to background context injection or the legacy `/query/search`
+  graph shape.
+- No reranking in the v1 API surface (seam only).
+- No multi-language `tsvector` configs — `'english'` only for v1.
+
+## Migration / rollout order
+
+1. Memory repo: extension + generated columns + indexes migration.
+2. Retrieval core (lexical functions, fusion, pipeline) + tests.
+3. `/search` endpoint + schema + tests.
+4. SDK `search()` + release.
+5. Petals worktree: explorer migration + (optional) assistant tool.
+6. n8n node + proxy endpoint operation.

--- a/drizzle/0024_hybrid_search_indexes.sql
+++ b/drizzle/0024_hybrid_search_indexes.sql
@@ -1,7 +1,12 @@
+-- Hybrid explicit-search lexical layer. Hand-written (not schema-generated):
+-- the `search_tsv` generated columns and pg_trgm indexes are infrastructure
+-- referenced via raw SQL in src/lib/graph.ts, intentionally NOT declared in
+-- src/db/schema.ts so Drizzle never enumerates them in select/returning (which
+-- would break every test that builds its DB from hand-written DDL).
 CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
-ALTER TABLE "claims" ADD COLUMN "search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
-ALTER TABLE "node_metadata" ADD COLUMN "search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
-CREATE INDEX "claims_search_tsv_idx" ON "claims" USING gin ("search_tsv");--> statement-breakpoint
-CREATE INDEX "claims_statement_trgm_idx" ON "claims" USING gin ("statement" gin_trgm_ops);--> statement-breakpoint
+ALTER TABLE "node_metadata" ADD COLUMN "search_tsv" tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
+ALTER TABLE "claims" ADD COLUMN "search_tsv" tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
 CREATE INDEX "node_metadata_search_tsv_idx" ON "node_metadata" USING gin ("search_tsv");--> statement-breakpoint
-CREATE INDEX "node_metadata_label_trgm_idx" ON "node_metadata" USING gin ("label" gin_trgm_ops);
+CREATE INDEX "node_metadata_label_trgm_idx" ON "node_metadata" USING gin ("label" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "claims_search_tsv_idx" ON "claims" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "claims_statement_trgm_idx" ON "claims" USING gin ("statement" gin_trgm_ops);

--- a/drizzle/0024_hybrid_search_indexes.sql
+++ b/drizzle/0024_hybrid_search_indexes.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+ALTER TABLE "claims" ADD COLUMN "search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
+ALTER TABLE "node_metadata" ADD COLUMN "search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))) STORED;--> statement-breakpoint
+CREATE INDEX "claims_search_tsv_idx" ON "claims" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "claims_statement_trgm_idx" ON "claims" USING gin ("statement" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "node_metadata_search_tsv_idx" ON "node_metadata" USING gin ("search_tsv");--> statement-breakpoint
+CREATE INDEX "node_metadata_label_trgm_idx" ON "node_metadata" USING gin ("label" gin_trgm_ops);

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "e434d513-c4d3-4bd3-a3fe-d50e787a76a3",
+  "id": "87a73260-8af0-4f9b-acd8-5ff531787c59",
   "prevId": "140c77e0-4065-40d5-a766-6620e356261e",
   "version": "7",
   "dialect": "postgresql",
@@ -51,40 +51,40 @@
         "aliases_user_id_users_id_fk": {
           "name": "aliases_user_id_users_id_fk",
           "tableFrom": "aliases",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "aliases_canonical_node_id_nodes_id_fk": {
           "name": "aliases_canonical_node_id_nodes_id_fk",
           "tableFrom": "aliases",
-          "tableTo": "nodes",
           "columnsFrom": [
             "canonical_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "aliases_user_normalized_canonical_unique": {
           "name": "aliases_user_normalized_canonical_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "user_id",
             "normalized_alias_text",
             "canonical_node_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -140,9 +140,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "hnsw",
-          "with": {}
+          "concurrently": false
         },
         "claim_embeddings_claim_id_idx": {
           "name": "claim_embeddings_claim_id_idx",
@@ -155,24 +155,24 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "claim_embeddings_claim_id_claims_id_fk": {
           "name": "claim_embeddings_claim_id_claims_id_fk",
           "tableFrom": "claim_embeddings",
-          "tableTo": "claims",
           "columnsFrom": [
             "claim_id"
           ],
+          "tableTo": "claims",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -232,16 +232,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "search_tsv": {
-          "name": "search_tsv",
-          "type": "tsvector",
-          "primaryKey": false,
-          "notNull": false,
-          "generated": {
-            "as": "to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))",
-            "type": "stored"
-          }
         },
         "metadata": {
           "name": "metadata",
@@ -350,9 +340,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_id_object_node_id_idx": {
           "name": "claims_user_id_object_node_id_idx",
@@ -371,9 +361,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_id_predicate_idx": {
           "name": "claims_user_id_predicate_idx",
@@ -392,9 +382,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_scope_status_stated_at_idx": {
           "name": "claims_user_scope_status_stated_at_idx",
@@ -425,9 +415,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_scope_kind_status_idx": {
           "name": "claims_user_scope_kind_status_idx",
@@ -458,9 +448,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_id_subject_status_idx": {
           "name": "claims_user_id_subject_status_idx",
@@ -485,9 +475,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "claims_user_id_object_status_idx": {
           "name": "claims_user_id_object_status_idx",
@@ -512,10 +502,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
         },
         "claims_trusted_open_task_status_idx": {
           "name": "claims_trusted_open_task_status_idx",
@@ -546,10 +536,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
         },
         "claims_candidate_open_task_status_idx": {
           "name": "claims_candidate_open_task_status_idx",
@@ -580,10 +570,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
         },
         "claims_task_metadata_lookup_idx": {
           "name": "claims_task_metadata_lookup_idx",
@@ -614,10 +604,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
         },
         "claims_due_instant_idx": {
           "name": "claims_due_instant_idx",
@@ -636,10 +626,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false
         },
         "claims_occurred_on_discovery_idx": {
           "name": "claims_occurred_on_discovery_idx",
@@ -658,10 +648,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false
         },
         "claims_source_id_idx": {
           "name": "claims_source_id_idx",
@@ -674,133 +664,102 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
-        },
-        "claims_search_tsv_idx": {
-          "name": "claims_search_tsv_idx",
-          "columns": [
-            {
-              "expression": "search_tsv",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "claims_statement_trgm_idx": {
-          "name": "claims_statement_trgm_idx",
-          "columns": [
-            {
-              "expression": "statement",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last",
-              "opclass": "gin_trgm_ops"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "claims_user_id_users_id_fk": {
           "name": "claims_user_id_users_id_fk",
           "tableFrom": "claims",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "claims_subject_node_id_nodes_id_fk": {
           "name": "claims_subject_node_id_nodes_id_fk",
           "tableFrom": "claims",
-          "tableTo": "nodes",
           "columnsFrom": [
             "subject_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "claims_object_node_id_nodes_id_fk": {
           "name": "claims_object_node_id_nodes_id_fk",
           "tableFrom": "claims",
-          "tableTo": "nodes",
           "columnsFrom": [
             "object_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "claims_source_id_sources_id_fk": {
           "name": "claims_source_id_sources_id_fk",
           "tableFrom": "claims",
-          "tableTo": "sources",
           "columnsFrom": [
             "source_id"
           ],
+          "tableTo": "sources",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "claims_asserted_by_node_id_nodes_id_fk": {
           "name": "claims_asserted_by_node_id_nodes_id_fk",
           "tableFrom": "claims",
-          "tableTo": "nodes",
           "columnsFrom": [
             "asserted_by_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "claims_superseded_by_claim_id_claims_id_fk": {
           "name": "claims_superseded_by_claim_id_claims_id_fk",
           "tableFrom": "claims",
-          "tableTo": "claims",
           "columnsFrom": [
             "superseded_by_claim_id"
           ],
+          "tableTo": "claims",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "claims_contradicted_by_claim_id_claims_id_fk": {
           "name": "claims_contradicted_by_claim_id_claims_id_fk",
           "tableFrom": "claims",
-          "tableTo": "claims",
           "columnsFrom": [
             "contradicted_by_claim_id"
           ],
+          "tableTo": "claims",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
@@ -880,50 +839,50 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "commitment_presentations_task_id_nodes_id_fk": {
           "name": "commitment_presentations_task_id_nodes_id_fk",
           "tableFrom": "commitment_presentations",
-          "tableTo": "nodes",
           "columnsFrom": [
             "task_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "commitment_presentations_user_id_users_id_fk": {
           "name": "commitment_presentations_user_id_users_id_fk",
           "tableFrom": "commitment_presentations",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "commitment_presentations_source_id_sources_id_fk": {
           "name": "commitment_presentations_source_id_sources_id_fk",
           "tableFrom": "commitment_presentations",
-          "tableTo": "sources",
           "columnsFrom": [
             "source_id"
           ],
+          "tableTo": "sources",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -981,9 +940,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "hnsw",
-          "with": {}
+          "concurrently": false
         },
         "metric_def_emb_def_id_idx": {
           "name": "metric_def_emb_def_id_idx",
@@ -996,34 +955,34 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
           "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
           "tableFrom": "metric_definition_embeddings",
-          "tableTo": "metric_definitions",
           "columnsFrom": [
             "metric_definition_id"
           ],
+          "tableTo": "metric_definitions",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "metric_def_emb_def_unique": {
           "name": "metric_def_emb_def_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "metric_definition_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1128,9 +1087,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "metric_definitions_user_needs_review_idx": {
           "name": "metric_definitions_user_needs_review_idx",
@@ -1143,49 +1102,49 @@
             }
           ],
           "isUnique": false,
-          "where": "\"metric_definitions\".\"needs_review\" = true",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "metric_definitions_user_id_users_id_fk": {
           "name": "metric_definitions_user_id_users_id_fk",
           "tableFrom": "metric_definitions",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "metric_definitions_review_task_node_id_nodes_id_fk": {
           "name": "metric_definitions_review_task_node_id_nodes_id_fk",
           "tableFrom": "metric_definitions",
-          "tableTo": "nodes",
           "columnsFrom": [
             "review_task_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "metric_definitions_user_slug_unique": {
           "name": "metric_definitions_user_slug_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "user_id",
             "slug"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1281,9 +1240,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "metric_observations_user_occurred_idx": {
           "name": "metric_observations_user_occurred_idx",
@@ -1302,9 +1261,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "metric_observations_event_node_idx": {
           "name": "metric_observations_event_node_idx",
@@ -1317,10 +1276,10 @@
             }
           ],
           "isUnique": false,
-          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false
         },
         "metric_observations_source_id_idx": {
           "name": "metric_observations_source_id_idx",
@@ -1333,63 +1292,63 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "metric_observations_user_id_users_id_fk": {
           "name": "metric_observations_user_id_users_id_fk",
           "tableFrom": "metric_observations",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "metric_observations_metric_definition_id_metric_definitions_id_fk": {
           "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
           "tableFrom": "metric_observations",
-          "tableTo": "metric_definitions",
           "columnsFrom": [
             "metric_definition_id"
           ],
+          "tableTo": "metric_definitions",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "metric_observations_event_node_id_nodes_id_fk": {
           "name": "metric_observations_event_node_id_nodes_id_fk",
           "tableFrom": "metric_observations",
-          "tableTo": "nodes",
           "columnsFrom": [
             "event_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "metric_observations_source_id_sources_id_fk": {
           "name": "metric_observations_source_id_sources_id_fk",
           "tableFrom": "metric_observations",
-          "tableTo": "sources",
           "columnsFrom": [
             "source_id"
           ],
+          "tableTo": "sources",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -1447,9 +1406,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "hnsw",
-          "with": {}
+          "concurrently": false
         },
         "node_embeddings_node_id_idx": {
           "name": "node_embeddings_node_id_idx",
@@ -1462,24 +1421,24 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "node_embeddings_node_id_nodes_id_fk": {
           "name": "node_embeddings_node_id_nodes_id_fk",
           "tableFrom": "node_embeddings",
-          "tableTo": "nodes",
           "columnsFrom": [
             "node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -1522,16 +1481,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "search_tsv": {
-          "name": "search_tsv",
-          "type": "tsvector",
-          "primaryKey": false,
-          "notNull": false,
-          "generated": {
-            "as": "to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))",
-            "type": "stored"
-          }
-        },
         "additional_data": {
           "name": "additional_data",
           "type": "jsonb",
@@ -1558,9 +1507,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "node_metadata_canonical_label_idx": {
           "name": "node_metadata_canonical_label_idx",
@@ -1573,65 +1522,34 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
-        },
-        "node_metadata_search_tsv_idx": {
-          "name": "node_metadata_search_tsv_idx",
-          "columns": [
-            {
-              "expression": "search_tsv",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "node_metadata_label_trgm_idx": {
-          "name": "node_metadata_label_trgm_idx",
-          "columns": [
-            {
-              "expression": "label",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last",
-              "opclass": "gin_trgm_ops"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "node_metadata_node_id_nodes_id_fk": {
           "name": "node_metadata_node_id_nodes_id_fk",
           "tableFrom": "node_metadata",
-          "tableTo": "nodes",
           "columnsFrom": [
             "node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "node_metadata_nodeId_unique": {
           "name": "node_metadata_nodeId_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "node_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1686,37 +1604,37 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "node_redirects_user_id_users_id_fk": {
           "name": "node_redirects_user_id_users_id_fk",
           "tableFrom": "node_redirects",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "node_redirects_to_node_id_nodes_id_fk": {
           "name": "node_redirects_to_node_id_nodes_id_fk",
           "tableFrom": "node_redirects",
-          "tableTo": "nodes",
           "columnsFrom": [
             "to_node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1775,9 +1693,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "nodes_user_id_node_type_idx": {
           "name": "nodes_user_id_node_type_idx",
@@ -1796,24 +1714,24 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "nodes_user_id_users_id_fk": {
           "name": "nodes_user_id_users_id_fk",
           "tableFrom": "nodes",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1858,15 +1776,15 @@
         "rollup_state_user_id_users_id_fk": {
           "name": "rollup_state_user_id_users_id_fk",
           "tableFrom": "rollup_state",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1925,34 +1843,34 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "scratchpads_user_id_users_id_fk": {
           "name": "scratchpads_user_id_users_id_fk",
           "tableFrom": "scratchpads",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "scratchpads_userId_unique": {
           "name": "scratchpads_userId_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "user_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -2007,9 +1925,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "source_links_node_id_idx": {
           "name": "source_links_node_id_idx",
@@ -2022,48 +1940,48 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "source_links_source_id_sources_id_fk": {
           "name": "source_links_source_id_sources_id_fk",
           "tableFrom": "source_links",
-          "tableTo": "sources",
           "columnsFrom": [
             "source_id"
           ],
+          "tableTo": "sources",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "source_links_node_id_nodes_id_fk": {
           "name": "source_links_node_id_nodes_id_fk",
           "tableFrom": "source_links",
-          "tableTo": "nodes",
           "columnsFrom": [
             "node_id"
           ],
+          "tableTo": "nodes",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "source_links_sourceId_nodeId_unique": {
           "name": "source_links_sourceId_nodeId_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "source_id",
             "node_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -2168,9 +2086,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "sources_status_idx": {
           "name": "sources_status_idx",
@@ -2183,36 +2101,36 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "sources_user_id_users_id_fk": {
           "name": "sources_user_id_users_id_fk",
           "tableFrom": "sources",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "sources_userId_type_externalId_unique": {
           "name": "sources_userId_type_externalId_unique",
-          "nullsNotDistinct": false,
           "columns": [
             "user_id",
             "type",
             "external_id"
-          ]
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -2273,15 +2191,15 @@
         "user_profiles_user_id_users_id_fk": {
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
-          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
+          "tableTo": "users",
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2312,10 +2230,10 @@
   },
   "enums": {},
   "schemas": {},
+  "views": {},
   "sequences": {},
   "roles": {},
   "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2324 @@
+{
+  "id": "e434d513-c4d3-4bd3-a3fe-d50e787a76a3",
+  "prevId": "140c77e0-4065-40d5-a766-6620e356261e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))",
+            "type": "stored"
+          }
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('OWNED_BY', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claims_search_tsv_idx": {
+          "name": "claims_search_tsv_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "claims_statement_trgm_idx": {
+          "name": "claims_statement_trgm_idx",
+          "columns": [
+            {
+              "expression": "statement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commitment_presentations": {
+      "name": "commitment_presentations",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commitment_presentations_user_id_idx": {
+          "name": "commitment_presentations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commitment_presentations_task_id_nodes_id_fk": {
+          "name": "commitment_presentations_task_id_nodes_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commitment_presentations_user_id_users_id_fk": {
+          "name": "commitment_presentations_user_id_users_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "commitment_presentations_source_id_sources_id_fk": {
+          "name": "commitment_presentations_source_id_sources_id_fk",
+          "tableFrom": "commitment_presentations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "metric_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "metric_definitions",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))",
+            "type": "stored"
+          }
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_metadata_search_tsv_idx": {
+          "name": "node_metadata_search_tsv_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "node_metadata_label_trgm_idx": {
+          "name": "node_metadata_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -173,7 +173,7 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1781610361896,
+      "when": 1781612744997,
       "tag": "0024_hybrid_search_indexes",
       "breakpoints": true
     }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1781443080497,
       "tag": "0023_cynical_tigra",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1781610361896,
+      "tag": "0024_hybrid_search_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,6 @@ import { typeId, typeIdNoDefault } from "./typeid";
 import { relations, sql } from "drizzle-orm";
 import {
   check,
-  customType,
   pgTable,
   varchar,
   timestamp,
@@ -25,17 +24,6 @@ import {
   SourceStatus,
   SourceType,
 } from "~/types/graph";
-
-/**
- * Postgres `tsvector` column type for full-text search. Drizzle has no native
- * tsvector type; this customType lets us declare GENERATED ALWAYS AS (...)
- * STORED columns and GIN-index them.
- */
-const tsvector = customType<{ data: string }>({
-  dataType() {
-    return "tsvector";
-  },
-});
 
 // --- Core Ontology & Structure ---
 
@@ -83,9 +71,6 @@ export const nodeMetadata = pgTable(
     label: text(),
     canonicalLabel: text("canonical_label"),
     description: text(),
-    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
-      sql`to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))`,
-    ),
     additionalData: jsonb(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
@@ -95,11 +80,6 @@ export const nodeMetadata = pgTable(
     index("node_metadata_node_id_idx").on(table.nodeId),
     index("node_metadata_canonical_label_idx").on(table.canonicalLabel),
     unique().on(table.nodeId),
-    index("node_metadata_search_tsv_idx").using("gin", table.searchTsv),
-    index("node_metadata_label_trgm_idx").using(
-      "gin",
-      table.label.op("gin_trgm_ops"),
-    ),
   ],
 );
 
@@ -129,9 +109,6 @@ export const claims = pgTable(
       .$type<Predicate>(),
     statement: text().notNull(),
     description: text(),
-    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
-      sql`to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))`,
-    ),
     metadata: jsonb(),
     /**
      * Resolved UTC instant of a time-qualified temporal-object claim — currently
@@ -249,11 +226,6 @@ export const claims = pgTable(
         sql`${table.predicate} = 'OCCURRED_ON' AND ${table.status} = 'active'`,
       ),
     index("claims_source_id_idx").on(table.sourceId),
-    index("claims_search_tsv_idx").using("gin", table.searchTsv),
-    index("claims_statement_trgm_idx").using(
-      "gin",
-      table.statement.op("gin_trgm_ops"),
-    ),
     check(
       "claims_object_shape_xor_ck",
       sql`(("object_node_id" IS NOT NULL AND "object_value" IS NULL) OR ("object_node_id" IS NULL AND "object_value" IS NOT NULL))`,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import { typeId, typeIdNoDefault } from "./typeid";
 import { relations, sql } from "drizzle-orm";
 import {
   check,
+  customType,
   pgTable,
   varchar,
   timestamp,
@@ -24,6 +25,17 @@ import {
   SourceStatus,
   SourceType,
 } from "~/types/graph";
+
+/**
+ * Postgres `tsvector` column type for full-text search. Drizzle has no native
+ * tsvector type; this customType lets us declare GENERATED ALWAYS AS (...)
+ * STORED columns and GIN-index them.
+ */
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
 
 // --- Core Ontology & Structure ---
 
@@ -71,6 +83,9 @@ export const nodeMetadata = pgTable(
     label: text(),
     canonicalLabel: text("canonical_label"),
     description: text(),
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      sql`to_tsvector('english', coalesce(label, '') || ' ' || coalesce(description, ''))`,
+    ),
     additionalData: jsonb(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
@@ -80,6 +95,11 @@ export const nodeMetadata = pgTable(
     index("node_metadata_node_id_idx").on(table.nodeId),
     index("node_metadata_canonical_label_idx").on(table.canonicalLabel),
     unique().on(table.nodeId),
+    index("node_metadata_search_tsv_idx").using("gin", table.searchTsv),
+    index("node_metadata_label_trgm_idx").using(
+      "gin",
+      table.label.op("gin_trgm_ops"),
+    ),
   ],
 );
 
@@ -109,6 +129,9 @@ export const claims = pgTable(
       .$type<Predicate>(),
     statement: text().notNull(),
     description: text(),
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      sql`to_tsvector('english', coalesce(statement, '') || ' ' || coalesce(description, ''))`,
+    ),
     metadata: jsonb(),
     /**
      * Resolved UTC instant of a time-qualified temporal-object claim — currently
@@ -226,6 +249,11 @@ export const claims = pgTable(
         sql`${table.predicate} = 'OCCURRED_ON' AND ${table.status} = 'active'`,
       ),
     index("claims_source_id_idx").on(table.sourceId),
+    index("claims_search_tsv_idx").using("gin", table.searchTsv),
+    index("claims_statement_trgm_idx").using(
+      "gin",
+      table.statement.op("gin_trgm_ops"),
+    ),
     check(
       "claims_object_shape_xor_ck",
       sql`(("object_node_id" IS NOT NULL AND "object_value" IS NULL) OR ("object_node_id" IS NULL AND "object_value" IS NOT NULL))`,

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -718,11 +718,14 @@ export async function findNodesByLexical(
   const db = await useDatabase();
 
   const tsq = sql`websearch_to_tsquery('english', ${query})`;
-  const rank = sql<number>`ts_rank_cd(${nodeMetadata.searchTsv}, ${tsq})`;
+  // search_tsv is a migration-managed generated column, intentionally not
+  // declared on the Drizzle schema (so the ORM never enumerates it in
+  // select/returning). Reference it by raw, table-qualified name.
+  const rank = sql<number>`ts_rank_cd(node_metadata.search_tsv, ${tsq})`;
   // word_similarity (not similarity): matches the query against the best-matching
   // word in the label, so a short typo ("Boux") still matches a long label
   // ("Boox Note Air 4C"). Full-string similarity() would score near-zero there.
-  const matched = sql`(${nodeMetadata.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${nodeMetadata.label}) > 0.3)`;
+  const matched = sql`(node_metadata.search_tsv @@ ${tsq} OR word_similarity(${query}, ${nodeMetadata.label}) > 0.3)`;
   const highlight = sql<string>`ts_headline('english', coalesce(${nodeMetadata.label}, '') || ' ' || coalesce(${nodeMetadata.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   let where = and(
@@ -777,10 +780,11 @@ export async function findClaimsByLexical(
   const db = await useDatabase();
 
   const tsq = sql`websearch_to_tsquery('english', ${query})`;
-  const rank = sql<number>`ts_rank_cd(${claims.searchTsv}, ${tsq})`;
+  // search_tsv is a migration-managed generated column (see findNodesByLexical).
+  const rank = sql<number>`ts_rank_cd(claims.search_tsv, ${tsq})`;
   // word_similarity matches the query against the best-matching word in the
   // statement (handles typos against long statements; see findNodesByLexical).
-  const matched = sql`(${claims.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${claims.statement}) > 0.3)`;
+  const matched = sql`(claims.search_tsv @@ ${tsq} OR word_similarity(${query}, ${claims.statement}) > 0.3)`;
   const highlight = sql<string>`ts_headline('english', coalesce(${claims.statement}, '') || ' ' || coalesce(${claims.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   const subjectNodeMetadata = aliasedTable(nodeMetadata, "subjectNodeMetadata");

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -113,7 +113,7 @@ export type FindSimilarClaimsOptions = SimilaritySearchBase & {
   statuses?: ClaimStatus[];
   asOf?: Date;
   /** Restrict to claims whose stated_at falls in this (inclusive) range. */
-  statedBetween?: { from?: Date; to?: Date };
+  statedBetween?: { from?: Date | undefined; to?: Date | undefined };
   includeReference?: boolean;
   /** When set, restrict to exactly this scope (takes precedence over includeReference). */
   scope?: Scope;
@@ -157,7 +157,7 @@ export interface NodeLexicalParams extends LexicalSearchParams {
 export interface ClaimLexicalParams extends LexicalSearchParams {
   statuses?: ClaimStatus[];
   asOf?: Date;
-  statedBetween?: { from?: Date; to?: Date };
+  statedBetween?: { from?: Date | undefined; to?: Date | undefined };
   includeAssistantInferred?: boolean;
 }
 

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -100,16 +100,23 @@ export type SimilaritySearchBase = (
 
 /** Options for semantic search */
 export type FindSimilarNodesOptions = SimilaritySearchBase & {
-  /** Optional list of node types to exclude from the search results */
   excludeNodeTypes?: NodeType[];
+  /** When set, restrict to these node types (takes precedence over exclude). */
+  includeNodeTypes?: NodeType[];
   includeReference?: boolean;
+  /** When set, restrict to exactly this scope (takes precedence over includeReference). */
+  scope?: Scope;
 };
 
 /** Options for semantic search on claims */
 export type FindSimilarClaimsOptions = SimilaritySearchBase & {
   statuses?: ClaimStatus[];
   asOf?: Date;
+  /** Restrict to claims whose stated_at falls in this (inclusive) range. */
+  statedBetween?: { from?: Date; to?: Date };
   includeReference?: boolean;
+  /** When set, restrict to exactly this scope (takes precedence over includeReference). */
+  scope?: Scope;
   includeAssistantInferred?: boolean;
 };
 
@@ -134,7 +141,36 @@ export interface ClaimSearchResult {
   timestamp: Date;
 }
 
-async function generateTextEmbedding(text: string): Promise<number[]> {
+export interface LexicalSearchParams {
+  userId: string;
+  query: string;
+  limit?: number;
+  /** Single scope to restrict to. Defaults to "personal"; never blends. */
+  scope?: Scope;
+}
+
+export interface NodeLexicalParams extends LexicalSearchParams {
+  excludeNodeTypes?: NodeType[];
+  includeNodeTypes?: NodeType[];
+}
+
+export interface ClaimLexicalParams extends LexicalSearchParams {
+  statuses?: ClaimStatus[];
+  asOf?: Date;
+  statedBetween?: { from?: Date; to?: Date };
+  includeAssistantInferred?: boolean;
+}
+
+export interface NodeLexicalResult extends NodeSearchResult {
+  /** ts_headline snippet over the matched text. */
+  highlight: string;
+}
+
+export interface ClaimLexicalResult extends ClaimSearchResult {
+  highlight: string;
+}
+
+export async function generateTextEmbedding(text: string): Promise<number[]> {
   const res = await generateEmbeddings({
     model: "jina-embeddings-v3",
     task: "retrieval.query",
@@ -184,7 +220,9 @@ export async function findSimilarNodes(
     limit = 10,
     minimumSimilarity,
     excludeNodeTypes,
+    includeNodeTypes,
     includeReference = false,
+    scope,
   } = opts;
 
   const emb =
@@ -197,7 +235,11 @@ export async function findSimilarNodes(
   // Base conditions
   let whereCondition = and(
     eq(nodes.userId, userId),
-    includeReference ? undefined : nodeHasScopeSupport(userId, "personal"),
+    scope
+      ? nodeHasScopeSupport(userId, scope)
+      : includeReference
+        ? undefined
+        : nodeHasScopeSupport(userId, "personal"),
     sql`${similarity} IS NOT NULL`,
   );
 
@@ -214,6 +256,13 @@ export async function findSimilarNodes(
     whereCondition = and(
       whereCondition,
       notInArray(nodes.nodeType, excludeNodeTypes),
+    );
+  }
+
+  if (includeNodeTypes && includeNodeTypes.length > 0) {
+    whereCondition = and(
+      whereCondition,
+      inArray(nodes.nodeType, includeNodeTypes),
     );
   }
 
@@ -248,7 +297,9 @@ export async function findSimilarClaims(
     minimumSimilarity,
     statuses = ["active"],
     asOf = new Date(),
+    statedBetween,
     includeReference = false,
+    scope,
     includeAssistantInferred = false,
   } = opts;
 
@@ -262,7 +313,11 @@ export async function findSimilarClaims(
   // Base conditions
   let whereCondition = and(
     eq(claims.userId, userId),
-    includeReference ? undefined : eq(claims.scope, "personal"),
+    scope
+      ? eq(claims.scope, scope)
+      : includeReference
+        ? undefined
+        : eq(claims.scope, "personal"),
     includeAssistantInferred
       ? undefined
       : ne(claims.assertedByKind, "assistant_inferred"),
@@ -276,6 +331,19 @@ export async function findSimilarClaims(
     whereCondition = and(
       whereCondition,
       sql`${similarity} >= ${minimumSimilarity}`,
+    );
+  }
+
+  if (statedBetween?.from) {
+    whereCondition = and(
+      whereCondition,
+      sql`${claims.statedAt} >= ${statedBetween.from}`,
+    );
+  }
+  if (statedBetween?.to) {
+    whereCondition = and(
+      whereCondition,
+      sql`${claims.statedAt} <= ${statedBetween.to}`,
     );
   }
 
@@ -629,4 +697,145 @@ export async function fetchClaimsBetweenNodeIds(
         isNotNull(tgt.label),
       ),
     );
+}
+
+/**
+ * Lexical node retrieval: full-text match on the generated tsvector plus a
+ * pg_trgm fuzzy match on the label, ranked by ts_rank_cd. Used by the hybrid
+ * explicit-search pipeline (NOT background context injection).
+ */
+export async function findNodesByLexical(
+  params: NodeLexicalParams,
+): Promise<NodeLexicalResult[]> {
+  const {
+    userId,
+    query,
+    limit = 10,
+    scope = "personal",
+    excludeNodeTypes,
+    includeNodeTypes,
+  } = params;
+  const db = await useDatabase();
+
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const rank = sql<number>`ts_rank_cd(${nodeMetadata.searchTsv}, ${tsq})`;
+  // word_similarity (not similarity): matches the query against the best-matching
+  // word in the label, so a short typo ("Boux") still matches a long label
+  // ("Boox Note Air 4C"). Full-string similarity() would score near-zero there.
+  const matched = sql`(${nodeMetadata.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${nodeMetadata.label}) > 0.3)`;
+  const highlight = sql<string>`ts_headline('english', coalesce(${nodeMetadata.label}, '') || ' ' || coalesce(${nodeMetadata.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
+
+  let where = and(
+    eq(nodes.userId, userId),
+    nodeHasScopeSupport(userId, scope),
+    matched,
+  );
+  if (includeNodeTypes && includeNodeTypes.length > 0) {
+    where = and(where, inArray(nodes.nodeType, includeNodeTypes));
+  } else if (excludeNodeTypes && excludeNodeTypes.length > 0) {
+    where = and(where, notInArray(nodes.nodeType, excludeNodeTypes));
+  }
+
+  const rows = await db
+    .select({
+      id: nodes.id,
+      type: nodes.nodeType,
+      label: nodeMetadata.label,
+      description: nodeMetadata.description,
+      timestamp: nodes.createdAt,
+      rank,
+      highlight,
+    })
+    .from(nodes)
+    .innerJoin(nodeMetadata, eq(nodes.id, nodeMetadata.nodeId))
+    .where(where)
+    .orderBy(desc(rank))
+    .limit(limit);
+
+  return rows.map((r) => ({ ...r, similarity: r.rank }));
+}
+
+/**
+ * Lexical claim retrieval: full-text match on the generated tsvector plus a
+ * pg_trgm fuzzy match on the statement, ranked by ts_rank_cd. Honours the same
+ * status/validity/scope filters as findSimilarClaims, plus an optional
+ * stated_at range.
+ */
+export async function findClaimsByLexical(
+  params: ClaimLexicalParams,
+): Promise<ClaimLexicalResult[]> {
+  const {
+    userId,
+    query,
+    limit = 10,
+    scope = "personal",
+    statuses = ["active"],
+    asOf = new Date(),
+    statedBetween,
+    includeAssistantInferred = false,
+  } = params;
+  const db = await useDatabase();
+
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const rank = sql<number>`ts_rank_cd(${claims.searchTsv}, ${tsq})`;
+  // word_similarity matches the query against the best-matching word in the
+  // statement (handles typos against long statements; see findNodesByLexical).
+  const matched = sql`(${claims.searchTsv} @@ ${tsq} OR word_similarity(${query}, ${claims.statement}) > 0.3)`;
+  const highlight = sql<string>`ts_headline('english', coalesce(${claims.statement}, '') || ' ' || coalesce(${claims.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
+
+  const subjectNodeMetadata = aliasedTable(nodeMetadata, "subjectNodeMetadata");
+  const objectNodeMetadata = aliasedTable(nodeMetadata, "objectNodeMetadata");
+
+  let where = and(
+    eq(claims.userId, userId),
+    eq(claims.scope, scope),
+    includeAssistantInferred
+      ? undefined
+      : ne(claims.assertedByKind, "assistant_inferred"),
+    inArray(claims.status, statuses),
+    or(isNull(claims.validTo), gt(claims.validTo, asOf)),
+    matched,
+  );
+  if (statedBetween?.from) {
+    where = and(where, sql`${claims.statedAt} >= ${statedBetween.from}`);
+  }
+  if (statedBetween?.to) {
+    where = and(where, sql`${claims.statedAt} <= ${statedBetween.to}`);
+  }
+
+  const rows = await db
+    .select({
+      id: claims.id,
+      subjectNodeId: claims.subjectNodeId,
+      objectNodeId: claims.objectNodeId,
+      objectValue: claims.objectValue,
+      subjectLabel: subjectNodeMetadata.label,
+      objectLabel: objectNodeMetadata.label,
+      predicate: claims.predicate,
+      statement: claims.statement,
+      description: claims.description,
+      sourceId: claims.sourceId,
+      scope: claims.scope,
+      assertedByKind: claims.assertedByKind,
+      assertedByNodeId: claims.assertedByNodeId,
+      status: claims.status,
+      statedAt: claims.statedAt,
+      timestamp: claims.createdAt,
+      rank,
+      highlight,
+    })
+    .from(claims)
+    .leftJoin(
+      subjectNodeMetadata,
+      eq(subjectNodeMetadata.nodeId, claims.subjectNodeId),
+    )
+    .leftJoin(
+      objectNodeMetadata,
+      eq(objectNodeMetadata.nodeId, claims.objectNodeId),
+    )
+    .where(where)
+    .orderBy(desc(rank))
+    .limit(limit);
+
+  return rows.map((r) => ({ ...r, similarity: r.rank }));
 }

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -732,10 +732,14 @@ export async function findNodesByLexical(
   // declared on the Drizzle schema (so the ORM never enumerates it in
   // select/returning). Reference it by raw, table-qualified name.
   const rank = sql<number>`ts_rank_cd(node_metadata.search_tsv, ${tsq})`;
-  // word_similarity (not similarity): matches the query against the best-matching
-  // word in the label, so a short typo ("Boux") still matches a long label
-  // ("Boox Note Air 4C"). Full-string similarity() would score near-zero there.
-  const matched = sql`(node_metadata.search_tsv @@ ${tsq} OR word_similarity(${query}, ${nodeMetadata.label}) > 0.3)`;
+  // Fuzzy fallback via the `<%` (word_similarity) operator: matches the query
+  // against the best-matching word in the label, so a short typo ("Boux") still
+  // matches a long label ("Boox Note Air 4C"). Using the operator (not a bare
+  // `word_similarity(...) > 0.3` call) keeps the clause index-eligible — a
+  // non-indexable function in this OR would force a seq scan for the whole
+  // predicate, de-optimizing the tsvector path too. The threshold comes from
+  // the pg_trgm.word_similarity_threshold GUC, set per-transaction below.
+  const matched = sql`(node_metadata.search_tsv @@ ${tsq} OR ${query} <% ${nodeMetadata.label})`;
   const highlight = sql<string>`ts_headline('english', coalesce(${nodeMetadata.label}, '') || ' ' || coalesce(${nodeMetadata.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   let where = and(
@@ -749,23 +753,28 @@ export async function findNodesByLexical(
     where = and(where, notInArray(nodes.nodeType, excludeNodeTypes));
   }
 
-  const rows = await db
-    .select({
-      id: nodes.id,
-      type: nodes.nodeType,
-      label: nodeMetadata.label,
-      description: nodeMetadata.description,
-      timestamp: nodes.createdAt,
-      rank,
-      highlight,
-    })
-    .from(nodes)
-    .innerJoin(nodeMetadata, eq(nodes.id, nodeMetadata.nodeId))
-    .where(where)
-    .orderBy(desc(rank))
-    .limit(limit);
-
-  return rows.map((r) => ({ ...r, similarity: r.rank }));
+  // SET LOCAL is transaction-scoped, so lowering the word-similarity threshold
+  // to 0.3 (from the 0.6 default) for the `<%` operator never leaks across the
+  // pooled connection.
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL pg_trgm.word_similarity_threshold = 0.3`);
+    const rows = await tx
+      .select({
+        id: nodes.id,
+        type: nodes.nodeType,
+        label: nodeMetadata.label,
+        description: nodeMetadata.description,
+        timestamp: nodes.createdAt,
+        rank,
+        highlight,
+      })
+      .from(nodes)
+      .innerJoin(nodeMetadata, eq(nodes.id, nodeMetadata.nodeId))
+      .where(where)
+      .orderBy(desc(rank))
+      .limit(limit);
+    return rows.map((r) => ({ ...r, similarity: r.rank }));
+  });
 }
 
 /**
@@ -792,9 +801,10 @@ export async function findClaimsByLexical(
   const tsq = sql`websearch_to_tsquery('english', ${query})`;
   // search_tsv is a migration-managed generated column (see findNodesByLexical).
   const rank = sql<number>`ts_rank_cd(claims.search_tsv, ${tsq})`;
-  // word_similarity matches the query against the best-matching word in the
-  // statement (handles typos against long statements; see findNodesByLexical).
-  const matched = sql`(claims.search_tsv @@ ${tsq} OR word_similarity(${query}, ${claims.statement}) > 0.3)`;
+  // Fuzzy fallback via the `<%` (word_similarity) operator against the best
+  // word in the statement (index-eligible; threshold from the GUC set below).
+  // See findNodesByLexical for the rationale.
+  const matched = sql`(claims.search_tsv @@ ${tsq} OR ${query} <% ${claims.statement})`;
   const highlight = sql<string>`ts_headline('english', coalesce(${claims.statement}, '') || ' ' || coalesce(${claims.description}, ''), ${tsq}, 'StartSel=<mark>, StopSel=</mark>, MaxFragments=1')`;
 
   const subjectNodeMetadata = aliasedTable(nodeMetadata, "subjectNodeMetadata");
@@ -817,39 +827,43 @@ export async function findClaimsByLexical(
     where = and(where, sql`${claims.statedAt} <= ${statedBetween.to}`);
   }
 
-  const rows = await db
-    .select({
-      id: claims.id,
-      subjectNodeId: claims.subjectNodeId,
-      objectNodeId: claims.objectNodeId,
-      objectValue: claims.objectValue,
-      subjectLabel: subjectNodeMetadata.label,
-      objectLabel: objectNodeMetadata.label,
-      predicate: claims.predicate,
-      statement: claims.statement,
-      description: claims.description,
-      sourceId: claims.sourceId,
-      scope: claims.scope,
-      assertedByKind: claims.assertedByKind,
-      assertedByNodeId: claims.assertedByNodeId,
-      status: claims.status,
-      statedAt: claims.statedAt,
-      timestamp: claims.createdAt,
-      rank,
-      highlight,
-    })
-    .from(claims)
-    .leftJoin(
-      subjectNodeMetadata,
-      eq(subjectNodeMetadata.nodeId, claims.subjectNodeId),
-    )
-    .leftJoin(
-      objectNodeMetadata,
-      eq(objectNodeMetadata.nodeId, claims.objectNodeId),
-    )
-    .where(where)
-    .orderBy(desc(rank))
-    .limit(limit);
-
-  return rows.map((r) => ({ ...r, similarity: r.rank }));
+  // SET LOCAL keeps the lowered word-similarity threshold scoped to this
+  // transaction (see findNodesByLexical).
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL pg_trgm.word_similarity_threshold = 0.3`);
+    const rows = await tx
+      .select({
+        id: claims.id,
+        subjectNodeId: claims.subjectNodeId,
+        objectNodeId: claims.objectNodeId,
+        objectValue: claims.objectValue,
+        subjectLabel: subjectNodeMetadata.label,
+        objectLabel: objectNodeMetadata.label,
+        predicate: claims.predicate,
+        statement: claims.statement,
+        description: claims.description,
+        sourceId: claims.sourceId,
+        scope: claims.scope,
+        assertedByKind: claims.assertedByKind,
+        assertedByNodeId: claims.assertedByNodeId,
+        status: claims.status,
+        statedAt: claims.statedAt,
+        timestamp: claims.createdAt,
+        rank,
+        highlight,
+      })
+      .from(claims)
+      .leftJoin(
+        subjectNodeMetadata,
+        eq(subjectNodeMetadata.nodeId, claims.subjectNodeId),
+      )
+      .leftJoin(
+        objectNodeMetadata,
+        eq(objectNodeMetadata.nodeId, claims.objectNodeId),
+      )
+      .where(where)
+      .orderBy(desc(rank))
+      .limit(limit);
+    return rows.map((r) => ({ ...r, similarity: r.rank }));
+  });
 }

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -400,12 +400,17 @@ async function findSimilarNodesViaSubstring(
     limit = 10,
     excludeNodeTypes,
     includeReference = false,
+    scope,
   } = opts;
   const db = await useDatabase();
 
   let where = and(
     eq(nodes.userId, userId),
-    includeReference ? undefined : nodeHasScopeSupport(userId, "personal"),
+    scope
+      ? nodeHasScopeSupport(userId, scope)
+      : includeReference
+        ? undefined
+        : nodeHasScopeSupport(userId, "personal"),
     sql`lower(${nodeMetadata.label}) LIKE ${`%${query.toLowerCase()}%`}`,
   );
   if (excludeNodeTypes && excludeNodeTypes.length > 0) {
@@ -444,6 +449,7 @@ async function findSimilarClaimsViaSubstring(
     statuses = ["active"],
     asOf = new Date(),
     includeReference = false,
+    scope,
     includeAssistantInferred = false,
   } = opts;
   const db = await useDatabase();
@@ -453,7 +459,11 @@ async function findSimilarClaimsViaSubstring(
 
   const where = and(
     eq(claims.userId, userId),
-    includeReference ? undefined : eq(claims.scope, "personal"),
+    scope
+      ? eq(claims.scope, scope)
+      : includeReference
+        ? undefined
+        : eq(claims.scope, "personal"),
     includeAssistantInferred
       ? undefined
       : ne(claims.assertedByKind, "assistant_inferred"),

--- a/src/lib/schemas/search.test.ts
+++ b/src/lib/schemas/search.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { searchRequestSchema, searchResponseSchema } from "./search";
+
+describe("search schemas", () => {
+  it("applies defaults and rejects empty query", () => {
+    const parsed = searchRequestSchema.parse({ userId: "u", query: "boox" });
+    expect(parsed.limit).toBe(20);
+    expect(parsed.scope).toBe("personal");
+    expect(() => searchRequestSchema.parse({ userId: "u", query: "" })).toThrow();
+  });
+
+  it("accepts entityTypes and statedBetween filters", () => {
+    const parsed = searchRequestSchema.parse({
+      userId: "u",
+      query: "x",
+      filters: {
+        entityTypes: ["Person", "Task"],
+        statedBetween: { from: "2026-05-01T00:00:00Z" },
+      },
+    });
+    expect(parsed.filters?.entityTypes).toEqual(["Person", "Task"]);
+    expect(parsed.filters?.statedBetween?.from).toBeInstanceOf(Date);
+  });
+
+  it("validates a hit-shaped response", () => {
+    const ok = searchResponseSchema.parse({
+      query: "x",
+      hits: [
+        {
+          kind: "claim",
+          nodeId: "node_abc",
+          claimId: "claim_abc",
+          text: "The Boox syncs to Drive",
+          highlight: "The <mark>Boox</mark> syncs to Drive",
+          score: 0.123,
+          source: { sourceId: "src_abc", type: "manual" },
+          statedAt: "2026-05-10T00:00:00Z",
+        },
+      ],
+    });
+    expect(ok.hits[0]!.kind).toBe("claim");
+  });
+});

--- a/src/lib/schemas/search.test.ts
+++ b/src/lib/schemas/search.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from "vitest";
 import { searchRequestSchema, searchResponseSchema } from "./search";
+import { describe, expect, it } from "vitest";
 
 describe("search schemas", () => {
   it("applies defaults and rejects empty query", () => {
     const parsed = searchRequestSchema.parse({ userId: "u", query: "boox" });
     expect(parsed.limit).toBe(20);
     expect(parsed.scope).toBe("personal");
-    expect(() => searchRequestSchema.parse({ userId: "u", query: "" })).toThrow();
+    expect(() =>
+      searchRequestSchema.parse({ userId: "u", query: "" }),
+    ).toThrow();
   });
 
   it("accepts entityTypes and statedBetween filters", () => {

--- a/src/lib/schemas/search.ts
+++ b/src/lib/schemas/search.ts
@@ -1,0 +1,66 @@
+/**
+ * Request/response schemas for the hybrid explicit-search route (`POST /search`).
+ * Distinct from `/context/search` (card-shaped, semantic background context):
+ * this surface returns ranked hits with highlights for intentional lookups.
+ *
+ * Common aliases: search schema, explicit search, hybrid search, SearchHit.
+ */
+import { z } from "zod";
+import { NodeTypeEnum } from "~/types/graph.js";
+
+export const searchRequestSchema = z.object({
+  userId: z.string(),
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(50).optional().default(20),
+  scope: z.enum(["personal", "reference"]).optional().default("personal"),
+  filters: z
+    .object({
+      /** Restrict hits to these entity (node) types. */
+      entityTypes: z.array(NodeTypeEnum).optional(),
+      /** Restrict claim hits to this stated_at range (inclusive). */
+      statedBetween: z
+        .object({
+          from: z.coerce.date().optional(),
+          to: z.coerce.date().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+export type SearchRequest = z.infer<typeof searchRequestSchema>;
+
+const sourceTypeEnum = z.enum([
+  "conversation",
+  "conversation_message",
+  "document",
+  "legacy_migration",
+  "manual",
+  "meeting_transcript",
+  "external_conversation",
+  "metric_push",
+  "metric_manual",
+  "rollup",
+]);
+
+export const searchHitSchema = z.object({
+  kind: z.enum(["node", "claim"]),
+  nodeId: z.string(),
+  claimId: z.string().optional(),
+  text: z.string(),
+  highlight: z.string(),
+  score: z.number(),
+  source: z.object({
+    sourceId: z.string(),
+    type: sourceTypeEnum,
+    title: z.string().nullish(),
+    author: z.string().nullish(),
+  }),
+  statedAt: z.coerce.date().optional(),
+});
+export type SearchHit = z.infer<typeof searchHitSchema>;
+
+export const searchResponseSchema = z.object({
+  query: z.string(),
+  hits: z.array(searchHitSchema),
+});
+export type SearchResponse = z.infer<typeof searchResponseSchema>;

--- a/src/lib/schemas/search.ts
+++ b/src/lib/schemas/search.ts
@@ -28,6 +28,8 @@ export const searchRequestSchema = z.object({
     .optional(),
 });
 export type SearchRequest = z.infer<typeof searchRequestSchema>;
+/** Caller-facing input type: fields with schema defaults (limit, scope) are optional. */
+export type SearchRequestInput = z.input<typeof searchRequestSchema>;
 
 const sourceTypeEnum = z.enum([
   "conversation",

--- a/src/lib/search/explicit-search.test.ts
+++ b/src/lib/search/explicit-search.test.ts
@@ -1,0 +1,86 @@
+// src/lib/search/explicit-search.test.ts
+import "dotenv/config";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  generateTextEmbedding: vi.fn(),
+  findSimilarNodes: vi.fn(),
+  findSimilarClaims: vi.fn(),
+  findNodesByLexical: vi.fn(),
+  findClaimsByLexical: vi.fn(),
+}));
+
+vi.mock("~/lib/graph", () => ({
+  generateTextEmbedding: mocks.generateTextEmbedding,
+  findSimilarNodes: mocks.findSimilarNodes,
+  findSimilarClaims: mocks.findSimilarClaims,
+  findNodesByLexical: mocks.findNodesByLexical,
+  findClaimsByLexical: mocks.findClaimsByLexical,
+}));
+
+import { explicitSearch } from "./explicit-search";
+
+// Stub hydrator: maps src_1 -> a manual source. Injected so the pipeline never
+// touches the DB in this unit test.
+const stubHydrate = async (ids: string[]) =>
+  new Map(ids.map((id) => [id, { sourceId: id, type: "manual" as const }]));
+
+describe("explicitSearch", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("fuses legs, builds hits, and orders by fused score", async () => {
+    mocks.generateTextEmbedding.mockResolvedValue([0.1, 0.2]);
+    mocks.findSimilarNodes.mockResolvedValue([
+      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 0.9 },
+    ]);
+    mocks.findNodesByLexical.mockResolvedValue([
+      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 1, highlight: "<mark>Boox</mark>" },
+    ]);
+    mocks.findSimilarClaims.mockResolvedValue([]);
+    mocks.findClaimsByLexical.mockResolvedValue([
+      {
+        id: "claim_1", subjectNodeId: "node_1", objectNodeId: null, objectValue: "v",
+        subjectLabel: "Boox", objectLabel: null, predicate: "HAS_ATTRIBUTE",
+        statement: "Boox syncs", description: null, sourceId: "src_1", scope: "personal",
+        assertedByKind: "user", assertedByNodeId: null, status: "active",
+        statedAt: new Date("2026-05-10Z"), timestamp: new Date(), similarity: 1,
+        highlight: "<mark>Boox</mark> syncs",
+      },
+    ]);
+
+    const result = await explicitSearch(
+      { userId: "u", query: "Boox", limit: 20, scope: "personal" },
+      stubHydrate,
+    );
+
+    // node_1 appears in both node legs (high fused score) -> first.
+    expect(result.hits[0]!.kind).toBe("node");
+    expect(result.hits[0]!.nodeId).toBe("node_1");
+    expect(result.hits[0]!.source).toBeDefined(); // node provenance is a placeholder in v1
+    const claimHit = result.hits.find((h) => h.kind === "claim")!;
+    expect(claimHit.nodeId).toBe("node_1"); // owning subject
+    expect(claimHit.claimId).toBe("claim_1");
+    expect(claimHit.highlight).toContain("<mark>");
+    expect(claimHit.source.type).toBe("manual"); // from stubHydrate
+  });
+
+  it("forwards scope to every retrieval leg", async () => {
+    mocks.generateTextEmbedding.mockResolvedValue([0.1]);
+    mocks.findSimilarNodes.mockResolvedValue([]);
+    mocks.findNodesByLexical.mockResolvedValue([]);
+    mocks.findSimilarClaims.mockResolvedValue([]);
+    mocks.findClaimsByLexical.mockResolvedValue([]);
+
+    await explicitSearch(
+      { userId: "u", query: "x", limit: 20, scope: "reference" },
+      stubHydrate,
+    );
+
+    expect(mocks.findSimilarClaims).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "reference" }),
+    );
+    expect(mocks.findNodesByLexical).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "reference" }),
+    );
+  });
+});

--- a/src/lib/search/explicit-search.test.ts
+++ b/src/lib/search/explicit-search.test.ts
@@ -1,4 +1,5 @@
 // src/lib/search/explicit-search.test.ts
+import { explicitSearch } from "./explicit-search";
 import "dotenv/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -18,8 +19,6 @@ vi.mock("~/lib/graph", () => ({
   findClaimsByLexical: mocks.findClaimsByLexical,
 }));
 
-import { explicitSearch } from "./explicit-search";
-
 // Stub hydrator: maps src_1 -> a manual source. Injected so the pipeline never
 // touches the DB in this unit test.
 const stubHydrate = async (ids: string[]) =>
@@ -31,19 +30,46 @@ describe("explicitSearch", () => {
   it("fuses legs, builds hits, and orders by fused score", async () => {
     mocks.generateTextEmbedding.mockResolvedValue([0.1, 0.2]);
     mocks.findSimilarNodes.mockResolvedValue([
-      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 0.9 },
+      {
+        id: "node_1",
+        type: "Object",
+        label: "Boox",
+        description: null,
+        timestamp: new Date(),
+        similarity: 0.9,
+      },
     ]);
     mocks.findNodesByLexical.mockResolvedValue([
-      { id: "node_1", type: "Object", label: "Boox", description: null, timestamp: new Date(), similarity: 1, highlight: "<mark>Boox</mark>" },
+      {
+        id: "node_1",
+        type: "Object",
+        label: "Boox",
+        description: null,
+        timestamp: new Date(),
+        similarity: 1,
+        highlight: "<mark>Boox</mark>",
+      },
     ]);
     mocks.findSimilarClaims.mockResolvedValue([]);
     mocks.findClaimsByLexical.mockResolvedValue([
       {
-        id: "claim_1", subjectNodeId: "node_1", objectNodeId: null, objectValue: "v",
-        subjectLabel: "Boox", objectLabel: null, predicate: "HAS_ATTRIBUTE",
-        statement: "Boox syncs", description: null, sourceId: "src_1", scope: "personal",
-        assertedByKind: "user", assertedByNodeId: null, status: "active",
-        statedAt: new Date("2026-05-10Z"), timestamp: new Date(), similarity: 1,
+        id: "claim_1",
+        subjectNodeId: "node_1",
+        objectNodeId: null,
+        objectValue: "v",
+        subjectLabel: "Boox",
+        objectLabel: null,
+        predicate: "HAS_ATTRIBUTE",
+        statement: "Boox syncs",
+        description: null,
+        sourceId: "src_1",
+        scope: "personal",
+        assertedByKind: "user",
+        assertedByNodeId: null,
+        status: "active",
+        statedAt: new Date("2026-05-10Z"),
+        timestamp: new Date(),
+        similarity: 1,
         highlight: "<mark>Boox</mark> syncs",
       },
     ]);

--- a/src/lib/search/explicit-search.ts
+++ b/src/lib/search/explicit-search.ts
@@ -1,0 +1,198 @@
+// src/lib/search/explicit-search.ts
+/**
+ * Hybrid explicit-search pipeline: runs vector + lexical retrieval for nodes
+ * and claims in parallel, fuses each id space with RRF, merges into one ranked
+ * SearchHit list, and hydrates source provenance. Powers `POST /search`.
+ *
+ * Common aliases: hybrid search, explicit search, search pipeline, runSearch.
+ */
+import { inArray } from "drizzle-orm";
+import {
+  generateTextEmbedding,
+  findSimilarNodes,
+  findSimilarClaims,
+  findNodesByLexical,
+  findClaimsByLexical,
+  type NodeLexicalResult,
+  type ClaimLexicalResult,
+  type NodeSearchResult,
+  type ClaimSearchResult,
+} from "~/lib/graph";
+import { reciprocalRankFusion } from "./fusion";
+import { sources } from "~/db/schema";
+import { useDatabase } from "~/utils/db";
+import type { NodeType, Scope, SourceType } from "~/types/graph";
+import type { SearchHit, SearchResponse } from "~/lib/schemas/search";
+import type { TypeId } from "~/types/typeid";
+import { z } from "zod";
+
+export interface ExplicitSearchParams {
+  userId: string;
+  query: string;
+  limit: number;
+  scope: Scope;
+  filters?: {
+    entityTypes?: NodeType[];
+    statedBetween?: { from?: Date; to?: Date };
+  };
+}
+
+interface HitSource {
+  sourceId: string;
+  type: SourceType;
+  title?: string | null;
+  author?: string | null;
+}
+
+/** Document sources carry title/author in metadata; parse leniently. */
+const docMetaSchema = z
+  .object({ title: z.string().nullish(), author: z.string().nullish() })
+  .partial()
+  .passthrough();
+
+export type SourceHydrator = (
+  sourceIds: TypeId<"source">[],
+) => Promise<Map<string, HitSource>>;
+
+const dbHydrateSources: SourceHydrator = async (sourceIds) => {
+  const map = new Map<string, HitSource>();
+  if (sourceIds.length === 0) return map;
+  const db = await useDatabase();
+  const rows = await db
+    .select({
+      id: sources.id,
+      type: sources.type,
+      metadata: sources.metadata,
+    })
+    .from(sources)
+    .where(inArray(sources.id, sourceIds));
+  for (const row of rows) {
+    const meta = docMetaSchema.safeParse(row.metadata ?? {});
+    map.set(row.id, {
+      sourceId: row.id,
+      type: row.type,
+      title: meta.success ? (meta.data.title ?? null) : null,
+      author: meta.success ? (meta.data.author ?? null) : null,
+    });
+  }
+  return map;
+};
+
+export async function explicitSearch(
+  params: ExplicitSearchParams,
+  hydrate: SourceHydrator = dbHydrateSources,
+): Promise<SearchResponse> {
+  const { userId, query, limit, scope, filters } = params;
+  const includeNodeTypes = filters?.entityTypes;
+  const statedBetween = filters?.statedBetween;
+  const legLimit = Math.max(limit * 2, 20);
+
+  const embedding = await generateTextEmbedding(query);
+
+  const [vecNodes, lexNodes, vecClaims, lexClaims]: [
+    NodeSearchResult[],
+    NodeLexicalResult[],
+    ClaimSearchResult[],
+    ClaimLexicalResult[],
+  ] = await Promise.all([
+    findSimilarNodes({
+      userId,
+      embedding,
+      limit: legLimit,
+      scope,
+      ...(includeNodeTypes ? { includeNodeTypes } : {}),
+    }),
+    findNodesByLexical({
+      userId,
+      query,
+      limit: legLimit,
+      scope,
+      ...(includeNodeTypes ? { includeNodeTypes } : {}),
+    }),
+    findSimilarClaims({
+      userId,
+      embedding,
+      limit: legLimit,
+      scope,
+      ...(statedBetween ? { statedBetween } : {}),
+    }),
+    findClaimsByLexical({
+      userId,
+      query,
+      limit: legLimit,
+      scope,
+      ...(statedBetween ? { statedBetween } : {}),
+    }),
+  ]);
+
+  const nodeFusion = reciprocalRankFusion([
+    vecNodes.map((n) => n.id),
+    lexNodes.map((n) => n.id),
+  ]);
+  const claimFusion = reciprocalRankFusion([
+    vecClaims.map((c) => c.id),
+    lexClaims.map((c) => c.id),
+  ]);
+
+  // Index rows for hit assembly. Lexical rows carry highlights; prefer them.
+  const nodeById = new Map<string, NodeSearchResult | NodeLexicalResult>();
+  for (const n of vecNodes) nodeById.set(n.id, n);
+  for (const n of lexNodes) nodeById.set(n.id, n);
+  const nodeHighlight = new Map(lexNodes.map((n) => [n.id, n.highlight]));
+
+  const claimById = new Map<string, ClaimSearchResult | ClaimLexicalResult>();
+  for (const c of vecClaims) claimById.set(c.id, c);
+  for (const c of lexClaims) claimById.set(c.id, c);
+  const claimHighlight = new Map(lexClaims.map((c) => [c.id, c.highlight]));
+
+  const claimSourceIds = claimFusion
+    .map((f) => claimById.get(f.id)?.sourceId)
+    .filter((s): s is TypeId<"source"> => Boolean(s));
+  const sourceMap = await hydrate(claimSourceIds);
+
+  const nodeHits: SearchHit[] = nodeFusion.flatMap((f) => {
+    const row = nodeById.get(f.id);
+    if (!row) return [];
+    return [
+      {
+        kind: "node",
+        nodeId: row.id,
+        text: row.label ?? "",
+        highlight: nodeHighlight.get(row.id) ?? row.label ?? "",
+        score: f.score,
+        // Node provenance is a v1 placeholder (a node has many sources); the
+        // UI fetches full provenance via get_entity when needed.
+        source: { sourceId: "", type: "manual" },
+      },
+    ];
+  });
+
+  const claimHits: SearchHit[] = claimFusion.flatMap((f) => {
+    const row = claimById.get(f.id);
+    if (!row) return [];
+    const source: HitSource = sourceMap.get(row.sourceId) ?? {
+      sourceId: row.sourceId,
+      type: "manual",
+      title: null,
+      author: null,
+    };
+    return [
+      {
+        kind: "claim",
+        nodeId: row.subjectNodeId,
+        claimId: row.id,
+        text: row.statement,
+        highlight: claimHighlight.get(row.id) ?? row.statement,
+        score: f.score,
+        source,
+        statedAt: row.statedAt,
+      },
+    ];
+  });
+
+  const hits = [...nodeHits, ...claimHits]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return { query, hits };
+}

--- a/src/lib/search/explicit-search.ts
+++ b/src/lib/search/explicit-search.ts
@@ -140,9 +140,14 @@ export async function explicitSearch(
   for (const c of lexClaims) claimById.set(c.id, c);
   const claimHighlight = new Map(lexClaims.map((c) => [c.id, c.highlight]));
 
-  const claimSourceIds = claimFusion
-    .map((f) => claimById.get(f.id)?.sourceId)
-    .filter((s): s is TypeId<"source"> => Boolean(s));
+  // Dedupe: many claims can share one source, and hydrate() queries by id.
+  const claimSourceIds = Array.from(
+    new Set(
+      claimFusion
+        .map((f) => claimById.get(f.id)?.sourceId)
+        .filter((s): s is TypeId<"source"> => Boolean(s)),
+    ),
+  );
   const sourceMap = await hydrate(claimSourceIds);
 
   const nodeHits: SearchHit[] = nodeFusion.flatMap((f) => {
@@ -185,8 +190,15 @@ export async function explicitSearch(
     ];
   });
 
+  // Deterministic tie-break (claims can share a subject nodeId, so fall through
+  // to claimId) keeps ordering stable across runs when fused scores collide.
   const hits = [...nodeHits, ...claimHits]
-    .sort((a, b) => b.score - a.score)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.nodeId.localeCompare(b.nodeId) ||
+        (a.claimId ?? "").localeCompare(b.claimId ?? ""),
+    )
     .slice(0, limit);
 
   return { query, hits };

--- a/src/lib/search/explicit-search.ts
+++ b/src/lib/search/explicit-search.ts
@@ -6,7 +6,10 @@
  *
  * Common aliases: hybrid search, explicit search, search pipeline, runSearch.
  */
+import { reciprocalRankFusion } from "./fusion";
 import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { sources } from "~/db/schema";
 import {
   generateTextEmbedding,
   findSimilarNodes,
@@ -18,13 +21,14 @@ import {
   type NodeSearchResult,
   type ClaimSearchResult,
 } from "~/lib/graph";
-import { reciprocalRankFusion } from "./fusion";
-import { sources } from "~/db/schema";
-import { useDatabase } from "~/utils/db";
+import type {
+  SearchHit,
+  SearchRequest,
+  SearchResponse,
+} from "~/lib/schemas/search";
 import type { SourceType } from "~/types/graph";
-import type { SearchHit, SearchRequest, SearchResponse } from "~/lib/schemas/search";
 import type { TypeId } from "~/types/typeid";
-import { z } from "zod";
+import { useDatabase } from "~/utils/db";
 
 export type ExplicitSearchParams = SearchRequest;
 

--- a/src/lib/search/explicit-search.ts
+++ b/src/lib/search/explicit-search.ts
@@ -21,21 +21,12 @@ import {
 import { reciprocalRankFusion } from "./fusion";
 import { sources } from "~/db/schema";
 import { useDatabase } from "~/utils/db";
-import type { NodeType, Scope, SourceType } from "~/types/graph";
-import type { SearchHit, SearchResponse } from "~/lib/schemas/search";
+import type { SourceType } from "~/types/graph";
+import type { SearchHit, SearchRequest, SearchResponse } from "~/lib/schemas/search";
 import type { TypeId } from "~/types/typeid";
 import { z } from "zod";
 
-export interface ExplicitSearchParams {
-  userId: string;
-  query: string;
-  limit: number;
-  scope: Scope;
-  filters?: {
-    entityTypes?: NodeType[];
-    statedBetween?: { from?: Date; to?: Date };
-  };
-}
+export type ExplicitSearchParams = SearchRequest;
 
 interface HitSource {
   sourceId: string;

--- a/src/lib/search/fusion.test.ts
+++ b/src/lib/search/fusion.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { reciprocalRankFusion, RRF_K } from "./fusion";
+import { describe, expect, it } from "vitest";
 
 describe("reciprocalRankFusion", () => {
   it("sums 1/(k+rank) across rankings and sorts descending", () => {

--- a/src/lib/search/fusion.test.ts
+++ b/src/lib/search/fusion.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { reciprocalRankFusion, RRF_K } from "./fusion";
+
+describe("reciprocalRankFusion", () => {
+  it("sums 1/(k+rank) across rankings and sorts descending", () => {
+    // id "a": rank 0 in list1, rank 1 in list2
+    // id "b": rank 1 in list1, rank 0 in list2
+    // both symmetric -> equal scores; tie broken by id ascending
+    const fused = reciprocalRankFusion([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+    expect(fused.map((f) => f.id)).toEqual(["a", "b"]);
+    const expectedScore = 1 / (RRF_K + 0) + 1 / (RRF_K + 1);
+    expect(fused[0]!.score).toBeCloseTo(expectedScore, 10);
+  });
+
+  it("ranks an id appearing high in both lists above a single-list id", () => {
+    const fused = reciprocalRankFusion([
+      ["x", "y", "z"],
+      ["x", "w"],
+    ]);
+    expect(fused[0]!.id).toBe("x");
+  });
+
+  it("handles empty rankings", () => {
+    expect(reciprocalRankFusion([])).toEqual([]);
+    expect(reciprocalRankFusion([[], []])).toEqual([]);
+  });
+
+  it("deduplicates ids within a single ranking by best (first) rank", () => {
+    const fused = reciprocalRankFusion([["a", "a", "b"]]);
+    const a = fused.find((f) => f.id === "a")!;
+    expect(a.score).toBeCloseTo(1 / (RRF_K + 0), 10);
+  });
+});

--- a/src/lib/search/fusion.ts
+++ b/src/lib/search/fusion.ts
@@ -1,0 +1,37 @@
+/**
+ * Reciprocal Rank Fusion (RRF) — merges several independent rankings of the
+ * same id space into one ranking without normalising heterogeneous scores.
+ * Each id scores Σ 1/(k + rank) over the lists it appears in.
+ *
+ * Common aliases: rrf, rank fusion, hybrid search fusion, mergeRankings.
+ */
+
+/** Standard RRF constant; dampens the contribution of low ranks. */
+export const RRF_K = 60;
+
+export interface FusedResult {
+  id: string;
+  score: number;
+}
+
+/**
+ * @param rankings Ordered id lists (index 0 = best). An id repeated within a
+ *   single list contributes only its first (best) rank.
+ */
+export function reciprocalRankFusion(
+  rankings: readonly (readonly string[])[],
+  k: number = RRF_K,
+): FusedResult[] {
+  const scores = new Map<string, number>();
+  for (const ranking of rankings) {
+    const seen = new Set<string>();
+    ranking.forEach((id, rank) => {
+      if (seen.has(id)) return;
+      seen.add(id);
+      scores.set(id, (scores.get(id) ?? 0) + 1 / (k + rank));
+    });
+  }
+  return [...scores.entries()]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : 1));
+}

--- a/src/lib/search/lexical.test.ts
+++ b/src/lib/search/lexical.test.ts
@@ -1,0 +1,99 @@
+import "dotenv/config";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createMigratedTestDb, isServerReachable } from "./test-db";
+import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
+import { nodes, nodeMetadata, claims, sources, users } from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+import type { MigratedTestDb } from "./test-db";
+
+const SERVER = await isServerReachable();
+const d = SERVER ? describe : describe.skip;
+
+d("lexical retrieval", () => {
+  let h: MigratedTestDb;
+  const userId = "user_lex";
+
+  beforeAll(async () => {
+    h = await createMigratedTestDb(
+      `memory_lex_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`,
+    );
+    const { db } = h;
+    await db.insert(users).values({ id: userId });
+
+    // Source for personal claims.
+    const srcId = newTypeId("source");
+    await db.insert(sources).values({
+      id: srcId,
+      userId,
+      type: "manual",
+      externalId: "ext_lex_1",
+      scope: "personal",
+    });
+
+    // Node "Boox Note Air" (personal via a claim referencing it).
+    const booxId = newTypeId("node");
+    await db.insert(nodes).values({
+      id: booxId,
+      userId,
+      nodeType: "Object",
+    });
+    await db.insert(nodeMetadata).values({
+      id: newTypeId("node_metadata"),
+      nodeId: booxId,
+      label: "Boox Note Air 4C",
+      canonicalLabel: "boox note air 4c",
+      description: "e-ink tablet",
+    });
+
+    // A claim mentioning Boox, stated 2026-05-10.
+    await db.insert(claims).values({
+      id: newTypeId("claim"),
+      userId,
+      subjectNodeId: booxId,
+      objectValue: "syncs handwriting to Drive",
+      predicate: "HAS_ATTRIBUTE",
+      statement: "The Boox Note Air syncs handwriting to Google Drive",
+      sourceId: srcId,
+      scope: "personal",
+      assertedByKind: "user",
+      statedAt: new Date("2026-05-10T00:00:00Z"),
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await h.drop();
+  });
+
+  it("matches an exact keyword and returns a highlight", async () => {
+    const rows = await findClaimsByLexical({ userId, query: "Boox", limit: 10 });
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]!.statement).toContain("Boox");
+    expect(rows[0]!.highlight).toMatch(/<mark>|Boox/);
+  });
+
+  it("matches a node label via trigram despite a typo", async () => {
+    const rows = await findNodesByLexical({ userId, query: "Boux", limit: 10 });
+    expect(rows.some((r) => r.label === "Boox Note Air 4C")).toBe(true);
+  });
+
+  it("filters claims by stated_at range", async () => {
+    const inRange = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      statedBetween: { from: new Date("2026-05-01Z"), to: new Date("2026-05-31Z") },
+    });
+    expect(inRange.length).toBeGreaterThan(0);
+    const outOfRange = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      statedBetween: { from: new Date("2026-01-01Z"), to: new Date("2026-02-01Z") },
+    });
+    expect(outOfRange.length).toBe(0);
+  });
+
+  it("does not return reference claims for a personal query", async () => {
+    const rows = await findClaimsByLexical({ userId, query: "Boox" });
+    expect(rows.every((r) => r.scope === "personal")).toBe(true);
+  });
+});

--- a/src/lib/search/lexical.test.ts
+++ b/src/lib/search/lexical.test.ts
@@ -1,10 +1,10 @@
+import { createMigratedTestDb, isServerReachable } from "./test-db";
+import type { MigratedTestDb } from "./test-db";
 import "dotenv/config";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createMigratedTestDb, isServerReachable } from "./test-db";
-import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
 import { nodes, nodeMetadata, claims, sources, users } from "~/db/schema";
+import { findClaimsByLexical, findNodesByLexical } from "~/lib/graph";
 import { newTypeId } from "~/types/typeid";
-import type { MigratedTestDb } from "./test-db";
 
 const SERVER = await isServerReachable();
 const d = SERVER ? describe : describe.skip;
@@ -66,7 +66,11 @@ d("lexical retrieval", () => {
   });
 
   it("matches an exact keyword and returns a highlight", async () => {
-    const rows = await findClaimsByLexical({ userId, query: "Boox", limit: 10 });
+    const rows = await findClaimsByLexical({
+      userId,
+      query: "Boox",
+      limit: 10,
+    });
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0]!.statement).toContain("Boox");
     expect(rows[0]!.highlight).toMatch(/<mark>|Boox/);
@@ -81,13 +85,19 @@ d("lexical retrieval", () => {
     const inRange = await findClaimsByLexical({
       userId,
       query: "Boox",
-      statedBetween: { from: new Date("2026-05-01Z"), to: new Date("2026-05-31Z") },
+      statedBetween: {
+        from: new Date("2026-05-01Z"),
+        to: new Date("2026-05-31Z"),
+      },
     });
     expect(inRange.length).toBeGreaterThan(0);
     const outOfRange = await findClaimsByLexical({
       userId,
       query: "Boox",
-      statedBetween: { from: new Date("2026-01-01Z"), to: new Date("2026-02-01Z") },
+      statedBetween: {
+        from: new Date("2026-01-01Z"),
+        to: new Date("2026-02-01Z"),
+      },
     });
     expect(outOfRange.length).toBe(0);
   });

--- a/src/lib/search/test-db.ts
+++ b/src/lib/search/test-db.ts
@@ -6,12 +6,12 @@
  * Common aliases: createMigratedTestDb, search test database, hybrid search
  * test setup.
  */
-import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
+import pg from "pg";
+import type { DrizzleDB } from "~/db";
 import * as schema from "~/db/schema";
 import { setTestDatabase } from "~/utils/db";
-import type { DrizzleDB } from "~/db";
 
 const HOST = process.env["TEST_PG_HOST"] ?? "localhost";
 const PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);

--- a/src/lib/search/test-db.ts
+++ b/src/lib/search/test-db.ts
@@ -1,0 +1,76 @@
+/**
+ * Test-only helper: provision a fresh Postgres database, run all Drizzle
+ * migrations against it (so generated tsvector columns and pg_trgm indexes
+ * exist exactly as in production), and register it as the global db handle.
+ *
+ * Common aliases: createMigratedTestDb, search test database, hybrid search
+ * test setup.
+ */
+import pg from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import * as schema from "~/db/schema";
+import { setTestDatabase } from "~/utils/db";
+import type { DrizzleDB } from "~/db";
+
+const HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const USER = process.env["TEST_PG_USER"] ?? "postgres";
+const PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+export const adminDsn = (): string =>
+  `postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${ADMIN_DB}`;
+const dsnFor = (db: string): string =>
+  `postgres://${USER}:${PASSWORD}@${HOST}:${PORT}/${db}`;
+
+export interface MigratedTestDb {
+  db: DrizzleDB;
+  client: pg.Client;
+  drop: () => Promise<void>;
+}
+
+export async function isServerReachable(): Promise<boolean> {
+  const client = new pg.Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function createMigratedTestDb(
+  dbName: string,
+): Promise<MigratedTestDb> {
+  const admin = new pg.Client({ connectionString: adminDsn() });
+  await admin.connect();
+  await admin.query(`CREATE DATABASE "${dbName}"`);
+  await admin.end();
+
+  const client = new pg.Client({ connectionString: dsnFor(dbName) });
+  await client.connect();
+  const db = drizzle(client, {
+    schema,
+    casing: "snake_case",
+  }) as unknown as DrizzleDB;
+  await migrate(db, { migrationsFolder: "./drizzle" });
+  setTestDatabase(db);
+
+  const drop = async (): Promise<void> => {
+    setTestDatabase(null);
+    await client.end();
+    const a = new pg.Client({ connectionString: adminDsn() });
+    await a.connect();
+    await a.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await a.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await a.end();
+  };
+
+  return { db, client, drop };
+}

--- a/src/lib/search/test-db.ts
+++ b/src/lib/search/test-db.ts
@@ -6,6 +6,10 @@
  * Common aliases: createMigratedTestDb, search test database, hybrid search
  * test setup.
  */
+// Load .env before importing ~/utils/db, which parses env eagerly at module
+// load. Without this, running a search DB test in isolation fails env
+// validation (it otherwise only worked when another suite loaded env first).
+import "dotenv/config";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import pg from "pg";

--- a/src/routes/search.post.ts
+++ b/src/routes/search.post.ts
@@ -12,11 +12,11 @@
 // `readBody` is deliberately NOT imported: Nitro auto-imports it globally,
 // which is what lets the route test stub it via vi.stubGlobal.
 import { defineEventHandler } from "h3";
-import { explicitSearch } from "~/lib/search/explicit-search";
 import {
   searchRequestSchema,
   searchResponseSchema,
 } from "~/lib/schemas/search";
+import { explicitSearch } from "~/lib/search/explicit-search";
 
 export default defineEventHandler(async (event) => {
   const { userId, query, limit, scope, filters } = searchRequestSchema.parse(

--- a/src/routes/search.post.ts
+++ b/src/routes/search.post.ts
@@ -1,0 +1,29 @@
+/**
+ * `POST /search` — hybrid explicit-search route.
+ *
+ * The intentional-lookup surface: a human typing in a search box, or an
+ * assistant deliberately looking something up. Fuses lexical (tsvector +
+ * pg_trgm) and vector retrieval (RRF) and returns ranked hits with highlights.
+ *
+ * Distinct from `POST /context/search` (semantic, card-shaped, auto-injected
+ * background context) and the legacy `POST /query/search` (raw graph for
+ * visualization). See docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md.
+ */
+// `readBody` is deliberately NOT imported: Nitro auto-imports it globally,
+// which is what lets the route test stub it via vi.stubGlobal.
+import { defineEventHandler } from "h3";
+import { explicitSearch } from "~/lib/search/explicit-search";
+import {
+  searchRequestSchema,
+  searchResponseSchema,
+} from "~/lib/schemas/search";
+
+export default defineEventHandler(async (event) => {
+  const { userId, query, limit, scope, filters } = searchRequestSchema.parse(
+    await readBody(event),
+  );
+
+  const result = await explicitSearch({ userId, query, limit, scope, filters });
+
+  return searchResponseSchema.parse(result);
+});

--- a/src/sdk/memory-client-search.test.ts
+++ b/src/sdk/memory-client-search.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryClient } from "./memory-client";
+
+describe("MemoryClient.search", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("POSTs to /search and parses the hit-shaped response", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        query: "Boox",
+        hits: [
+          {
+            kind: "node",
+            nodeId: "node_1",
+            text: "Boox",
+            highlight: "<mark>Boox</mark>",
+            score: 0.4,
+            source: { sourceId: "src_1", type: "manual" },
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new MemoryClient({ baseUrl: "http://memory.test" });
+    const res = await client.search({ userId: "u", query: "Boox" });
+
+    expect(res.hits[0]!.nodeId).toBe("node_1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://memory.test/search",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/src/sdk/memory-client-search.test.ts
+++ b/src/sdk/memory-client-search.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryClient } from "./memory-client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("MemoryClient.search", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -48,6 +48,11 @@ import {
   bootstrapMemoryRequestSchema,
 } from "../lib/schemas/context.js";
 import {
+  searchResponseSchema,
+  type SearchRequest,
+  type SearchResponse,
+} from "../lib/schemas/search.js";
+import {
   CreateCommitmentRequest,
   CreateCommitmentResponse,
   createCommitmentResponseSchema,
@@ -470,6 +475,16 @@ export class MemoryClient {
       contextSearchResponseSchema,
       payload,
     );
+  }
+
+  /**
+   * Hybrid explicit search: lexical + vector retrieval fused with RRF, returning
+   * ranked hits with highlights. Use for intentional lookups (a search box, or
+   * the assistant deliberately looking something up) — not for automatic
+   * conversation context, which is `contextSearch`.
+   */
+  async search(payload: SearchRequest): Promise<SearchResponse> {
+    return this._fetch("POST", "/search", searchResponseSchema, payload);
   }
 
   async queryAtlas(payload: QueryAtlasRequest): Promise<QueryAtlasResponse> {

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -49,7 +49,7 @@ import {
 } from "../lib/schemas/context.js";
 import {
   searchResponseSchema,
-  type SearchRequest,
+  type SearchRequestInput,
   type SearchResponse,
 } from "../lib/schemas/search.js";
 import {
@@ -483,7 +483,7 @@ export class MemoryClient {
    * the assistant deliberately looking something up) — not for automatic
    * conversation context, which is `contextSearch`.
    */
-  async search(payload: SearchRequest): Promise<SearchResponse> {
+  async search(payload: SearchRequestInput): Promise<SearchResponse> {
     return this._fetch("POST", "/search", searchResponseSchema, payload);
   }
 

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -48,11 +48,6 @@ import {
   bootstrapMemoryRequestSchema,
 } from "../lib/schemas/context.js";
 import {
-  searchResponseSchema,
-  type SearchRequestInput,
-  type SearchResponse,
-} from "../lib/schemas/search.js";
-import {
   CreateCommitmentRequest,
   CreateCommitmentResponse,
   createCommitmentResponseSchema,
@@ -236,6 +231,11 @@ import {
   scratchpadResponseSchema,
   scratchpadEditResponseSchema,
 } from "../lib/schemas/scratchpad.js";
+import {
+  searchResponseSchema,
+  type SearchRequestInput,
+  type SearchResponse,
+} from "../lib/schemas/search.js";
 import {
   SetCommitmentDueRequest,
   SetCommitmentDueResponse,

--- a/src/search-route.test.ts
+++ b/src/search-route.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+
+const mocks = vi.hoisted(() => ({ explicitSearch: vi.fn() }));
+vi.mock("~/lib/search/explicit-search", () => ({
+  explicitSearch: mocks.explicitSearch,
+}));
+
+import handler from "./routes/search.post";
+import { searchResponseSchema } from "~/lib/schemas/search";
+
+describe("POST /search", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("validates the request, calls the pipeline, and round-trips the response", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "u", query: "Boox" }));
+    mocks.explicitSearch.mockResolvedValue({
+      query: "Boox",
+      hits: [
+        {
+          kind: "claim",
+          nodeId: "node_1",
+          claimId: "claim_1",
+          text: "Boox syncs",
+          highlight: "<mark>Boox</mark> syncs",
+          score: 0.5,
+          source: { sourceId: "src_1", type: "manual" },
+          statedAt: new Date("2026-05-10Z"),
+        },
+      ],
+    });
+
+    const response = searchResponseSchema.parse(await handler({} as H3Event));
+    expect(response.hits).toHaveLength(1);
+    expect(mocks.explicitSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u", query: "Boox", limit: 20, scope: "personal" }),
+    );
+  });
+
+  it("rejects an empty query", async () => {
+    vi.stubGlobal("readBody", async () => ({ userId: "u", query: "" }));
+    await expect(handler({} as H3Event)).rejects.toThrow();
+  });
+});

--- a/src/search-route.test.ts
+++ b/src/search-route.test.ts
@@ -1,13 +1,12 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import handler from "./routes/search.post";
 import type { H3Event } from "h3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { searchResponseSchema } from "~/lib/schemas/search";
 
 const mocks = vi.hoisted(() => ({ explicitSearch: vi.fn() }));
 vi.mock("~/lib/search/explicit-search", () => ({
   explicitSearch: mocks.explicitSearch,
 }));
-
-import handler from "./routes/search.post";
-import { searchResponseSchema } from "~/lib/schemas/search";
 
 describe("POST /search", () => {
   afterEach(() => {
@@ -36,7 +35,12 @@ describe("POST /search", () => {
     const response = searchResponseSchema.parse(await handler({} as H3Event));
     expect(response.hits).toHaveLength(1);
     expect(mocks.explicitSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "u", query: "Boox", limit: 20, scope: "personal" }),
+      expect.objectContaining({
+        userId: "u",
+        query: "Boox",
+        limit: 20,
+        scope: "personal",
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

Adds a dedicated **hybrid (lexical + vector) explicit-search** endpoint `POST /search` to the memory service, drawing a clear boundary between the two retrieval intents:

- **`/context/*`** = what the system pulls in *automatically* (semantic, card-shaped background context) — unchanged.
- **`POST /search`** (new) = what a human or assistant asks for *on purpose* — hybrid, returns ranked hits with highlights.
- **`/query/search`** (legacy) = graph visualization — unchanged.

**Engine:** native Postgres `tsvector` + GIN (keyword/phrase) and `pg_trgm` `word_similarity` (fuzzy/typo) fused with the existing pgvector HNSW via **Reciprocal Rank Fusion**. No new infrastructure beyond the `pg_trgm` extension.

**Highlights of the design:**
- `search_tsv` is a **migration-managed shadow column** (generated `STORED` tsvector + GIN indexes), intentionally *not* declared in the Drizzle schema — so the ORM never enumerates it and the many tests that build their DB from hand-written DDL are unaffected.
- `scope` (`personal`/`reference`) is a **hard boundary** end-to-end — never blended — including in the eval-only substring seam.
- The `0.4` cosine floor is **not** applied on this path (explicit search ranks rather than thresholds).
- v1 facets: **entity type** + **time range** (claim hits). Reranking is a documented off-by-default seam.
- New `MemoryClient.search()` SDK method.

Spec: `docs/superpowers/specs/2026-06-16-hybrid-explicit-search-design.md`
Plan: `docs/superpowers/plans/2026-06-16-hybrid-explicit-search.md`

## Deferred (separate follow-on, cross-repo)
Petals manual-explorer migration onto `search()`, the `n8n-nodes-petals` operation + Petals proxy endpoint, and an optional assistant MCP `search_text` tool.

## Test Plan
- [x] `pnpm run build:check` (tsc + structured-output schemas) — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format` — clean
- [x] `pnpm test` — **500 passed / 100 files** (lexical/DB suite runs on :5431, not skipped)
- [x] `pnpm run build-sdk` — clean
- [x] `pnpm drizzle:generate` — no drift
- [ ] Reviewer: confirm scope hard-boundary and that the background-context path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)