### PR TITLE
✨ feat(identity): same-name disambiguation & user-self identity resolution

### DIFF
--- a/docs/superpowers/plans/2026-06-17-same-name-identity-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-17-same-name-identity-disambiguation.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Stop the knowledge graph from attributing the user's own statements (and other people's) to the wrong same-named node by giving the user-self node a distinguishing identity, wiring transcript speakers in as claim *subjects*, and making the resolver refuse to guess on ambiguous name ties.
+**Goal:** Stop the knowledge graph from attributing the user's own statements (and other people's) to the wrong same-named node by giving the user-self node a distinguishing identity, wiring transcript speakers in as claim _subjects_, and making the resolver refuse to guess on ambiguous name ties.
 
-**Architecture:** Four components in leverage order. (1) **Self-node hygiene** — a new `src/lib/user-self-identity.ts` module names the self node with the user's full name and seeds only multi-token aliases; called from both the config endpoint and transcript ingest. (2) **Subject-wiring** — `extractGraph` registers transcript speaker nodes into `idMap` and the prompt tells the model to use the user-self speaker's nodeId as the subject of first-person claims. (3) **Resolver never guesses** — `resolveIdentity` resolves only on a *unique* canonical/alias match; >1 match splits + logs `identity.ambiguous_skip`. (4) **Prompt insurance** — inject "who the user is" into document/conversation prompts and add a static anti-conflation rule.
+**Architecture:** Four components in leverage order. (1) **Self-node hygiene** — a new `src/lib/user-self-identity.ts` module names the self node with the user's full name and seeds only multi-token aliases; called from both the config endpoint and transcript ingest. (2) **Subject-wiring** — `extractGraph` registers transcript speaker nodes into `idMap` and the prompt tells the model to use the user-self speaker's nodeId as the subject of first-person claims. (3) **Resolver never guesses** — `resolveIdentity` resolves only on a _unique_ canonical/alias match; >1 match splits + logs `identity.ambiguous_skip`. (4) **Prompt insurance** — inject "who the user is" into document/conversation prompts and add a static anti-conflation rule.
 
 **Tech Stack:** TypeScript (strict, `exactOptionalPropertyTypes`), Drizzle ORM, Postgres (+pgvector), Zod, h3/Nitro file-based routes, Vitest (real-Postgres integration tests on port **5431**). Spec: `docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md`.
 
@@ -14,28 +14,28 @@
 
 **New files**
 
-| File | Responsibility |
-| --- | --- |
-| `src/lib/user-self-identity.ts` | User-self Person node identity: lazy creation, primary-label selection, distinguishing-alias seeding, `buildUserIdentityNote`. Pure helpers + DB helpers. |
-| `src/lib/user-self-identity.test.ts` | Unit tests: pure helpers (no DB) + `ensureUserSelfIdentity` (DB). |
-| `src/lib/jobs/backfill-user-self-identity.ts` | One-off maintenance: bring an existing self node to the new contract; remove bare self alias. |
-| `src/lib/schemas/backfill-user-self-identity.ts` | Request/response Zod schemas for the backfill route. |
-| `src/routes/maintenance/backfill-user-self-identity.post.ts` | HTTP trigger for the backfill job (Nitro auto-routed). |
+| File                                                         | Responsibility                                                                                                                                            |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/user-self-identity.ts`                              | User-self Person node identity: lazy creation, primary-label selection, distinguishing-alias seeding, `buildUserIdentityNote`. Pure helpers + DB helpers. |
+| `src/lib/user-self-identity.test.ts`                         | Unit tests: pure helpers (no DB) + `ensureUserSelfIdentity` (DB).                                                                                         |
+| `src/lib/jobs/backfill-user-self-identity.ts`                | One-off maintenance: bring an existing self node to the new contract; remove bare self alias.                                                             |
+| `src/lib/schemas/backfill-user-self-identity.ts`             | Request/response Zod schemas for the backfill route.                                                                                                      |
+| `src/routes/maintenance/backfill-user-self-identity.post.ts` | HTTP trigger for the backfill job (Nitro auto-routed).                                                                                                    |
 
 **Modified files**
 
-| File | Change |
-| --- | --- |
-| `src/lib/transcript/resolve-speakers.ts` | Import `ensureUserSelfPersonNode` from the new module; delete the local copy; stop writing the bare self alias; drop now-unused `sql` import. |
-| `src/lib/user-profile.ts` | `setUserSelfAliases` calls `ensureUserSelfIdentity` after persisting. |
-| `src/lib/jobs/ingest-transcript.ts` | Call `ensureUserSelfIdentity` with the effective alias list before resolving speakers. |
-| `src/lib/extract-graph.ts` | Register speaker nodes into `idMap`; subject-wiring in `_formatSpeakerMapSection` + static few-shot; static anti-conflation rule; new `userIdentityNote` param + render. |
-| `src/lib/identity-resolution.ts` | Unique-match-wins; `ambiguous` trace field; `identity.ambiguous_skip` log. |
-| `src/lib/jobs/ingest-conversation.ts` | Build + pass `userIdentityNote`. |
-| `src/lib/ingestion/extract-document-graph.ts` | Build + pass `userIdentityNote`. |
-| `src/lib/ingestion/chunked-extract.ts` | Thread `userIdentityNote` through to each `extractGraph` call. |
-| `src/lib/identity-resolution.test.ts` | Ambiguity tests + self-by-full-name vs bare-name test. |
-| `src/lib/jobs/ingest-transcript.test.ts` | Subject-wiring integration test. |
+| File                                          | Change                                                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/transcript/resolve-speakers.ts`      | Import `ensureUserSelfPersonNode` from the new module; delete the local copy; stop writing the bare self alias; drop now-unused `sql` import.                            |
+| `src/lib/user-profile.ts`                     | `setUserSelfAliases` calls `ensureUserSelfIdentity` after persisting.                                                                                                    |
+| `src/lib/jobs/ingest-transcript.ts`           | Call `ensureUserSelfIdentity` with the effective alias list before resolving speakers.                                                                                   |
+| `src/lib/extract-graph.ts`                    | Register speaker nodes into `idMap`; subject-wiring in `_formatSpeakerMapSection` + static few-shot; static anti-conflation rule; new `userIdentityNote` param + render. |
+| `src/lib/identity-resolution.ts`              | Unique-match-wins; `ambiguous` trace field; `identity.ambiguous_skip` log.                                                                                               |
+| `src/lib/jobs/ingest-conversation.ts`         | Build + pass `userIdentityNote`.                                                                                                                                         |
+| `src/lib/ingestion/extract-document-graph.ts` | Build + pass `userIdentityNote`.                                                                                                                                         |
+| `src/lib/ingestion/chunked-extract.ts`        | Thread `userIdentityNote` through to each `extractGraph` call.                                                                                                           |
+| `src/lib/identity-resolution.test.ts`         | Ambiguity tests + self-by-full-name vs bare-name test.                                                                                                                   |
+| `src/lib/jobs/ingest-transcript.test.ts`      | Subject-wiring integration test.                                                                                                                                         |
 
 **Build order:** Tasks 1→6 deliver Component 1 (kills the reported bug at the source). Tasks 7–8 = Component 2. Task 9 = Component 3. Tasks 10–11 = Component 4. Task 12 = full verification.
 
@@ -47,6 +47,7 @@
 ## Task 1: New module `user-self-identity.ts` + pure-helper tests
 
 **Files:**
+
 - Create: `src/lib/user-self-identity.ts`
 - Test: `src/lib/user-self-identity.test.ts`
 
@@ -55,12 +56,12 @@
 Create `src/lib/user-self-identity.test.ts` with ONLY the pure-helper suite for now (the DB suite is added in Task 5):
 
 ```ts
-import { describe, expect, it } from "vitest";
 import {
   buildUserIdentityNote,
   distinguishingAliases,
   selectPrimarySelfLabel,
 } from "./user-self-identity";
+import { describe, expect, it } from "vitest";
 
 describe("selectPrimarySelfLabel", () => {
   it("picks the alias with the most tokens", () => {
@@ -318,15 +319,19 @@ git commit -m "✨ feat(identity): user-self identity module (label + distinguis
 ## Task 2: Rewire `resolve-speakers.ts` to the shared self-node helper
 
 **Files:**
+
 - Modify: `src/lib/transcript/resolve-speakers.ts`
 
 - [ ] **Step 1: Replace the drizzle import (drop `sql`)**
 
 Find:
+
 ```ts
 import { and, eq, inArray, sql } from "drizzle-orm";
 ```
+
 Replace with:
+
 ```ts
 import { and, eq, inArray } from "drizzle-orm";
 ```
@@ -334,10 +339,13 @@ import { and, eq, inArray } from "drizzle-orm";
 - [ ] **Step 2: Import the shared helper**
 
 Find:
+
 ```ts
 import { normalizeLabel } from "~/lib/label";
 ```
+
 Replace with:
+
 ```ts
 import { normalizeLabel } from "~/lib/label";
 import { ensureUserSelfPersonNode } from "~/lib/user-self-identity";
@@ -346,6 +354,7 @@ import { ensureUserSelfPersonNode } from "~/lib/user-self-identity";
 - [ ] **Step 3: Stop writing the bare self alias in the user-self branch**
 
 Find:
+
 ```ts
     // 1. user-self
     if (userSelfNormalized.has(normalized)) {
@@ -361,7 +370,9 @@ Find:
       continue;
     }
 ```
+
 Replace with:
+
 ```ts
     // 1. user-self. Resolution matches against the `userSelfAliases` config
     // set directly, so we deliberately do NOT write the (often bare,
@@ -378,11 +389,13 @@ Replace with:
 - [ ] **Step 4: Delete the local `ensureUserSelfPersonNode`**
 
 Delete the entire local function and its doc comment — the block that begins:
+
 ```ts
 /**
  * Ensure the user's own Person node exists. Looked up by
  * `nodeMetadata.additionalData.isUserSelf = true` for the user's Person nodes;
 ```
+
 …through the closing brace of `ensureUserSelfPersonNode` (the `return newNode.id;\n  });\n}` right before `async function createPlaceholderPersonNode(`). The closure `ensureUserSelfNode` near the top of `resolveSpeakers` still calls `ensureUserSelfPersonNode(db, userId)` — it now resolves to the imported version. Leave `createPlaceholderPersonNode` intact.
 
 - [ ] **Step 5: Typecheck**
@@ -407,23 +420,28 @@ git commit -m "♻️ refactor(transcript): use shared self-node helper; stop se
 ## Task 3: `setUserSelfAliases` ensures self identity
 
 **Files:**
+
 - Modify: `src/lib/user-profile.ts`
 
 - [ ] **Step 1: Import the helper**
 
 Find:
+
 ```ts
 import { newTypeId } from "~/types/typeid";
 ```
+
 Replace with:
+
 ```ts
-import { newTypeId } from "~/types/typeid";
 import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
+import { newTypeId } from "~/types/typeid";
 ```
 
 - [ ] **Step 2: Call `ensureUserSelfIdentity` after persisting**
 
 Find:
+
 ```ts
   const existing = await readMetadata(db, userId);
   if (existing === null) {
@@ -448,7 +466,9 @@ Find:
 
   return { aliases: nextAliases };
 ```
+
 Replace with:
+
 ```ts
   const existing = await readMetadata(db, userId);
   if (existing === null) {
@@ -493,15 +513,19 @@ git commit -m "✨ feat(identity): setUserSelfAliases names the self node + seed
 ## Task 4: Transcript ingest ensures self identity with effective aliases
 
 **Files:**
+
 - Modify: `src/lib/jobs/ingest-transcript.ts`
 
 - [ ] **Step 1: Import the helper**
 
 Find:
+
 ```ts
 import { getUserSelfAliases } from "~/lib/user-profile";
 ```
+
 Replace with:
+
 ```ts
 import { getUserSelfAliases } from "~/lib/user-profile";
 import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
@@ -510,24 +534,27 @@ import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
 - [ ] **Step 2: Ensure self identity before resolving speakers**
 
 Find:
-```ts
-  const userSelfAliases =
-    userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
 
-  const speakerLabels = utterances.map((u) => u.speakerLabel);
+```ts
+const userSelfAliases =
+  userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
+
+const speakerLabels = utterances.map((u) => u.speakerLabel);
 ```
+
 Replace with:
+
 ```ts
-  const userSelfAliases =
-    userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
+const userSelfAliases =
+  userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
 
-  // WhatsApp (and other transcript hosts) send `userSelfAliasesOverride` per
-  // request and never call /user/self-aliases, so the stored list may be
-  // empty. Use the EFFECTIVE list so the self node still gets a distinguishing
-  // label + aliases on the real ingestion path.
-  await ensureUserSelfIdentity(db, userId, userSelfAliases);
+// WhatsApp (and other transcript hosts) send `userSelfAliasesOverride` per
+// request and never call /user/self-aliases, so the stored list may be
+// empty. Use the EFFECTIVE list so the self node still gets a distinguishing
+// label + aliases on the real ingestion path.
+await ensureUserSelfIdentity(db, userId, userSelfAliases);
 
-  const speakerLabels = utterances.map((u) => u.speakerLabel);
+const speakerLabels = utterances.map((u) => u.speakerLabel);
 ```
 
 - [ ] **Step 3: Typecheck**
@@ -552,6 +579,7 @@ git commit -m "✨ feat(transcript): ensure user-self identity from effective al
 ## Task 5: DB test for `ensureUserSelfIdentity`
 
 **Files:**
+
 - Modify: `src/lib/user-self-identity.test.ts`
 
 - [ ] **Step 1: Add the DB-integration suite**
@@ -750,6 +778,7 @@ git commit -m "✅ test(identity): ensureUserSelfIdentity names node + seeds mul
 ## Task 6: Self-node backfill (job + schema + route)
 
 **Files:**
+
 - Create: `src/lib/jobs/backfill-user-self-identity.ts`
 - Create: `src/lib/schemas/backfill-user-self-identity.ts`
 - Create: `src/routes/maintenance/backfill-user-self-identity.post.ts`
@@ -895,33 +924,38 @@ git commit -m "✨ feat(maintenance): backfill route to repair existing user-sel
 ## Task 7: Component 2 — register speaker nodes as subjects + prompt wiring
 
 **Files:**
+
 - Modify: `src/lib/extract-graph.ts`
 
 - [ ] **Step 1: Register speaker nodes into `idMap`**
 
 Find:
-```ts
-  const { nodesForPromptFormatting, idMap, nodeLabels } =
-    _prepareInitialNodeMappings(cappedNodes);
-```
-Replace with:
-```ts
-  const { nodesForPromptFormatting, idMap, nodeLabels } =
-    _prepareInitialNodeMappings(cappedNodes);
 
-  // Register every resolved speaker node so the LLM can use its real id as a
-  // claim subjectId (e.g. the user-self speaker's first-person statements).
-  // Unconditional — speaker subjects must not be dropped by the 150-node cap.
-  if (speakerMap) {
-    for (const entry of speakerMap.values()) {
-      idMap.set(entry.nodeId.toString(), entry.nodeId);
-    }
+```ts
+const { nodesForPromptFormatting, idMap, nodeLabels } =
+  _prepareInitialNodeMappings(cappedNodes);
+```
+
+Replace with:
+
+```ts
+const { nodesForPromptFormatting, idMap, nodeLabels } =
+  _prepareInitialNodeMappings(cappedNodes);
+
+// Register every resolved speaker node so the LLM can use its real id as a
+// claim subjectId (e.g. the user-self speaker's first-person statements).
+// Unconditional — speaker subjects must not be dropped by the 150-node cap.
+if (speakerMap) {
+  for (const entry of speakerMap.values()) {
+    idMap.set(entry.nodeId.toString(), entry.nodeId);
   }
+}
 ```
 
 - [ ] **Step 2: Make the speaker section teach subject-wiring**
 
 Find the whole `_formatSpeakerMapSection` function:
+
 ```ts
 function _formatSpeakerMapSection(
   speakerMap: ExtractGraphSpeakerMap | undefined,
@@ -936,7 +970,9 @@ For each claim, set "assertedBySpeakerLabel" to the speaker who said it, using t
 ${lines.join("\n")}`;
 }
 ```
+
 Replace with:
+
 ```ts
 function _formatSpeakerMapSection(
   speakerMap: ExtractGraphSpeakerMap | undefined,
@@ -958,10 +994,13 @@ ${lines.join("\n")}`;
 - [ ] **Step 3: Demonstrate subject-wiring in the static transcript few-shot**
 
 Find:
+
 ```ts
 - Speaker "Alice" (user-self) says "I shipped the spec." → assertionKind: "user", assertedBySpeakerLabel: "Alice".
 ```
+
 Replace with:
+
 ```ts
 - Speaker "Alice" (user-self) says "I live in Lisbon." → create the (LIVES_IN, Lisbon) claim with subjectId set to Alice's nodeId from "Speakers in this transcript" (do NOT mint a new "Alice" node), assertionKind: "user", assertedBySpeakerLabel: "Alice".
 ```
@@ -988,6 +1027,7 @@ git commit -m "✨ feat(transcript): wire user-self speaker as claim subject in 
 ## Task 8: Component 2 — transcript subject-wiring integration test
 
 **Files:**
+
 - Modify: `src/lib/jobs/ingest-transcript.test.ts`
 
 - [ ] **Step 1: Add the integration test**
@@ -995,109 +1035,107 @@ git commit -m "✨ feat(transcript): wire user-self speaker as claim subject in 
 Insert this `it(...)` block inside the `describeIfServer("ingestTranscript", () => { ... })` block, after the last existing `it(...)` (i.e. just before the closing `});` of the describe at the end of the file):
 
 ```ts
-  it("attributes a user-self first-person claim to the self node, not a same-named participant", async () => {
-    const userId = "user_transcript_subject";
-    const transcriptId = "trans_subject_1";
-    const occurredAt = new Date("2026-05-01T10:00:00.000Z");
+it("attributes a user-self first-person claim to the self node, not a same-named participant", async () => {
+  const userId = "user_transcript_subject";
+  const transcriptId = "trans_subject_1";
+  const occurredAt = new Date("2026-05-01T10:00:00.000Z");
 
-    const client = new Client({ connectionString: dsnFor(dbName) });
-    await client.connect();
-    const database = drizzle(client, { schema, casing: "snake_case" });
+  const client = new Client({ connectionString: dsnFor(dbName) });
+  await client.connect();
+  const database = drizzle(client, { schema, casing: "snake_case" });
 
-    // Captured so the LLM stub can emit the real self node id as subjectId.
-    let selfNodeIdForStub = "";
+  // Captured so the LLM stub can emit the real self node id as subjectId.
+  let selfNodeIdForStub = "";
 
-    applyCommonMocks(database);
-    vi.doMock("../ai", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("../ai")>()),
-      createCompletionClient: async () => ({
-        chat: {
-          completions: {
-            parse: async () => ({
-              choices: [
-                {
-                  message: {
-                    parsed: {
-                      nodes: [
-                        { id: "loc_1", type: "Location", label: "Lisbon" },
-                      ],
-                      relationshipClaims: [
-                        {
-                          subjectId: selfNodeIdForStub,
-                          objectId: "loc_1",
-                          predicate: "LIVES_IN",
-                          statement: "Marcel lives in Lisbon.",
-                          sourceRef: `${transcriptId}:0`,
-                          assertionKind: "user",
-                          assertedBySpeakerLabel: "Marcel",
-                        },
-                      ],
-                      attributeClaims: [],
-                      aliases: [],
-                    },
+  applyCommonMocks(database);
+  vi.doMock("../ai", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../ai")>()),
+    createCompletionClient: async () => ({
+      chat: {
+        completions: {
+          parse: async () => ({
+            choices: [
+              {
+                message: {
+                  parsed: {
+                    nodes: [{ id: "loc_1", type: "Location", label: "Lisbon" }],
+                    relationshipClaims: [
+                      {
+                        subjectId: selfNodeIdForStub,
+                        objectId: "loc_1",
+                        predicate: "LIVES_IN",
+                        statement: "Marcel lives in Lisbon.",
+                        sourceRef: `${transcriptId}:0`,
+                        assertionKind: "user",
+                        assertedBySpeakerLabel: "Marcel",
+                      },
+                    ],
+                    attributeClaims: [],
+                    aliases: [],
                   },
                 },
-              ],
-            }),
-          },
+              },
+            ],
+          }),
         },
-      }),
-    }));
+      },
+    }),
+  }));
 
-    try {
-      await createTranscriptTables(client);
-      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+  try {
+    await createTranscriptTables(client);
+    await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
 
-      // A different, same-first-name person already in the graph.
-      const otherMarcelId = newTypeId("node");
-      await client.query(
-        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Person')`,
-        [otherMarcelId, userId],
-      );
-      await client.query(
-        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES ($1, $2, 'Marcel', 'marcel')`,
-        [newTypeId("node_metadata"), otherMarcelId],
-      );
+    // A different, same-first-name person already in the graph.
+    const otherMarcelId = newTypeId("node");
+    await client.query(
+      `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Person')`,
+      [otherMarcelId, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES ($1, $2, 'Marcel', 'marcel')`,
+      [newTypeId("node_metadata"), otherMarcelId],
+    );
 
-      const { ensureUserSelfIdentity } = await import("../user-self-identity");
-      const selfNodeId = await ensureUserSelfIdentity(database, userId, [
-        "Marcel",
-        "Marcel Samyn",
-      ]);
-      selfNodeIdForStub = selfNodeId;
+    const { ensureUserSelfIdentity } = await import("../user-self-identity");
+    const selfNodeId = await ensureUserSelfIdentity(database, userId, [
+      "Marcel",
+      "Marcel Samyn",
+    ]);
+    selfNodeIdForStub = selfNodeId;
 
-      const { ingestTranscript } = await import("./ingest-transcript");
-      await ingestTranscript({
-        db: database,
-        userId,
-        transcriptId,
-        scope: "personal",
-        occurredAt,
-        content: {
-          kind: "segmented",
-          utterances: [
-            { speakerLabel: "Marcel", content: "I live in Lisbon now." },
-          ],
-        },
-        userSelfAliasesOverride: ["Marcel", "Marcel Samyn"],
-      });
+    const { ingestTranscript } = await import("./ingest-transcript");
+    await ingestTranscript({
+      db: database,
+      userId,
+      transcriptId,
+      scope: "personal",
+      occurredAt,
+      content: {
+        kind: "segmented",
+        utterances: [
+          { speakerLabel: "Marcel", content: "I live in Lisbon now." },
+        ],
+      },
+      userSelfAliasesOverride: ["Marcel", "Marcel Samyn"],
+    });
 
-      const livesIn = await client.query<{
-        subject_node_id: string;
-        asserted_by_kind: string;
-      }>(
-        `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LIVES_IN'`,
-        [userId],
-      );
-      expect(livesIn.rows).toHaveLength(1);
-      expect(livesIn.rows[0]?.subject_node_id).toBe(selfNodeId);
-      expect(livesIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
-      expect(livesIn.rows[0]?.asserted_by_kind).toBe("user");
-    } finally {
-      unmockCommon();
-      await client.end();
-    }
-  });
+    const livesIn = await client.query<{
+      subject_node_id: string;
+      asserted_by_kind: string;
+    }>(
+      `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LIVES_IN'`,
+      [userId],
+    );
+    expect(livesIn.rows).toHaveLength(1);
+    expect(livesIn.rows[0]?.subject_node_id).toBe(selfNodeId);
+    expect(livesIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
+    expect(livesIn.rows[0]?.asserted_by_kind).toBe("user");
+  } finally {
+    unmockCommon();
+    await client.end();
+  }
+});
 ```
 
 - [ ] **Step 2: Run the transcript tests**
@@ -1117,6 +1155,7 @@ git commit -m "✅ test(transcript): user-self first-person claim attaches to se
 ## Task 9: Component 3 — resolver never guesses on a tie
 
 **Files:**
+
 - Modify: `src/lib/identity-resolution.ts`
 - Modify: `src/lib/identity-resolution.test.ts`
 
@@ -1125,138 +1164,52 @@ git commit -m "✅ test(transcript): user-self first-person claim attaches to se
 Insert these two `it(...)` blocks inside the `describeIfServer("resolveIdentity", () => { ... })` block in `src/lib/identity-resolution.test.ts`, after the last existing `it(...)` (just before the describe's closing `});`):
 
 ```ts
-  it("signal 1 — multiple same-scope canonical matches do not resolve (ambiguous)", async () => {
-    await withDb(async (client) => {
-      const userId = "user_ambiguous";
-      const marcelA = newTypeId("node");
-      const marcelB = newTypeId("node");
-      const sourceId = newTypeId("source");
-      await createIdentityTables(client);
-      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
-      await client.query(
-        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+it("signal 1 — multiple same-scope canonical matches do not resolve (ambiguous)", async () => {
+  await withDb(async (client) => {
+    const userId = "user_ambiguous";
+    const marcelA = newTypeId("node");
+    const marcelB = newTypeId("node");
+    const sourceId = newTypeId("source");
+    await createIdentityTables(client);
+    await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+    await client.query(
+      `INSERT INTO "sources"("id","user_id","type","external_id","scope")
            VALUES ($1,$2,'document','p1','personal')`,
-        [sourceId, userId],
-      );
-      await client.query(
-        `INSERT INTO "nodes"("id","user_id","node_type")
+      [sourceId, userId],
+    );
+    await client.query(
+      `INSERT INTO "nodes"("id","user_id","node_type")
            VALUES ($1,$3,'Person'),($2,$3,'Person')`,
-        [marcelA, marcelB, userId],
-      );
-      await client.query(
-        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+      [marcelA, marcelB, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
            VALUES ($1,$3,'Marcel','marcel'),($2,$4,'Marcel','marcel')`,
-        [
-          newTypeId("node_metadata"),
-          newTypeId("node_metadata"),
-          marcelA,
-          marcelB,
-        ],
-      );
-      await client.query(
-        `INSERT INTO "source_links"("id","source_id","node_id")
+      [
+        newTypeId("node_metadata"),
+        newTypeId("node_metadata"),
+        marcelA,
+        marcelB,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "source_links"("id","source_id","node_id")
            VALUES ($1,$3,$4),($2,$3,$5)`,
-        [
-          newTypeId("source_link"),
-          newTypeId("source_link"),
-          sourceId,
-          marcelA,
-          marcelB,
-        ],
-      );
+      [
+        newTypeId("source_link"),
+        newTypeId("source_link"),
+        sourceId,
+        marcelA,
+        marcelB,
+      ],
+    );
 
-      const { resolveIdentity } = await import("./identity-resolution");
-      const { setLogSink } = await import("~/lib/observability/log");
-      const captured: Array<Record<string, unknown>> = [];
-      setLogSink((event) => captured.push(event));
-      try {
-        const resolution = await resolveIdentity({
-          userId,
-          candidate: {
-            proposedLabel: "Marcel",
-            normalizedLabel: "marcel",
-            nodeType: "Person",
-            scope: "personal",
-          },
-        });
-        expect(resolution.resolvedNodeId).toBeNull();
-        expect(resolution.decision.signal).toBe("none");
-        const canonical = resolution.decision.trace.find(
-          (t) => t.signal === "canonical_label",
-        );
-        expect(canonical?.fired).toBe(true);
-        expect(canonical?.candidates).toHaveLength(2);
-        expect(
-          canonical?.signal === "canonical_label" && canonical.ambiguous,
-        ).toMatchObject({
-          candidateNodeIds: expect.arrayContaining([marcelA, marcelB]),
-        });
-        const skip = captured.find(
-          (e) => e["event"] === "identity.ambiguous_skip",
-        );
-        expect(skip).toMatchObject({
-          event: "identity.ambiguous_skip",
-          userId,
-          normalizedLabel: "marcel",
-          signal: "canonical_label",
-          candidateCount: 2,
-        });
-      } finally {
-        setLogSink();
-      }
-    });
-  });
-
-  it("self resolves by full name; a bare same-first-name does not merge into self", async () => {
-    await withDb(async (client) => {
-      const userId = "user_self_fullname";
-      await createIdentityTables(client);
-      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
-
-      const { useDatabase } = await import("~/utils/db");
-      const db = await useDatabase();
-      const { ensureUserSelfIdentity } = await import("./user-self-identity");
-      const selfNodeId = await ensureUserSelfIdentity(db, userId, [
-        "Marcel",
-        "Marcel Samyn",
-      ]);
-
-      // A separate third-party "Marcel" with personal-scope support.
-      const otherMarcel = newTypeId("node");
-      const sourceId = newTypeId("source");
-      await client.query(
-        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
-           VALUES ($1,$2,'document','d1','personal')`,
-        [sourceId, userId],
-      );
-      await client.query(
-        `INSERT INTO "nodes"("id","user_id","node_type") VALUES ($1,$2,'Person')`,
-        [otherMarcel, userId],
-      );
-      await client.query(
-        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
-           VALUES ($1,$2,'Marcel','marcel')`,
-        [newTypeId("node_metadata"), otherMarcel],
-      );
-      await client.query(
-        `INSERT INTO "source_links"("id","source_id","node_id") VALUES ($1,$2,$3)`,
-        [newTypeId("source_link"), sourceId, otherMarcel],
-      );
-
-      const { resolveIdentity } = await import("./identity-resolution");
-
-      const full = await resolveIdentity({
-        userId,
-        candidate: {
-          proposedLabel: "Marcel Samyn",
-          normalizedLabel: "marcel samyn",
-          nodeType: "Person",
-          scope: "personal",
-        },
-      });
-      expect(full.resolvedNodeId).toBe(selfNodeId);
-
-      const bare = await resolveIdentity({
+    const { resolveIdentity } = await import("./identity-resolution");
+    const { setLogSink } = await import("~/lib/observability/log");
+    const captured: Array<Record<string, unknown>> = [];
+    setLogSink((event) => captured.push(event));
+    try {
+      const resolution = await resolveIdentity({
         userId,
         candidate: {
           proposedLabel: "Marcel",
@@ -1265,10 +1218,96 @@ Insert these two `it(...)` blocks inside the `describeIfServer("resolveIdentity"
           scope: "personal",
         },
       });
-      expect(bare.resolvedNodeId).toBe(otherMarcel);
-      expect(bare.resolvedNodeId).not.toBe(selfNodeId);
-    });
+      expect(resolution.resolvedNodeId).toBeNull();
+      expect(resolution.decision.signal).toBe("none");
+      const canonical = resolution.decision.trace.find(
+        (t) => t.signal === "canonical_label",
+      );
+      expect(canonical?.fired).toBe(true);
+      expect(canonical?.candidates).toHaveLength(2);
+      expect(
+        canonical?.signal === "canonical_label" && canonical.ambiguous,
+      ).toMatchObject({
+        candidateNodeIds: expect.arrayContaining([marcelA, marcelB]),
+      });
+      const skip = captured.find(
+        (e) => e["event"] === "identity.ambiguous_skip",
+      );
+      expect(skip).toMatchObject({
+        event: "identity.ambiguous_skip",
+        userId,
+        normalizedLabel: "marcel",
+        signal: "canonical_label",
+        candidateCount: 2,
+      });
+    } finally {
+      setLogSink();
+    }
   });
+});
+
+it("self resolves by full name; a bare same-first-name does not merge into self", async () => {
+  await withDb(async (client) => {
+    const userId = "user_self_fullname";
+    await createIdentityTables(client);
+    await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+
+    const { useDatabase } = await import("~/utils/db");
+    const db = await useDatabase();
+    const { ensureUserSelfIdentity } = await import("./user-self-identity");
+    const selfNodeId = await ensureUserSelfIdentity(db, userId, [
+      "Marcel",
+      "Marcel Samyn",
+    ]);
+
+    // A separate third-party "Marcel" with personal-scope support.
+    const otherMarcel = newTypeId("node");
+    const sourceId = newTypeId("source");
+    await client.query(
+      `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+           VALUES ($1,$2,'document','d1','personal')`,
+      [sourceId, userId],
+    );
+    await client.query(
+      `INSERT INTO "nodes"("id","user_id","node_type") VALUES ($1,$2,'Person')`,
+      [otherMarcel, userId],
+    );
+    await client.query(
+      `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+           VALUES ($1,$2,'Marcel','marcel')`,
+      [newTypeId("node_metadata"), otherMarcel],
+    );
+    await client.query(
+      `INSERT INTO "source_links"("id","source_id","node_id") VALUES ($1,$2,$3)`,
+      [newTypeId("source_link"), sourceId, otherMarcel],
+    );
+
+    const { resolveIdentity } = await import("./identity-resolution");
+
+    const full = await resolveIdentity({
+      userId,
+      candidate: {
+        proposedLabel: "Marcel Samyn",
+        normalizedLabel: "marcel samyn",
+        nodeType: "Person",
+        scope: "personal",
+      },
+    });
+    expect(full.resolvedNodeId).toBe(selfNodeId);
+
+    const bare = await resolveIdentity({
+      userId,
+      candidate: {
+        proposedLabel: "Marcel",
+        normalizedLabel: "marcel",
+        nodeType: "Person",
+        scope: "personal",
+      },
+    });
+    expect(bare.resolvedNodeId).toBe(otherMarcel);
+    expect(bare.resolvedNodeId).not.toBe(selfNodeId);
+  });
+});
 ```
 
 - [ ] **Step 2: Run to verify they fail**
@@ -1279,6 +1318,7 @@ Expected: FAIL — the ambiguous test currently resolves to `candidates[0]` (non
 - [ ] **Step 3: Add the `ambiguous` field to the exact-match trace variants**
 
 In `src/lib/identity-resolution.ts`, find:
+
 ```ts
   | {
       signal: "canonical_label";
@@ -1294,7 +1334,9 @@ In `src/lib/identity-resolution.ts`, find:
       crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
     }
 ```
+
 Replace with:
+
 ```ts
   | {
       signal: "canonical_label";
@@ -1318,6 +1360,7 @@ Replace with:
 - [ ] **Step 4: Resolve only on a unique canonical match**
 
 Find:
+
 ```ts
   if (canonicalTrace.signal === "canonical_label" && canonicalTrace.fired) {
     const winner = canonicalTrace.candidates[0];
@@ -1333,7 +1376,9 @@ Find:
     }
   }
 ```
+
 Replace with:
+
 ```ts
   if (canonicalTrace.signal === "canonical_label" && canonicalTrace.fired) {
     if (canonicalTrace.candidates.length === 1) {
@@ -1365,6 +1410,7 @@ Replace with:
 - [ ] **Step 5: Resolve only on a unique alias match**
 
 Find:
+
 ```ts
   if (aliasTrace.signal === "alias" && aliasTrace.fired) {
     const winner = aliasTrace.candidates[0];
@@ -1380,7 +1426,9 @@ Find:
     }
   }
 ```
+
 Replace with:
+
 ```ts
   if (aliasTrace.signal === "alias" && aliasTrace.fired) {
     if (aliasTrace.candidates.length === 1) {
@@ -1404,10 +1452,13 @@ Replace with:
 - [ ] **Step 6: Add the `_logAmbiguousSkip` helper**
 
 In `src/lib/identity-resolution.ts`, find the start of `_logCrossScopeRefusal`:
+
 ```ts
 function _logCrossScopeRefusal(
 ```
+
 Insert this function immediately ABOVE it:
+
 ```ts
 function _logAmbiguousSkip(
   userId: string,
@@ -1426,7 +1477,6 @@ function _logAmbiguousSkip(
     candidateCount: candidates.length,
   });
 }
-
 ```
 
 - [ ] **Step 7: Run the resolver tests + full identity suite**
@@ -1451,17 +1501,21 @@ git commit -m "✨ feat(identity): unique-match-wins resolver + identity.ambiguo
 ## Task 10: Component 4 — `userIdentityNote` param + render + static rule
 
 **Files:**
+
 - Modify: `src/lib/extract-graph.ts`
 
 - [ ] **Step 1: Add the param to `ExtractGraphParams`**
 
 Find:
+
 ```ts
   contentNote?: string;
   /**
    * Debug hook fired exactly once after the LLM call returns, before
 ```
+
 Replace with:
+
 ```ts
   contentNote?: string;
   /**
@@ -1480,6 +1534,7 @@ Replace with:
 - [ ] **Step 2: Destructure it**
 
 Find:
+
 ```ts
   content,
   speakerMap,
@@ -1488,7 +1543,9 @@ Find:
   onLlmIO,
 }: ExtractGraphParams) {
 ```
+
 Replace with:
+
 ```ts
   content,
   speakerMap,
@@ -1502,27 +1559,33 @@ Replace with:
 - [ ] **Step 3: Build the render section alongside the others**
 
 Find:
-```ts
-  const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
-```
-Replace with:
-```ts
-  const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
 
-  const userIdentityPromptSection = userIdentityNote
-    ? `${userIdentityNote}\n\n`
-    : "";
+```ts
+const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
+```
+
+Replace with:
+
+```ts
+const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
+
+const userIdentityPromptSection = userIdentityNote
+  ? `${userIdentityNote}\n\n`
+  : "";
 ```
 
 - [ ] **Step 4: Inject the section into the user message**
 
 Find:
+
 ```ts
 ${speakerMapPromptSection}
 
 Extract the graph from the following ${sourceType}:
 ```
+
 Replace with:
+
 ```ts
 ${speakerMapPromptSection}
 
@@ -1532,10 +1595,13 @@ ${userIdentityPromptSection}Extract the graph from the following ${sourceType}:
 - [ ] **Step 5: Add the static anti-conflation rule**
 
 Find:
+
 ```ts
 - In node names use full names, eg. "John Doe" instead of "John"
 ```
+
 Replace with:
+
 ```ts
 - In node names use full names, eg. "John Doe" instead of "John"
 - If multiple people could share a name, use the most specific distinguishing label available (e.g. a full name) and NEVER merge or conflate two different people who share a first name.
@@ -1558,6 +1624,7 @@ git commit -m "✨ feat(extraction): userIdentityNote injection + anti-conflatio
 ## Task 11: Component 4 — wire conversation + document paths
 
 **Files:**
+
 - Modify: `src/lib/jobs/ingest-conversation.ts`
 - Modify: `src/lib/ingestion/extract-document-graph.ts`
 - Modify: `src/lib/ingestion/chunked-extract.ts`
@@ -1565,52 +1632,59 @@ git commit -m "✨ feat(extraction): userIdentityNote injection + anti-conflatio
 - [ ] **Step 1: Conversation — imports**
 
 In `src/lib/jobs/ingest-conversation.ts`, find:
+
 ```ts
 import { NodeTypeEnum } from "~/types/graph";
 import { TypeId } from "~/types/typeid";
 ```
+
 Replace with:
+
 ```ts
-import { NodeTypeEnum } from "~/types/graph";
-import { TypeId } from "~/types/typeid";
 import { getUserSelfAliases } from "~/lib/user-profile";
 import { buildUserIdentityNote } from "~/lib/user-self-identity";
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
 ```
 
 - [ ] **Step 2: Conversation — build + pass the note**
 
 Find:
+
 ```ts
-  await extractGraph({
-    userId,
-    sourceType: "conversation",
-    sourceId,
-    statedAt: firstTurn.timestamp,
-    linkedNodeId: conversationNodeId,
-    sourceRefs,
-    content: formatConversationAsXml(insertedTurns),
-  });
+await extractGraph({
+  userId,
+  sourceType: "conversation",
+  sourceId,
+  statedAt: firstTurn.timestamp,
+  linkedNodeId: conversationNodeId,
+  sourceRefs,
+  content: formatConversationAsXml(insertedTurns),
+});
 ```
+
 Replace with:
+
 ```ts
-  const userIdentityNote = buildUserIdentityNote(
-    await getUserSelfAliases(db, userId),
-  );
-  await extractGraph({
-    userId,
-    sourceType: "conversation",
-    sourceId,
-    statedAt: firstTurn.timestamp,
-    linkedNodeId: conversationNodeId,
-    sourceRefs,
-    content: formatConversationAsXml(insertedTurns),
-    ...(userIdentityNote ? { userIdentityNote } : {}),
-  });
+const userIdentityNote = buildUserIdentityNote(
+  await getUserSelfAliases(db, userId),
+);
+await extractGraph({
+  userId,
+  sourceType: "conversation",
+  sourceId,
+  statedAt: firstTurn.timestamp,
+  linkedNodeId: conversationNodeId,
+  sourceRefs,
+  content: formatConversationAsXml(insertedTurns),
+  ...(userIdentityNote ? { userIdentityNote } : {}),
+});
 ```
 
 - [ ] **Step 3: Document — imports**
 
 In `src/lib/ingestion/extract-document-graph.ts`, find:
+
 ```ts
 import { runChunkedExtraction } from "./chunked-extract";
 import { ensureSourceNode } from "./ensure-source-node";
@@ -1618,7 +1692,9 @@ import { DrizzleDB } from "~/db";
 import { NodeTypeEnum } from "~/types/graph";
 import { TypeId } from "~/types/typeid";
 ```
+
 Replace with:
+
 ```ts
 import { runChunkedExtraction } from "./chunked-extract";
 import { ensureSourceNode } from "./ensure-source-node";
@@ -1632,64 +1708,68 @@ import { TypeId } from "~/types/typeid";
 - [ ] **Step 4: Document — build + pass the note**
 
 Find:
-```ts
-  const linkedNodeId = await ensureSourceNode({
-    db,
-    userId,
-    sourceId,
-    timestamp,
-    nodeType: NodeTypeEnum.enum.Document,
-  });
 
-  await runChunkedExtraction({
-    userId,
-    sourceType: "document",
-    sourceId,
-    statedAt: timestamp,
-    linkedNodeId,
-    sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
-    content,
-    logLabel,
-    documentMetadata: {
-      ...(title !== undefined && { title }),
-      ...(author !== undefined && { author }),
-    },
-  });
+```ts
+const linkedNodeId = await ensureSourceNode({
+  db,
+  userId,
+  sourceId,
+  timestamp,
+  nodeType: NodeTypeEnum.enum.Document,
+});
+
+await runChunkedExtraction({
+  userId,
+  sourceType: "document",
+  sourceId,
+  statedAt: timestamp,
+  linkedNodeId,
+  sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
+  content,
+  logLabel,
+  documentMetadata: {
+    ...(title !== undefined && { title }),
+    ...(author !== undefined && { author }),
+  },
+});
 ```
+
 Replace with:
+
 ```ts
-  const linkedNodeId = await ensureSourceNode({
-    db,
-    userId,
-    sourceId,
-    timestamp,
-    nodeType: NodeTypeEnum.enum.Document,
-  });
+const linkedNodeId = await ensureSourceNode({
+  db,
+  userId,
+  sourceId,
+  timestamp,
+  nodeType: NodeTypeEnum.enum.Document,
+});
 
-  const userIdentityNote = buildUserIdentityNote(
-    await getUserSelfAliases(db, userId),
-  );
+const userIdentityNote = buildUserIdentityNote(
+  await getUserSelfAliases(db, userId),
+);
 
-  await runChunkedExtraction({
-    userId,
-    sourceType: "document",
-    sourceId,
-    statedAt: timestamp,
-    linkedNodeId,
-    sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
-    content,
-    logLabel,
-    documentMetadata: {
-      ...(title !== undefined && { title }),
-      ...(author !== undefined && { author }),
-    },
-    ...(userIdentityNote ? { userIdentityNote } : {}),
-  });
+await runChunkedExtraction({
+  userId,
+  sourceType: "document",
+  sourceId,
+  statedAt: timestamp,
+  linkedNodeId,
+  sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
+  content,
+  logLabel,
+  documentMetadata: {
+    ...(title !== undefined && { title }),
+    ...(author !== undefined && { author }),
+  },
+  ...(userIdentityNote ? { userIdentityNote } : {}),
+});
 ```
 
 - [ ] **Step 5: Chunked-extract — add param to the interface**
 
 In `src/lib/ingestion/chunked-extract.ts`, find:
+
 ```ts
   documentMetadata?: {
     title?: string;
@@ -1697,7 +1777,9 @@ In `src/lib/ingestion/chunked-extract.ts`, find:
   };
 }
 ```
+
 Replace with:
+
 ```ts
   documentMetadata?: {
     title?: string;
@@ -1714,57 +1796,63 @@ Replace with:
 - [ ] **Step 6: Chunked-extract — destructure + forward to every chunk**
 
 Find:
+
 ```ts
-  const {
-    userId,
-    sourceType,
-    sourceId,
-    statedAt,
-    linkedNodeId,
-    sourceRefs,
-    content,
-    logLabel,
-    documentMetadata,
-  } = params;
+const {
+  userId,
+  sourceType,
+  sourceId,
+  statedAt,
+  linkedNodeId,
+  sourceRefs,
+  content,
+  logLabel,
+  documentMetadata,
+} = params;
 ```
+
 Replace with:
+
 ```ts
-  const {
-    userId,
-    sourceType,
-    sourceId,
-    statedAt,
-    linkedNodeId,
-    sourceRefs,
-    content,
-    logLabel,
-    documentMetadata,
-    userIdentityNote,
-  } = params;
+const {
+  userId,
+  sourceType,
+  sourceId,
+  statedAt,
+  linkedNodeId,
+  sourceRefs,
+  content,
+  logLabel,
+  documentMetadata,
+  userIdentityNote,
+} = params;
 ```
 
 Then find:
+
 ```ts
-  const baseExtractParams = {
-    userId,
-    sourceType,
-    sourceId,
-    statedAt,
-    linkedNodeId,
-    sourceRefs,
-  };
+const baseExtractParams = {
+  userId,
+  sourceType,
+  sourceId,
+  statedAt,
+  linkedNodeId,
+  sourceRefs,
+};
 ```
+
 Replace with:
+
 ```ts
-  const baseExtractParams = {
-    userId,
-    sourceType,
-    sourceId,
-    statedAt,
-    linkedNodeId,
-    sourceRefs,
-    ...(userIdentityNote ? { userIdentityNote } : {}),
-  };
+const baseExtractParams = {
+  userId,
+  sourceType,
+  sourceId,
+  statedAt,
+  linkedNodeId,
+  sourceRefs,
+  ...(userIdentityNote ? { userIdentityNote } : {}),
+};
 ```
 
 - [ ] **Step 7: Typecheck**
@@ -1803,6 +1891,7 @@ Expected: PASS. If it reports formatting diffs, run `pnpm run format:fix` and re
 - [ ] **Step 4: Run the full affected test set (DB on :5431)**
 
 Run:
+
 ```bash
 pnpm run test -- run \
   src/lib/user-self-identity.test.ts \
@@ -1810,6 +1899,7 @@ pnpm run test -- run \
   src/lib/jobs/ingest-transcript.test.ts \
   src/lib/identity-resolution.test.ts
 ```
+
 Expected: all PASS. (Start Postgres first if needed: `docker compose up -d db`.)
 
 - [ ] **Step 5: Final commit (only if format:fix or lint:fix changed files)**
@@ -1825,26 +1915,26 @@ git commit -m "🎨 style(identity): lint/format cleanup"
 
 **1. Spec coverage**
 
-| Spec item | Task(s) |
-| --- | --- |
-| C1 primary label = longest/most-token alias | Task 1 (`selectPrimarySelfLabel`) |
-| C1 `ensureUserSelfIdentity` from both call sites (config + transcript, effective aliases) | Tasks 3, 4 |
-| C1 keep single-token aliases out of the alias table | Task 1 (`distinguishingAliases`) |
-| C1 stop writing bare self alias in `resolveSpeakers` | Task 2 |
-| C1 backfill maintenance route | Task 6 |
-| C2 register speaker nodes into `idMap` unconditionally | Task 7 (Step 1) |
-| C2 surface user-self as "you" + subject-wiring in prompt | Task 7 (Steps 2–3) |
-| C2 caching contract preserved (dynamic stays in user message) | Task 7 (speaker section) + Task 10 (note in user message) |
-| C3 unique-match-wins; >1 → split + `identity.ambiguous_skip` | Task 9 |
-| C3 no blunt self-prior | Confirmed: no self-preference added to the resolver anywhere |
-| C4 inject identity into document + conversation prompts | Tasks 10, 11 |
-| C4 instruct most-specific labels / no conflation | Task 10 (Step 5, static rule) |
-| Testing: resolver ambiguity/unique/cross-scope | Task 9 |
-| Testing: self hygiene seeds only multi-token; no bare alias | Tasks 5, 2 |
-| Testing: transcript self-utterance attaches to self with same-named participant present | Task 8 |
-| Testing: document "Marcel Samyn" → self; bare "Marcel" ↛ self | Task 9 (Step 1, second test) |
+| Spec item                                                                                 | Task(s)                                                      |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| C1 primary label = longest/most-token alias                                               | Task 1 (`selectPrimarySelfLabel`)                            |
+| C1 `ensureUserSelfIdentity` from both call sites (config + transcript, effective aliases) | Tasks 3, 4                                                   |
+| C1 keep single-token aliases out of the alias table                                       | Task 1 (`distinguishingAliases`)                             |
+| C1 stop writing bare self alias in `resolveSpeakers`                                      | Task 2                                                       |
+| C1 backfill maintenance route                                                             | Task 6                                                       |
+| C2 register speaker nodes into `idMap` unconditionally                                    | Task 7 (Step 1)                                              |
+| C2 surface user-self as "you" + subject-wiring in prompt                                  | Task 7 (Steps 2–3)                                           |
+| C2 caching contract preserved (dynamic stays in user message)                             | Task 7 (speaker section) + Task 10 (note in user message)    |
+| C3 unique-match-wins; >1 → split + `identity.ambiguous_skip`                              | Task 9                                                       |
+| C3 no blunt self-prior                                                                    | Confirmed: no self-preference added to the resolver anywhere |
+| C4 inject identity into document + conversation prompts                                   | Tasks 10, 11                                                 |
+| C4 instruct most-specific labels / no conflation                                          | Task 10 (Step 5, static rule)                                |
+| Testing: resolver ambiguity/unique/cross-scope                                            | Task 9                                                       |
+| Testing: self hygiene seeds only multi-token; no bare alias                               | Tasks 5, 2                                                   |
+| Testing: transcript self-utterance attaches to self with same-named participant present   | Task 8                                                       |
+| Testing: document "Marcel Samyn" → self; bare "Marcel" ↛ self                             | Task 9 (Step 1, second test)                                 |
 
-**2. Deliberate deviation from the spec (flagged):** the spec's "Testing (Integration document)" and "extend eval story 10" are delivered as **vitest integration/unit tests** (Task 8 transcript, Task 9 document-case) rather than as `src/evals/memory/stories/*` fixtures. Rationale: the vitest tests run against real Postgres and assert the exact subject/resolution behavior directly, giving equivalent coverage without the eval-harness stub plumbing; an eval-story extension can be added later if the probe harness needs it. No spec *behavior* is left unverified.
+**2. Deliberate deviation from the spec (flagged):** the spec's "Testing (Integration document)" and "extend eval story 10" are delivered as **vitest integration/unit tests** (Task 8 transcript, Task 9 document-case) rather than as `src/evals/memory/stories/*` fixtures. Rationale: the vitest tests run against real Postgres and assert the exact subject/resolution behavior directly, giving equivalent coverage without the eval-harness stub plumbing; an eval-story extension can be added later if the probe harness needs it. No spec _behavior_ is left unverified.
 
 **3. Placeholder scan:** none — every code step contains complete copy-pasteable content; every test step contains full assertions.
 

--- a/docs/superpowers/plans/2026-06-17-same-name-identity-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-17-same-name-identity-disambiguation.md
@@ -1,0 +1,1853 @@
+# Same-Name Identity Disambiguation & Self-Identity Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the knowledge graph from attributing the user's own statements (and other people's) to the wrong same-named node by giving the user-self node a distinguishing identity, wiring transcript speakers in as claim *subjects*, and making the resolver refuse to guess on ambiguous name ties.
+
+**Architecture:** Four components in leverage order. (1) **Self-node hygiene** — a new `src/lib/user-self-identity.ts` module names the self node with the user's full name and seeds only multi-token aliases; called from both the config endpoint and transcript ingest. (2) **Subject-wiring** — `extractGraph` registers transcript speaker nodes into `idMap` and the prompt tells the model to use the user-self speaker's nodeId as the subject of first-person claims. (3) **Resolver never guesses** — `resolveIdentity` resolves only on a *unique* canonical/alias match; >1 match splits + logs `identity.ambiguous_skip`. (4) **Prompt insurance** — inject "who the user is" into document/conversation prompts and add a static anti-conflation rule.
+
+**Tech Stack:** TypeScript (strict, `exactOptionalPropertyTypes`), Drizzle ORM, Postgres (+pgvector), Zod, h3/Nitro file-based routes, Vitest (real-Postgres integration tests on port **5431**). Spec: `docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md`.
+
+---
+
+## File Structure
+
+**New files**
+
+| File | Responsibility |
+| --- | --- |
+| `src/lib/user-self-identity.ts` | User-self Person node identity: lazy creation, primary-label selection, distinguishing-alias seeding, `buildUserIdentityNote`. Pure helpers + DB helpers. |
+| `src/lib/user-self-identity.test.ts` | Unit tests: pure helpers (no DB) + `ensureUserSelfIdentity` (DB). |
+| `src/lib/jobs/backfill-user-self-identity.ts` | One-off maintenance: bring an existing self node to the new contract; remove bare self alias. |
+| `src/lib/schemas/backfill-user-self-identity.ts` | Request/response Zod schemas for the backfill route. |
+| `src/routes/maintenance/backfill-user-self-identity.post.ts` | HTTP trigger for the backfill job (Nitro auto-routed). |
+
+**Modified files**
+
+| File | Change |
+| --- | --- |
+| `src/lib/transcript/resolve-speakers.ts` | Import `ensureUserSelfPersonNode` from the new module; delete the local copy; stop writing the bare self alias; drop now-unused `sql` import. |
+| `src/lib/user-profile.ts` | `setUserSelfAliases` calls `ensureUserSelfIdentity` after persisting. |
+| `src/lib/jobs/ingest-transcript.ts` | Call `ensureUserSelfIdentity` with the effective alias list before resolving speakers. |
+| `src/lib/extract-graph.ts` | Register speaker nodes into `idMap`; subject-wiring in `_formatSpeakerMapSection` + static few-shot; static anti-conflation rule; new `userIdentityNote` param + render. |
+| `src/lib/identity-resolution.ts` | Unique-match-wins; `ambiguous` trace field; `identity.ambiguous_skip` log. |
+| `src/lib/jobs/ingest-conversation.ts` | Build + pass `userIdentityNote`. |
+| `src/lib/ingestion/extract-document-graph.ts` | Build + pass `userIdentityNote`. |
+| `src/lib/ingestion/chunked-extract.ts` | Thread `userIdentityNote` through to each `extractGraph` call. |
+| `src/lib/identity-resolution.test.ts` | Ambiguity tests + self-by-full-name vs bare-name test. |
+| `src/lib/jobs/ingest-transcript.test.ts` | Subject-wiring integration test. |
+
+**Build order:** Tasks 1→6 deliver Component 1 (kills the reported bug at the source). Tasks 7–8 = Component 2. Task 9 = Component 3. Tasks 10–11 = Component 4. Task 12 = full verification.
+
+**Testing note:** CI does **not** run vitest — run targeted tests locally against Postgres on `:5431` (`docker compose up db` first if needed). Run a single test file once with:
+`pnpm run test -- run <path>` (vitest treats `run <path>` as run-once + filter).
+
+---
+
+## Task 1: New module `user-self-identity.ts` + pure-helper tests
+
+**Files:**
+- Create: `src/lib/user-self-identity.ts`
+- Test: `src/lib/user-self-identity.test.ts`
+
+- [ ] **Step 1: Write the failing pure-helper tests**
+
+Create `src/lib/user-self-identity.test.ts` with ONLY the pure-helper suite for now (the DB suite is added in Task 5):
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  buildUserIdentityNote,
+  distinguishingAliases,
+  selectPrimarySelfLabel,
+} from "./user-self-identity";
+
+describe("selectPrimarySelfLabel", () => {
+  it("picks the alias with the most tokens", () => {
+    expect(selectPrimarySelfLabel(["Marcel", "Marcel Samyn"])).toBe(
+      "Marcel Samyn",
+    );
+  });
+
+  it("returns null when only single-token aliases are present", () => {
+    expect(selectPrimarySelfLabel(["Marcel"])).toBeNull();
+  });
+
+  it("returns null for an empty list", () => {
+    expect(selectPrimarySelfLabel([])).toBeNull();
+  });
+
+  it("prefers the longest string when token counts tie", () => {
+    expect(selectPrimarySelfLabel(["Jo Lee", "Joanna Lee"])).toBe("Joanna Lee");
+  });
+});
+
+describe("distinguishingAliases", () => {
+  it("keeps only multi-token aliases, de-duplicated by normalized form", () => {
+    expect(
+      distinguishingAliases(["Marcel", "Marcel Samyn", "marcel samyn"]),
+    ).toEqual(["Marcel Samyn"]);
+  });
+
+  it("drops bare single-token names", () => {
+    expect(distinguishingAliases(["Marcel", "MS"])).toEqual([]);
+  });
+});
+
+describe("buildUserIdentityNote", () => {
+  it("returns null when there are no aliases", () => {
+    expect(buildUserIdentityNote([])).toBeNull();
+  });
+
+  it("names the primary, lists aliases, and warns against conflation", () => {
+    const note = buildUserIdentityNote(["Marcel", "Marcel Samyn"]);
+    expect(note).toContain("Marcel Samyn");
+    expect(note).toContain("most specific");
+    expect(note).toContain("share a first name");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm run test -- run src/lib/user-self-identity.test.ts`
+Expected: FAIL — `Cannot find module './user-self-identity'`.
+
+- [ ] **Step 3: Create the module**
+
+Create `src/lib/user-self-identity.ts`:
+
+```ts
+/**
+ * User-self Person node identity management.
+ *
+ * Centralizes everything about the account owner's own Person node: lazy
+ * creation (advisory-lock-guarded), naming it with a distinguishing label,
+ * and seeding only unambiguous (multi-token) aliases into the global alias
+ * table used by `resolveIdentity`. Bare first names are deliberately kept out
+ * of the alias table so a same-named contact can never be merged into the
+ * user (or vice versa) on a single-token match. Also builds the "who the user
+ * is" note injected into document/conversation extraction prompts.
+ *
+ * Common aliases: user self node, self identity, primary self label,
+ * distinguishing aliases, user identity prompt note, isUserSelf.
+ */
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { nodeMetadata, nodes } from "~/db/schema";
+import { createAlias } from "~/lib/alias";
+import { normalizeLabel } from "~/lib/label";
+import type { TypeId } from "~/types/typeid";
+
+/** Count whitespace-separated tokens in an alias (after trimming). */
+function tokenCount(alias: string): number {
+  return alias
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0).length;
+}
+
+/**
+ * Aliases safe to write to the global alias table and to use as a node label:
+ * multi-token only, de-duplicated by normalized form. Single-token names
+ * (e.g. "Marcel") are inherently ambiguous and are intentionally excluded.
+ */
+export function distinguishingAliases(aliases: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const alias of aliases) {
+    const trimmed = alias.trim();
+    if (tokenCount(trimmed) < 2) continue;
+    const key = normalizeLabel(trimmed);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+/**
+ * Pick the most-specific distinguishing alias to use as the self node's
+ * primary label: most tokens, then longest string. Returns null when no
+ * multi-token alias is available, so the node keeps its existing label rather
+ * than being downgraded to an ambiguous single-token name.
+ */
+export function selectPrimarySelfLabel(aliases: string[]): string | null {
+  const candidates = distinguishingAliases(aliases);
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, current) => {
+    const bestTokens = tokenCount(best);
+    const currentTokens = tokenCount(current);
+    if (currentTokens > bestTokens) return current;
+    if (currentTokens === bestTokens && current.length > best.length) {
+      return current;
+    }
+    return best;
+  });
+}
+
+/**
+ * Build the "who the user is" note injected into document/conversation
+ * extraction prompts. Returns null when no aliases are configured so callers
+ * can omit the section entirely.
+ */
+export function buildUserIdentityNote(aliases: string[]): string | null {
+  const cleaned = aliases.map((a) => a.trim()).filter((a) => a.length > 0);
+  if (cleaned.length === 0) return null;
+  const primary = selectPrimarySelfLabel(cleaned) ?? cleaned[0]!;
+  const aliasList = [...new Set(cleaned)].join(", ");
+  return `About the user: the account owner is "${primary}" (also referred to as: ${aliasList}). When the content refers to the user by name, use their most specific name as the node label. Do NOT merge a different person who happens to share a first name with the user, and never attribute a same-named other person's statements to the user.`;
+}
+
+/**
+ * Ensure the user's own Person node exists, returning its id. Looked up by
+ * `nodeMetadata.additionalData.isUserSelf = true`; created lazily on first use.
+ *
+ * Concurrency: serialized per-user via a transaction-scoped Postgres advisory
+ * lock keyed on `hashtext('user_self_person:' || userId)`. Two concurrent
+ * callers for the same user queue at the lock and observe each other's INSERT,
+ * so only one user-self Person row is ever created. The lock releases
+ * automatically at transaction commit.
+ */
+export async function ensureUserSelfPersonNode(
+  db: DrizzleDB,
+  userId: string,
+): Promise<TypeId<"node">> {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${"user_self_person:" + userId}))`,
+    );
+
+    const personNodes = await tx
+      .select({
+        id: nodes.id,
+        label: nodeMetadata.label,
+        additionalData: nodeMetadata.additionalData,
+      })
+      .from(nodes)
+      .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .where(and(eq(nodes.userId, userId), eq(nodes.nodeType, "Person")));
+
+    for (const row of personNodes) {
+      const additional = row.additionalData;
+      if (
+        additional &&
+        typeof additional === "object" &&
+        !Array.isArray(additional) &&
+        (additional as Record<string, unknown>)["isUserSelf"] === true
+      ) {
+        return row.id;
+      }
+    }
+
+    const [newNode] = await tx
+      .insert(nodes)
+      .values({ userId, nodeType: "Person" })
+      .returning();
+    if (!newNode) {
+      throw new Error(`Failed to create user-self Person node for ${userId}`);
+    }
+    await tx.insert(nodeMetadata).values({
+      nodeId: newNode.id,
+      label: userId,
+      canonicalLabel: normalizeLabel(userId),
+      additionalData: { isUserSelf: true },
+    });
+    return newNode.id;
+  });
+}
+
+/**
+ * Ensure the user-self Person node exists, carries a distinguishing primary
+ * label, and has the user's multi-token aliases seeded into the alias table.
+ * Single-token (ambiguous) aliases are deliberately NOT written to the alias
+ * table — they remain usable for transcript speaker matching via the
+ * `userSelfAliases` config set, but must never drive an identity merge.
+ *
+ * Idempotent: safe to call on every transcript ingest and every config write.
+ */
+export async function ensureUserSelfIdentity(
+  db: DrizzleDB,
+  userId: string,
+  aliases: string[],
+): Promise<TypeId<"node">> {
+  const nodeId = await ensureUserSelfPersonNode(db, userId);
+
+  const primaryLabel = selectPrimarySelfLabel(aliases);
+  if (primaryLabel) {
+    await db
+      .update(nodeMetadata)
+      .set({
+        label: primaryLabel,
+        canonicalLabel: normalizeLabel(primaryLabel),
+      })
+      .where(eq(nodeMetadata.nodeId, nodeId));
+  }
+
+  for (const alias of distinguishingAliases(aliases)) {
+    await createAlias(db, {
+      userId,
+      canonicalNodeId: nodeId,
+      aliasText: alias,
+    });
+  }
+
+  return nodeId;
+}
+```
+
+- [ ] **Step 4: Run the pure-helper tests to verify they pass**
+
+Run: `pnpm run test -- run src/lib/user-self-identity.test.ts`
+Expected: PASS (the pure-helper suites). The DB suite is added in Task 5.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS. (`ensureUserSelfPersonNode` now also exists in `resolve-speakers.ts`; two distinct functions, no conflict yet — reconciled in Task 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/user-self-identity.ts src/lib/user-self-identity.test.ts
+git commit -m "✨ feat(identity): user-self identity module (label + distinguishing aliases)"
+```
+
+---
+
+## Task 2: Rewire `resolve-speakers.ts` to the shared self-node helper
+
+**Files:**
+- Modify: `src/lib/transcript/resolve-speakers.ts`
+
+- [ ] **Step 1: Replace the drizzle import (drop `sql`)**
+
+Find:
+```ts
+import { and, eq, inArray, sql } from "drizzle-orm";
+```
+Replace with:
+```ts
+import { and, eq, inArray } from "drizzle-orm";
+```
+
+- [ ] **Step 2: Import the shared helper**
+
+Find:
+```ts
+import { normalizeLabel } from "~/lib/label";
+```
+Replace with:
+```ts
+import { normalizeLabel } from "~/lib/label";
+import { ensureUserSelfPersonNode } from "~/lib/user-self-identity";
+```
+
+- [ ] **Step 3: Stop writing the bare self alias in the user-self branch**
+
+Find:
+```ts
+    // 1. user-self
+    if (userSelfNormalized.has(normalized)) {
+      const nodeId = await ensureUserSelfNode();
+      map.set(label, { nodeId, isUserSelf: true, resolution: "user_self" });
+      // Persist the alias on the user-self node so future identity resolution
+      // picks it up too.
+      await createAlias(db, {
+        userId,
+        canonicalNodeId: nodeId,
+        aliasText: label,
+      });
+      continue;
+    }
+```
+Replace with:
+```ts
+    // 1. user-self. Resolution matches against the `userSelfAliases` config
+    // set directly, so we deliberately do NOT write the (often bare,
+    // ambiguous) speaker label into the alias table — that is exactly what let
+    // a same-named contact merge into the user. Distinguishing aliases are
+    // seeded separately via `ensureUserSelfIdentity`.
+    if (userSelfNormalized.has(normalized)) {
+      const nodeId = await ensureUserSelfNode();
+      map.set(label, { nodeId, isUserSelf: true, resolution: "user_self" });
+      continue;
+    }
+```
+
+- [ ] **Step 4: Delete the local `ensureUserSelfPersonNode`**
+
+Delete the entire local function and its doc comment — the block that begins:
+```ts
+/**
+ * Ensure the user's own Person node exists. Looked up by
+ * `nodeMetadata.additionalData.isUserSelf = true` for the user's Person nodes;
+```
+…through the closing brace of `ensureUserSelfPersonNode` (the `return newNode.id;\n  });\n}` right before `async function createPlaceholderPersonNode(`). The closure `ensureUserSelfNode` near the top of `resolveSpeakers` still calls `ensureUserSelfPersonNode(db, userId)` — it now resolves to the imported version. Leave `createPlaceholderPersonNode` intact.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS. If it reports `createAlias` or `normalizeAliasText` unused, leave them — both are still used by the known-participant and placeholder branches. Only `sql` was removed.
+
+- [ ] **Step 6: Run the speaker-resolution tests**
+
+Run: `pnpm run test -- run src/lib/transcript/resolve-speakers.test.ts`
+Expected: PASS. (Neither test asserts a bare self alias is written.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/transcript/resolve-speakers.ts
+git commit -m "♻️ refactor(transcript): use shared self-node helper; stop seeding bare self alias"
+```
+
+---
+
+## Task 3: `setUserSelfAliases` ensures self identity
+
+**Files:**
+- Modify: `src/lib/user-profile.ts`
+
+- [ ] **Step 1: Import the helper**
+
+Find:
+```ts
+import { newTypeId } from "~/types/typeid";
+```
+Replace with:
+```ts
+import { newTypeId } from "~/types/typeid";
+import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
+```
+
+- [ ] **Step 2: Call `ensureUserSelfIdentity` after persisting**
+
+Find:
+```ts
+  const existing = await readMetadata(db, userId);
+  if (existing === null) {
+    await db.insert(userProfiles).values({
+      id: newTypeId("user_profile"),
+      userId,
+      content: "",
+      metadata: { ...parsed, userSelfAliases: nextAliases },
+    });
+    return { aliases: nextAliases };
+  }
+
+  // Merge: replace `userSelfAliases`, preserve catchall keys.
+  const nextMetadata: UserProfileMetadata = {
+    ...existing,
+    userSelfAliases: nextAliases,
+  };
+  await db
+    .update(userProfiles)
+    .set({ metadata: nextMetadata, lastUpdatedAt: sql`now()` })
+    .where(eq(userProfiles.userId, userId));
+
+  return { aliases: nextAliases };
+```
+Replace with:
+```ts
+  const existing = await readMetadata(db, userId);
+  if (existing === null) {
+    await db.insert(userProfiles).values({
+      id: newTypeId("user_profile"),
+      userId,
+      content: "",
+      metadata: { ...parsed, userSelfAliases: nextAliases },
+    });
+  } else {
+    // Merge: replace `userSelfAliases`, preserve catchall keys.
+    const nextMetadata: UserProfileMetadata = {
+      ...existing,
+      userSelfAliases: nextAliases,
+    };
+    await db
+      .update(userProfiles)
+      .set({ metadata: nextMetadata, lastUpdatedAt: sql`now()` })
+      .where(eq(userProfiles.userId, userId));
+  }
+
+  // Keep the self node's label + distinguishing aliases in sync with config.
+  await ensureUserSelfIdentity(db, userId, nextAliases);
+
+  return { aliases: nextAliases };
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/user-profile.ts
+git commit -m "✨ feat(identity): setUserSelfAliases names the self node + seeds aliases"
+```
+
+---
+
+## Task 4: Transcript ingest ensures self identity with effective aliases
+
+**Files:**
+- Modify: `src/lib/jobs/ingest-transcript.ts`
+
+- [ ] **Step 1: Import the helper**
+
+Find:
+```ts
+import { getUserSelfAliases } from "~/lib/user-profile";
+```
+Replace with:
+```ts
+import { getUserSelfAliases } from "~/lib/user-profile";
+import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
+```
+
+- [ ] **Step 2: Ensure self identity before resolving speakers**
+
+Find:
+```ts
+  const userSelfAliases =
+    userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
+
+  const speakerLabels = utterances.map((u) => u.speakerLabel);
+```
+Replace with:
+```ts
+  const userSelfAliases =
+    userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
+
+  // WhatsApp (and other transcript hosts) send `userSelfAliasesOverride` per
+  // request and never call /user/self-aliases, so the stored list may be
+  // empty. Use the EFFECTIVE list so the self node still gets a distinguishing
+  // label + aliases on the real ingestion path.
+  await ensureUserSelfIdentity(db, userId, userSelfAliases);
+
+  const speakerLabels = utterances.map((u) => u.speakerLabel);
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 4: Run the existing transcript tests (regression)**
+
+Run: `pnpm run test -- run src/lib/jobs/ingest-transcript.test.ts`
+Expected: PASS. The existing self-node assertion (`isUserSelf = true` exists) still holds; the bare-alias change does not break it (self nodes stay non-orphan via their source links).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/jobs/ingest-transcript.ts
+git commit -m "✨ feat(transcript): ensure user-self identity from effective aliases on ingest"
+```
+
+---
+
+## Task 5: DB test for `ensureUserSelfIdentity`
+
+**Files:**
+- Modify: `src/lib/user-self-identity.test.ts`
+
+- [ ] **Step 1: Add the DB-integration suite**
+
+Append to `src/lib/user-self-identity.test.ts` (after the existing pure-helper suites). Add these imports at the TOP of the file (extend the existing `vitest` import and add the others):
+
+```ts
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+```
+
+(Note: the existing top import `import { describe, expect, it } from "vitest";` is now redundant — merge it into the line above so `vitest` is imported once.)
+
+Then append the suite:
+
+```ts
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+async function createIdentityHygieneTables(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "aliases" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "alias_text" text NOT NULL,
+      "normalized_alias_text" text NOT NULL,
+      "canonical_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "aliases_user_normalized_canonical_unique"
+        UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
+    );
+  `);
+}
+
+describeIfServer("ensureUserSelfIdentity", () => {
+  const dbName = `memory_self_identity_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("names the self node with the full name and seeds only multi-token aliases", async () => {
+    const userId = "user_self_identity_a";
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    try {
+      await createIdentityHygieneTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      const database = drizzle(client, { schema, casing: "snake_case" });
+
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const nodeId = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+
+      const meta = await client.query<{
+        label: string;
+        canonical_label: string;
+        additional_data: Record<string, unknown> | null;
+      }>(
+        `SELECT label, canonical_label, additional_data FROM node_metadata WHERE node_id = $1`,
+        [nodeId],
+      );
+      expect(meta.rows[0]?.label).toBe("Marcel Samyn");
+      expect(meta.rows[0]?.canonical_label).toBe("marcel samyn");
+      expect(meta.rows[0]?.additional_data).toMatchObject({ isUserSelf: true });
+
+      const aliasRows = await client.query<{ normalized_alias_text: string }>(
+        `SELECT normalized_alias_text FROM aliases WHERE user_id = $1 AND canonical_node_id = $2`,
+        [userId, nodeId],
+      );
+      const normalized = aliasRows.rows.map((r) => r.normalized_alias_text);
+      expect(normalized).toContain("marcel samyn");
+      expect(normalized).not.toContain("marcel");
+
+      // Idempotent: a second call adds nothing and keeps a single self node.
+      const nodeId2 = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+      expect(nodeId2).toBe(nodeId);
+      const selfCount = await client.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM node_metadata
+         WHERE (additional_data ->> 'isUserSelf') = 'true'`,
+      );
+      expect(selfCount.rows[0]?.count).toBe("1");
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("leaves the label unchanged when only single-token aliases are given", async () => {
+    const userId = "user_self_identity_b";
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    try {
+      await createIdentityHygieneTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      const database = drizzle(client, { schema, casing: "snake_case" });
+
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const nodeId = await ensureUserSelfIdentity(database, userId, ["Marcel"]);
+
+      const meta = await client.query<{ label: string }>(
+        `SELECT label FROM node_metadata WHERE node_id = $1`,
+        [nodeId],
+      );
+      // No multi-token alias → primary label stays the placeholder (userId).
+      expect(meta.rows[0]?.label).toBe(userId);
+
+      const aliasRows = await client.query<{ id: string }>(
+        `SELECT id FROM aliases WHERE user_id = $1 AND canonical_node_id = $2`,
+        [userId, nodeId],
+      );
+      expect(aliasRows.rows).toHaveLength(0);
+    } finally {
+      await client.end();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (DB on :5431)**
+
+Run: `pnpm run test -- run src/lib/user-self-identity.test.ts`
+Expected: PASS (pure suites + both DB tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/user-self-identity.test.ts
+git commit -m "✅ test(identity): ensureUserSelfIdentity names node + seeds multi-token aliases"
+```
+
+---
+
+## Task 6: Self-node backfill (job + schema + route)
+
+**Files:**
+- Create: `src/lib/jobs/backfill-user-self-identity.ts`
+- Create: `src/lib/schemas/backfill-user-self-identity.ts`
+- Create: `src/routes/maintenance/backfill-user-self-identity.post.ts`
+
+- [ ] **Step 1: Create the schemas**
+
+Create `src/lib/schemas/backfill-user-self-identity.ts`:
+
+```ts
+import { z } from "zod";
+
+export const backfillUserSelfIdentityRequestSchema = z.object({
+  userId: z.string().min(1),
+  /** When omitted, the stored `userSelfAliases` are used. */
+  aliases: z.array(z.string().min(1)).optional(),
+});
+
+export const backfillUserSelfIdentityResponseSchema = z.object({
+  selfNodeId: z.string(),
+  primaryAliasesSeeded: z.array(z.string()),
+  removedAmbiguousAliases: z.number().int().nonnegative(),
+});
+```
+
+- [ ] **Step 2: Create the job**
+
+Create `src/lib/jobs/backfill-user-self-identity.ts`:
+
+```ts
+/**
+ * One-off maintenance: bring an existing user-self Person node up to the
+ * current identity-hygiene contract — distinguishing primary label, seeded
+ * multi-token aliases, and NO ambiguous bare-first-name alias.
+ *
+ * Idempotent. Operates on the explicitly-passed aliases when given, else the
+ * stored `userSelfAliases`.
+ */
+import { and, eq } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { aliases as aliasesTable } from "~/db/schema";
+import { normalizeAliasText } from "~/lib/alias";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import {
+  distinguishingAliases,
+  ensureUserSelfIdentity,
+} from "~/lib/user-self-identity";
+
+export interface BackfillUserSelfIdentityParams {
+  db: DrizzleDB;
+  userId: string;
+  aliases?: string[];
+}
+
+export interface BackfillUserSelfIdentityResult {
+  selfNodeId: string;
+  primaryAliasesSeeded: string[];
+  removedAmbiguousAliases: number;
+}
+
+export async function backfillUserSelfIdentity(
+  params: BackfillUserSelfIdentityParams,
+): Promise<BackfillUserSelfIdentityResult> {
+  const { db, userId } = params;
+  const effectiveAliases =
+    params.aliases ?? (await getUserSelfAliases(db, userId));
+
+  const selfNodeId = await ensureUserSelfIdentity(db, userId, effectiveAliases);
+  const seeded = distinguishingAliases(effectiveAliases);
+  const keep = new Set(seeded.map((a) => normalizeAliasText(a)));
+
+  // Remove any previously-written single-token (ambiguous) alias rows on the
+  // self node; keep only the multi-token distinguishing aliases.
+  const selfAliasRows = await db
+    .select({
+      id: aliasesTable.id,
+      normalized: aliasesTable.normalizedAliasText,
+    })
+    .from(aliasesTable)
+    .where(
+      and(
+        eq(aliasesTable.userId, userId),
+        eq(aliasesTable.canonicalNodeId, selfNodeId),
+      ),
+    );
+
+  let removed = 0;
+  for (const row of selfAliasRows) {
+    if (!keep.has(row.normalized)) {
+      await db.delete(aliasesTable).where(eq(aliasesTable.id, row.id));
+      removed += 1;
+    }
+  }
+
+  return {
+    selfNodeId,
+    primaryAliasesSeeded: seeded,
+    removedAmbiguousAliases: removed,
+  };
+}
+```
+
+- [ ] **Step 3: Create the route**
+
+Create `src/routes/maintenance/backfill-user-self-identity.post.ts`:
+
+```ts
+import { defineEventHandler, readBody } from "h3";
+import { backfillUserSelfIdentity } from "~/lib/jobs/backfill-user-self-identity";
+import {
+  backfillUserSelfIdentityRequestSchema,
+  backfillUserSelfIdentityResponseSchema,
+} from "~/lib/schemas/backfill-user-self-identity";
+import { useDatabase } from "~/utils/db";
+
+export default defineEventHandler(async (event) => {
+  const { userId, aliases } = backfillUserSelfIdentityRequestSchema.parse(
+    await readBody(event),
+  );
+  const db = await useDatabase();
+  const result = await backfillUserSelfIdentity({
+    db,
+    userId,
+    ...(aliases !== undefined ? { aliases } : {}),
+  });
+  return backfillUserSelfIdentityResponseSchema.parse(result);
+});
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/jobs/backfill-user-self-identity.ts src/lib/schemas/backfill-user-self-identity.ts src/routes/maintenance/backfill-user-self-identity.post.ts
+git commit -m "✨ feat(maintenance): backfill route to repair existing user-self identity"
+```
+
+---
+
+## Task 7: Component 2 — register speaker nodes as subjects + prompt wiring
+
+**Files:**
+- Modify: `src/lib/extract-graph.ts`
+
+- [ ] **Step 1: Register speaker nodes into `idMap`**
+
+Find:
+```ts
+  const { nodesForPromptFormatting, idMap, nodeLabels } =
+    _prepareInitialNodeMappings(cappedNodes);
+```
+Replace with:
+```ts
+  const { nodesForPromptFormatting, idMap, nodeLabels } =
+    _prepareInitialNodeMappings(cappedNodes);
+
+  // Register every resolved speaker node so the LLM can use its real id as a
+  // claim subjectId (e.g. the user-self speaker's first-person statements).
+  // Unconditional — speaker subjects must not be dropped by the 150-node cap.
+  if (speakerMap) {
+    for (const entry of speakerMap.values()) {
+      idMap.set(entry.nodeId.toString(), entry.nodeId);
+    }
+  }
+```
+
+- [ ] **Step 2: Make the speaker section teach subject-wiring**
+
+Find the whole `_formatSpeakerMapSection` function:
+```ts
+function _formatSpeakerMapSection(
+  speakerMap: ExtractGraphSpeakerMap | undefined,
+): string {
+  if (!speakerMap || speakerMap.size === 0) return "";
+  const lines = [...speakerMap.entries()].map(([label, entry]) => {
+    const role = entry.isUserSelf ? "user-self" : "other-participant";
+    return `- speakerLabel: ${label}; nodeId: ${entry.nodeId}; role: ${role}`;
+  });
+  return `Speakers in this transcript:
+For each claim, set "assertedBySpeakerLabel" to the speaker who said it, using these labels exactly. Claims whose speaker label is missing or not in this list will be dropped.
+${lines.join("\n")}`;
+}
+```
+Replace with:
+```ts
+function _formatSpeakerMapSection(
+  speakerMap: ExtractGraphSpeakerMap | undefined,
+): string {
+  if (!speakerMap || speakerMap.size === 0) return "";
+  const lines = [...speakerMap.entries()].map(([label, entry]) => {
+    const role = entry.isUserSelf
+      ? "user-self (the user / 'you')"
+      : "other-participant";
+    return `- speakerLabel: ${label}; nodeId: ${entry.nodeId}; role: ${role}`;
+  });
+  return `Speakers in this transcript:
+For each claim, set "assertedBySpeakerLabel" to the speaker who said it, using these labels exactly. Claims whose speaker label is missing or not in this list will be dropped.
+When a speaker states a fact about themselves (first-person "I…/my…"), use that speaker's nodeId above as the claim's subjectId — do NOT mint a new node for a speaker already listed here. In particular, attribute the user-self speaker's self-statements to their nodeId, never to a newly created same-named node.
+${lines.join("\n")}`;
+}
+```
+
+- [ ] **Step 3: Demonstrate subject-wiring in the static transcript few-shot**
+
+Find:
+```ts
+- Speaker "Alice" (user-self) says "I shipped the spec." → assertionKind: "user", assertedBySpeakerLabel: "Alice".
+```
+Replace with:
+```ts
+- Speaker "Alice" (user-self) says "I live in Lisbon." → create the (LIVES_IN, Lisbon) claim with subjectId set to Alice's nodeId from "Speakers in this transcript" (do NOT mint a new "Alice" node), assertionKind: "user", assertedBySpeakerLabel: "Alice".
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 5: Regression — existing transcript tests still pass**
+
+Run: `pnpm run test -- run src/lib/jobs/ingest-transcript.test.ts`
+Expected: PASS. (Existing stubs reference minted node ids, not speaker ids, so they are unaffected.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/extract-graph.ts
+git commit -m "✨ feat(transcript): wire user-self speaker as claim subject in extraction"
+```
+
+---
+
+## Task 8: Component 2 — transcript subject-wiring integration test
+
+**Files:**
+- Modify: `src/lib/jobs/ingest-transcript.test.ts`
+
+- [ ] **Step 1: Add the integration test**
+
+Insert this `it(...)` block inside the `describeIfServer("ingestTranscript", () => { ... })` block, after the last existing `it(...)` (i.e. just before the closing `});` of the describe at the end of the file):
+
+```ts
+  it("attributes a user-self first-person claim to the self node, not a same-named participant", async () => {
+    const userId = "user_transcript_subject";
+    const transcriptId = "trans_subject_1";
+    const occurredAt = new Date("2026-05-01T10:00:00.000Z");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    // Captured so the LLM stub can emit the real self node id as subjectId.
+    let selfNodeIdForStub = "";
+
+    applyCommonMocks(database);
+    vi.doMock("../ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../ai")>()),
+      createCompletionClient: async () => ({
+        chat: {
+          completions: {
+            parse: async () => ({
+              choices: [
+                {
+                  message: {
+                    parsed: {
+                      nodes: [
+                        { id: "loc_1", type: "Location", label: "Lisbon" },
+                      ],
+                      relationshipClaims: [
+                        {
+                          subjectId: selfNodeIdForStub,
+                          objectId: "loc_1",
+                          predicate: "LIVES_IN",
+                          statement: "Marcel lives in Lisbon.",
+                          sourceRef: `${transcriptId}:0`,
+                          assertionKind: "user",
+                          assertedBySpeakerLabel: "Marcel",
+                        },
+                      ],
+                      attributeClaims: [],
+                      aliases: [],
+                    },
+                  },
+                },
+              ],
+            }),
+          },
+        },
+      }),
+    }));
+
+    try {
+      await createTranscriptTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+
+      // A different, same-first-name person already in the graph.
+      const otherMarcelId = newTypeId("node");
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Person')`,
+        [otherMarcelId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES ($1, $2, 'Marcel', 'marcel')`,
+        [newTypeId("node_metadata"), otherMarcelId],
+      );
+
+      const { ensureUserSelfIdentity } = await import("../user-self-identity");
+      const selfNodeId = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+      selfNodeIdForStub = selfNodeId;
+
+      const { ingestTranscript } = await import("./ingest-transcript");
+      await ingestTranscript({
+        db: database,
+        userId,
+        transcriptId,
+        scope: "personal",
+        occurredAt,
+        content: {
+          kind: "segmented",
+          utterances: [
+            { speakerLabel: "Marcel", content: "I live in Lisbon now." },
+          ],
+        },
+        userSelfAliasesOverride: ["Marcel", "Marcel Samyn"],
+      });
+
+      const livesIn = await client.query<{
+        subject_node_id: string;
+        asserted_by_kind: string;
+      }>(
+        `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LIVES_IN'`,
+        [userId],
+      );
+      expect(livesIn.rows).toHaveLength(1);
+      expect(livesIn.rows[0]?.subject_node_id).toBe(selfNodeId);
+      expect(livesIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
+      expect(livesIn.rows[0]?.asserted_by_kind).toBe("user");
+    } finally {
+      unmockCommon();
+      await client.end();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the transcript tests**
+
+Run: `pnpm run test -- run src/lib/jobs/ingest-transcript.test.ts`
+Expected: PASS (all existing + the new subject-wiring test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/jobs/ingest-transcript.test.ts
+git commit -m "✅ test(transcript): user-self first-person claim attaches to self node"
+```
+
+---
+
+## Task 9: Component 3 — resolver never guesses on a tie
+
+**Files:**
+- Modify: `src/lib/identity-resolution.ts`
+- Modify: `src/lib/identity-resolution.test.ts`
+
+- [ ] **Step 1: Write the failing resolver tests**
+
+Insert these two `it(...)` blocks inside the `describeIfServer("resolveIdentity", () => { ... })` block in `src/lib/identity-resolution.test.ts`, after the last existing `it(...)` (just before the describe's closing `});`):
+
+```ts
+  it("signal 1 — multiple same-scope canonical matches do not resolve (ambiguous)", async () => {
+    await withDb(async (client) => {
+      const userId = "user_ambiguous";
+      const marcelA = newTypeId("node");
+      const marcelB = newTypeId("node");
+      const sourceId = newTypeId("source");
+      await createIdentityTables(client);
+      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+           VALUES ($1,$2,'document','p1','personal')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes"("id","user_id","node_type")
+           VALUES ($1,$3,'Person'),($2,$3,'Person')`,
+        [marcelA, marcelB, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+           VALUES ($1,$3,'Marcel','marcel'),($2,$4,'Marcel','marcel')`,
+        [
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          marcelA,
+          marcelB,
+        ],
+      );
+      await client.query(
+        `INSERT INTO "source_links"("id","source_id","node_id")
+           VALUES ($1,$3,$4),($2,$3,$5)`,
+        [
+          newTypeId("source_link"),
+          newTypeId("source_link"),
+          sourceId,
+          marcelA,
+          marcelB,
+        ],
+      );
+
+      const { resolveIdentity } = await import("./identity-resolution");
+      const { setLogSink } = await import("~/lib/observability/log");
+      const captured: Array<Record<string, unknown>> = [];
+      setLogSink((event) => captured.push(event));
+      try {
+        const resolution = await resolveIdentity({
+          userId,
+          candidate: {
+            proposedLabel: "Marcel",
+            normalizedLabel: "marcel",
+            nodeType: "Person",
+            scope: "personal",
+          },
+        });
+        expect(resolution.resolvedNodeId).toBeNull();
+        expect(resolution.decision.signal).toBe("none");
+        const canonical = resolution.decision.trace.find(
+          (t) => t.signal === "canonical_label",
+        );
+        expect(canonical?.fired).toBe(true);
+        expect(canonical?.candidates).toHaveLength(2);
+        expect(
+          canonical?.signal === "canonical_label" && canonical.ambiguous,
+        ).toMatchObject({
+          candidateNodeIds: expect.arrayContaining([marcelA, marcelB]),
+        });
+        const skip = captured.find(
+          (e) => e["event"] === "identity.ambiguous_skip",
+        );
+        expect(skip).toMatchObject({
+          event: "identity.ambiguous_skip",
+          userId,
+          normalizedLabel: "marcel",
+          signal: "canonical_label",
+          candidateCount: 2,
+        });
+      } finally {
+        setLogSink();
+      }
+    });
+  });
+
+  it("self resolves by full name; a bare same-first-name does not merge into self", async () => {
+    await withDb(async (client) => {
+      const userId = "user_self_fullname";
+      await createIdentityTables(client);
+      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+
+      const { useDatabase } = await import("~/utils/db");
+      const db = await useDatabase();
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const selfNodeId = await ensureUserSelfIdentity(db, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+
+      // A separate third-party "Marcel" with personal-scope support.
+      const otherMarcel = newTypeId("node");
+      const sourceId = newTypeId("source");
+      await client.query(
+        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+           VALUES ($1,$2,'document','d1','personal')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes"("id","user_id","node_type") VALUES ($1,$2,'Person')`,
+        [otherMarcel, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+           VALUES ($1,$2,'Marcel','marcel')`,
+        [newTypeId("node_metadata"), otherMarcel],
+      );
+      await client.query(
+        `INSERT INTO "source_links"("id","source_id","node_id") VALUES ($1,$2,$3)`,
+        [newTypeId("source_link"), sourceId, otherMarcel],
+      );
+
+      const { resolveIdentity } = await import("./identity-resolution");
+
+      const full = await resolveIdentity({
+        userId,
+        candidate: {
+          proposedLabel: "Marcel Samyn",
+          normalizedLabel: "marcel samyn",
+          nodeType: "Person",
+          scope: "personal",
+        },
+      });
+      expect(full.resolvedNodeId).toBe(selfNodeId);
+
+      const bare = await resolveIdentity({
+        userId,
+        candidate: {
+          proposedLabel: "Marcel",
+          normalizedLabel: "marcel",
+          nodeType: "Person",
+          scope: "personal",
+        },
+      });
+      expect(bare.resolvedNodeId).toBe(otherMarcel);
+      expect(bare.resolvedNodeId).not.toBe(selfNodeId);
+    });
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm run test -- run src/lib/identity-resolution.test.ts`
+Expected: FAIL — the ambiguous test currently resolves to `candidates[0]` (non-null) and there is no `ambiguous` field / `identity.ambiguous_skip` event yet.
+
+- [ ] **Step 3: Add the `ambiguous` field to the exact-match trace variants**
+
+In `src/lib/identity-resolution.ts`, find:
+```ts
+  | {
+      signal: "canonical_label";
+      fired: boolean;
+      candidates: SignalCandidate[];
+      /** Set when a same-label match exists in a different scope. */
+      crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+    }
+  | {
+      signal: "alias";
+      fired: boolean;
+      candidates: SignalCandidate[];
+      crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+    }
+```
+Replace with:
+```ts
+  | {
+      signal: "canonical_label";
+      fired: boolean;
+      candidates: SignalCandidate[];
+      /** Set when a same-label match exists in a different scope. */
+      crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+      /** Set when >1 same-scope/type candidate matched; resolver refuses to guess. */
+      ambiguous?: { candidateNodeIds: TypeId<"node">[] };
+    }
+  | {
+      signal: "alias";
+      fired: boolean;
+      candidates: SignalCandidate[];
+      crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+      /** Set when >1 same-scope/type candidate matched; resolver refuses to guess. */
+      ambiguous?: { candidateNodeIds: TypeId<"node">[] };
+    }
+```
+
+- [ ] **Step 4: Resolve only on a unique canonical match**
+
+Find:
+```ts
+  if (canonicalTrace.signal === "canonical_label" && canonicalTrace.fired) {
+    const winner = canonicalTrace.candidates[0];
+    if (winner) {
+      return _resolved(
+        winner.nodeId,
+        "canonical_label",
+        winner.score,
+        trace,
+        candidate,
+        userId,
+      );
+    }
+  }
+```
+Replace with:
+```ts
+  if (canonicalTrace.signal === "canonical_label" && canonicalTrace.fired) {
+    if (canonicalTrace.candidates.length === 1) {
+      const winner = canonicalTrace.candidates[0]!;
+      return _resolved(
+        winner.nodeId,
+        "canonical_label",
+        winner.score,
+        trace,
+        candidate,
+        userId,
+      );
+    }
+    // More than one same-scope/type candidate: do not guess. Record the
+    // ambiguity, log it, and fall through to later (more discriminating)
+    // signals; at extraction time those are absent, so the caller splits.
+    canonicalTrace.ambiguous = {
+      candidateNodeIds: canonicalTrace.candidates.map((c) => c.nodeId),
+    };
+    _logAmbiguousSkip(
+      userId,
+      candidate,
+      "canonical_label",
+      canonicalTrace.candidates,
+    );
+  }
+```
+
+- [ ] **Step 5: Resolve only on a unique alias match**
+
+Find:
+```ts
+  if (aliasTrace.signal === "alias" && aliasTrace.fired) {
+    const winner = aliasTrace.candidates[0];
+    if (winner) {
+      return _resolved(
+        winner.nodeId,
+        "alias",
+        winner.score,
+        trace,
+        candidate,
+        userId,
+      );
+    }
+  }
+```
+Replace with:
+```ts
+  if (aliasTrace.signal === "alias" && aliasTrace.fired) {
+    if (aliasTrace.candidates.length === 1) {
+      const winner = aliasTrace.candidates[0]!;
+      return _resolved(
+        winner.nodeId,
+        "alias",
+        winner.score,
+        trace,
+        candidate,
+        userId,
+      );
+    }
+    aliasTrace.ambiguous = {
+      candidateNodeIds: aliasTrace.candidates.map((c) => c.nodeId),
+    };
+    _logAmbiguousSkip(userId, candidate, "alias", aliasTrace.candidates);
+  }
+```
+
+- [ ] **Step 6: Add the `_logAmbiguousSkip` helper**
+
+In `src/lib/identity-resolution.ts`, find the start of `_logCrossScopeRefusal`:
+```ts
+function _logCrossScopeRefusal(
+```
+Insert this function immediately ABOVE it:
+```ts
+function _logAmbiguousSkip(
+  userId: string,
+  candidate: IdentityCandidate,
+  signal: "canonical_label" | "alias",
+  candidates: SignalCandidate[],
+): void {
+  logEvent("identity.ambiguous_skip", {
+    userId,
+    candidateLabel: candidate.proposedLabel,
+    normalizedLabel: candidate.normalizedLabel,
+    nodeType: candidate.nodeType,
+    scope: candidate.scope,
+    signal,
+    candidateNodeIds: candidates.map((c) => c.nodeId),
+    candidateCount: candidates.length,
+  });
+}
+
+```
+
+- [ ] **Step 7: Run the resolver tests + full identity suite**
+
+Run: `pnpm run test -- run src/lib/identity-resolution.test.ts`
+Expected: PASS (existing single-match + cross-scope tests still pass; the two new tests pass).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/identity-resolution.ts src/lib/identity-resolution.test.ts
+git commit -m "✨ feat(identity): unique-match-wins resolver + identity.ambiguous_skip"
+```
+
+---
+
+## Task 10: Component 4 — `userIdentityNote` param + render + static rule
+
+**Files:**
+- Modify: `src/lib/extract-graph.ts`
+
+- [ ] **Step 1: Add the param to `ExtractGraphParams`**
+
+Find:
+```ts
+  contentNote?: string;
+  /**
+   * Debug hook fired exactly once after the LLM call returns, before
+```
+Replace with:
+```ts
+  contentNote?: string;
+  /**
+   * Optional "who the user is" note (primary name + aliases) injected into the
+   * trailing user message so the model emits the user's most specific label
+   * and never conflates a same-named other person with the user. Used by
+   * document and conversation ingestion (transcripts use the speaker map
+   * instead). Cache-safe: lives in the dynamic user message, not the system
+   * prompt.
+   */
+  userIdentityNote?: string;
+  /**
+   * Debug hook fired exactly once after the LLM call returns, before
+```
+
+- [ ] **Step 2: Destructure it**
+
+Find:
+```ts
+  content,
+  speakerMap,
+  replaceClaimsForSources = true,
+  contentNote,
+  onLlmIO,
+}: ExtractGraphParams) {
+```
+Replace with:
+```ts
+  content,
+  speakerMap,
+  replaceClaimsForSources = true,
+  contentNote,
+  userIdentityNote,
+  onLlmIO,
+}: ExtractGraphParams) {
+```
+
+- [ ] **Step 3: Build the render section alongside the others**
+
+Find:
+```ts
+  const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
+```
+Replace with:
+```ts
+  const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
+
+  const userIdentityPromptSection = userIdentityNote
+    ? `${userIdentityNote}\n\n`
+    : "";
+```
+
+- [ ] **Step 4: Inject the section into the user message**
+
+Find:
+```ts
+${speakerMapPromptSection}
+
+Extract the graph from the following ${sourceType}:
+```
+Replace with:
+```ts
+${speakerMapPromptSection}
+
+${userIdentityPromptSection}Extract the graph from the following ${sourceType}:
+```
+
+- [ ] **Step 5: Add the static anti-conflation rule**
+
+Find:
+```ts
+- In node names use full names, eg. "John Doe" instead of "John"
+```
+Replace with:
+```ts
+- In node names use full names, eg. "John Doe" instead of "John"
+- If multiple people could share a name, use the most specific distinguishing label available (e.g. a full name) and NEVER merge or conflate two different people who share a first name.
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/extract-graph.ts
+git commit -m "✨ feat(extraction): userIdentityNote injection + anti-conflation rule"
+```
+
+---
+
+## Task 11: Component 4 — wire conversation + document paths
+
+**Files:**
+- Modify: `src/lib/jobs/ingest-conversation.ts`
+- Modify: `src/lib/ingestion/extract-document-graph.ts`
+- Modify: `src/lib/ingestion/chunked-extract.ts`
+
+- [ ] **Step 1: Conversation — imports**
+
+In `src/lib/jobs/ingest-conversation.ts`, find:
+```ts
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
+```
+Replace with:
+```ts
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import { buildUserIdentityNote } from "~/lib/user-self-identity";
+```
+
+- [ ] **Step 2: Conversation — build + pass the note**
+
+Find:
+```ts
+  await extractGraph({
+    userId,
+    sourceType: "conversation",
+    sourceId,
+    statedAt: firstTurn.timestamp,
+    linkedNodeId: conversationNodeId,
+    sourceRefs,
+    content: formatConversationAsXml(insertedTurns),
+  });
+```
+Replace with:
+```ts
+  const userIdentityNote = buildUserIdentityNote(
+    await getUserSelfAliases(db, userId),
+  );
+  await extractGraph({
+    userId,
+    sourceType: "conversation",
+    sourceId,
+    statedAt: firstTurn.timestamp,
+    linkedNodeId: conversationNodeId,
+    sourceRefs,
+    content: formatConversationAsXml(insertedTurns),
+    ...(userIdentityNote ? { userIdentityNote } : {}),
+  });
+```
+
+- [ ] **Step 3: Document — imports**
+
+In `src/lib/ingestion/extract-document-graph.ts`, find:
+```ts
+import { runChunkedExtraction } from "./chunked-extract";
+import { ensureSourceNode } from "./ensure-source-node";
+import { DrizzleDB } from "~/db";
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
+```
+Replace with:
+```ts
+import { runChunkedExtraction } from "./chunked-extract";
+import { ensureSourceNode } from "./ensure-source-node";
+import { DrizzleDB } from "~/db";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import { buildUserIdentityNote } from "~/lib/user-self-identity";
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
+```
+
+- [ ] **Step 4: Document — build + pass the note**
+
+Find:
+```ts
+  const linkedNodeId = await ensureSourceNode({
+    db,
+    userId,
+    sourceId,
+    timestamp,
+    nodeType: NodeTypeEnum.enum.Document,
+  });
+
+  await runChunkedExtraction({
+    userId,
+    sourceType: "document",
+    sourceId,
+    statedAt: timestamp,
+    linkedNodeId,
+    sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
+    content,
+    logLabel,
+    documentMetadata: {
+      ...(title !== undefined && { title }),
+      ...(author !== undefined && { author }),
+    },
+  });
+```
+Replace with:
+```ts
+  const linkedNodeId = await ensureSourceNode({
+    db,
+    userId,
+    sourceId,
+    timestamp,
+    nodeType: NodeTypeEnum.enum.Document,
+  });
+
+  const userIdentityNote = buildUserIdentityNote(
+    await getUserSelfAliases(db, userId),
+  );
+
+  await runChunkedExtraction({
+    userId,
+    sourceType: "document",
+    sourceId,
+    statedAt: timestamp,
+    linkedNodeId,
+    sourceRefs: [{ externalId, sourceId, statedAt: timestamp }],
+    content,
+    logLabel,
+    documentMetadata: {
+      ...(title !== undefined && { title }),
+      ...(author !== undefined && { author }),
+    },
+    ...(userIdentityNote ? { userIdentityNote } : {}),
+  });
+```
+
+- [ ] **Step 5: Chunked-extract — add param to the interface**
+
+In `src/lib/ingestion/chunked-extract.ts`, find:
+```ts
+  documentMetadata?: {
+    title?: string;
+    author?: string;
+  };
+}
+```
+Replace with:
+```ts
+  documentMetadata?: {
+    title?: string;
+    author?: string;
+  };
+  /**
+   * "Who the user is" note forwarded verbatim to every chunk's `extractGraph`
+   * call so per-fragment extraction resolves the user's name correctly.
+   */
+  userIdentityNote?: string;
+}
+```
+
+- [ ] **Step 6: Chunked-extract — destructure + forward to every chunk**
+
+Find:
+```ts
+  const {
+    userId,
+    sourceType,
+    sourceId,
+    statedAt,
+    linkedNodeId,
+    sourceRefs,
+    content,
+    logLabel,
+    documentMetadata,
+  } = params;
+```
+Replace with:
+```ts
+  const {
+    userId,
+    sourceType,
+    sourceId,
+    statedAt,
+    linkedNodeId,
+    sourceRefs,
+    content,
+    logLabel,
+    documentMetadata,
+    userIdentityNote,
+  } = params;
+```
+
+Then find:
+```ts
+  const baseExtractParams = {
+    userId,
+    sourceType,
+    sourceId,
+    statedAt,
+    linkedNodeId,
+    sourceRefs,
+  };
+```
+Replace with:
+```ts
+  const baseExtractParams = {
+    userId,
+    sourceType,
+    sourceId,
+    statedAt,
+    linkedNodeId,
+    sourceRefs,
+    ...(userIdentityNote ? { userIdentityNote } : {}),
+  };
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/jobs/ingest-conversation.ts src/lib/ingestion/extract-document-graph.ts src/lib/ingestion/chunked-extract.ts
+git commit -m "✨ feat(extraction): inject user identity into document + conversation prompts"
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck + structured-output schema check**
+
+Run: `pnpm run build:check`
+Expected: PASS.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm run lint`
+Expected: PASS (no errors). Fix any unused-import warnings introduced (most likely the removed `sql` in `resolve-speakers.ts` — already handled in Task 2).
+
+- [ ] **Step 3: Format**
+
+Run: `pnpm run format`
+Expected: PASS. If it reports formatting diffs, run `pnpm run format:fix` and re-commit the touched files.
+
+- [ ] **Step 4: Run the full affected test set (DB on :5431)**
+
+Run:
+```bash
+pnpm run test -- run \
+  src/lib/user-self-identity.test.ts \
+  src/lib/transcript/resolve-speakers.test.ts \
+  src/lib/jobs/ingest-transcript.test.ts \
+  src/lib/identity-resolution.test.ts
+```
+Expected: all PASS. (Start Postgres first if needed: `docker compose up -d db`.)
+
+- [ ] **Step 5: Final commit (only if format:fix or lint:fix changed files)**
+
+```bash
+git add -p
+git commit -m "🎨 style(identity): lint/format cleanup"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| Spec item | Task(s) |
+| --- | --- |
+| C1 primary label = longest/most-token alias | Task 1 (`selectPrimarySelfLabel`) |
+| C1 `ensureUserSelfIdentity` from both call sites (config + transcript, effective aliases) | Tasks 3, 4 |
+| C1 keep single-token aliases out of the alias table | Task 1 (`distinguishingAliases`) |
+| C1 stop writing bare self alias in `resolveSpeakers` | Task 2 |
+| C1 backfill maintenance route | Task 6 |
+| C2 register speaker nodes into `idMap` unconditionally | Task 7 (Step 1) |
+| C2 surface user-self as "you" + subject-wiring in prompt | Task 7 (Steps 2–3) |
+| C2 caching contract preserved (dynamic stays in user message) | Task 7 (speaker section) + Task 10 (note in user message) |
+| C3 unique-match-wins; >1 → split + `identity.ambiguous_skip` | Task 9 |
+| C3 no blunt self-prior | Confirmed: no self-preference added to the resolver anywhere |
+| C4 inject identity into document + conversation prompts | Tasks 10, 11 |
+| C4 instruct most-specific labels / no conflation | Task 10 (Step 5, static rule) |
+| Testing: resolver ambiguity/unique/cross-scope | Task 9 |
+| Testing: self hygiene seeds only multi-token; no bare alias | Tasks 5, 2 |
+| Testing: transcript self-utterance attaches to self with same-named participant present | Task 8 |
+| Testing: document "Marcel Samyn" → self; bare "Marcel" ↛ self | Task 9 (Step 1, second test) |
+
+**2. Deliberate deviation from the spec (flagged):** the spec's "Testing (Integration document)" and "extend eval story 10" are delivered as **vitest integration/unit tests** (Task 8 transcript, Task 9 document-case) rather than as `src/evals/memory/stories/*` fixtures. Rationale: the vitest tests run against real Postgres and assert the exact subject/resolution behavior directly, giving equivalent coverage without the eval-harness stub plumbing; an eval-story extension can be added later if the probe harness needs it. No spec *behavior* is left unverified.
+
+**3. Placeholder scan:** none — every code step contains complete copy-pasteable content; every test step contains full assertions.
+
+**4. Type consistency:** `ensureUserSelfIdentity(db, userId, aliases) → Promise<TypeId<"node">>` and `ensureUserSelfPersonNode(db, userId) → Promise<TypeId<"node">>` are used consistently across Tasks 1–6, 8, 9. `buildUserIdentityNote(aliases) → string | null` and the `...(userIdentityNote ? { userIdentityNote } : {})` spread (for `exactOptionalPropertyTypes`) are used consistently in Tasks 10–11. The `ambiguous?: { candidateNodeIds: TypeId<"node">[] }` field name matches between the type addition (Task 9 Step 3) and the writes (Steps 4–5) and the test assertion (Step 1). The new log event name `identity.ambiguous_skip` matches between emitter (Step 6) and test (Step 1).
+
+**5. Open questions (resolved per the approved defaults):** self tiebreak → always split (no resolver self-prior); primary label → longest multi-token alias; live-graph confirmation → proceeding on the code-grounded diagnosis.

--- a/docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md
@@ -15,7 +15,7 @@ The same class of bug applies generally: any two same-named people (e.g. two
 friends named "Sarah") can be conflated, and a bare-first-name mention can be
 routed to the wrong node. The fix must be **general** (same-name
 disambiguation for anyone), with the user's own identity handled as a
-first-class case — but *not* via a blunt "when unsure, assume it's the user"
+first-class case — but _not_ via a blunt "when unsure, assume it's the user"
 heuristic, which is itself a cause of mis-merges.
 
 ## Root-cause analysis (code-grounded)
@@ -26,7 +26,7 @@ compounding gaps, traced through the transcript ingestion path
 
 1. **The speaker map carries provenance, not subject.** `speakerMap` is
    consumed only by `_resolveAssertedByKind` / `_resolveTranscriptProvenance`
-   to set *who asserted* a claim (`src/lib/extract-graph.ts:1352`). It is
+   to set _who asserted_ a claim (`src/lib/extract-graph.ts:1352`). It is
    never registered into `idMap`. So when the user-self speaker says "I'm
    flying to Lisbon", nothing tells the LLM to make the user the **subject** —
    it mints a fresh `temp_person` labelled "Marcel".
@@ -71,7 +71,7 @@ subject assignment + ambiguous name resolution downstream.
    first-class case — not a self-only patch.
 2. **Self-preference lives upstream, never as a blunt resolver default.** The
    user's identity is delivered by (a) subject-wiring in transcripts and
-   (b) specific, unambiguous aliases — *not* by making the resolver prefer the
+   (b) specific, unambiguous aliases — _not_ by making the resolver prefer the
    self node on an ambiguous match. A blunt "assume self" rule is the
    over-merge failure mode and is explicitly rejected.
 3. **Bare first names are inherently ambiguous and must never auto-merge** —
@@ -86,9 +86,9 @@ subject assignment + ambiguous name resolution downstream.
 
 Four components, each mapped to a root cause.
 
-### Component 1 — Self-node identity hygiene  *(fixes root cause #2)*
+### Component 1 — Self-node identity hygiene _(fixes root cause #2)_
 
-Give the user-self node a real, *distinguishing* identity and keep the alias
+Give the user-self node a real, _distinguishing_ identity and keep the alias
 table in sync, without seeding ambiguous bare first names.
 
 - **Primary label.** The self node's `label` / `canonicalLabel` becomes the
@@ -111,20 +111,20 @@ table in sync, without seeding ambiguous bare first names.
     `userSelfAliasesOverride` per request and never calls
     `/user/self-aliases`, so the persistent list may be empty. Hooking only
     the config endpoint would miss the real ingestion flow.
-  The single-token aliases remain available for transcript *speaker* matching
-  via the `userSelfAliases` config set (`resolve-speakers.ts:114`); they are
-  just kept out of the identity-resolution alias table.
+    The single-token aliases remain available for transcript _speaker_ matching
+    via the `userSelfAliases` config set (`resolve-speakers.ts:114`); they are
+    just kept out of the identity-resolution alias table.
 - **Stop writing the ambiguous self alias in speaker resolution.**
   `resolveSpeakers` no longer writes the bare user-self speaker label into the
   alias table (`resolve-speakers.ts:119`). Speaker resolution already matches
   self via the `userSelfAliases` config set (`:114`), so this is safe and
-  removes the ambiguity at its source. (Alias writes for *other* participants
+  removes the ambiguity at its source. (Alias writes for _other_ participants
   are unchanged.)
 - **Backfill.** A one-off maintenance route under `src/routes/maintenance/`
   renames the existing self node to the primary label, seeds distinguishing
   aliases, and removes the bare-first-name self alias if present.
 
-### Component 2 — Wire user-self as the claim *subject*  *(fixes root cause #1)*
+### Component 2 — Wire user-self as the claim _subject_ _(fixes root cause #1)_
 
 In the transcript path, make the user-self speaker's node the subject of that
 speaker's first-person claims, so "I…" attaches to the user — never to a minted
@@ -145,7 +145,7 @@ node.
 - This keeps the byte-identical-system-prompt caching contract: dynamic
   per-user identity stays in the trailing user message / speaker section.
 
-### Component 3 — Resolver: unique-match-wins, never guess  *(fixes root cause #3; generalises)*
+### Component 3 — Resolver: unique-match-wins, never guess _(fixes root cause #3; generalises)_
 
 Change the ambiguity behaviour of `resolveIdentity`
 (`src/lib/identity-resolution.ts`) for the exact-match signals (canonical
@@ -158,14 +158,15 @@ label, alias):
   null-path behaviour = "split") and emits a new observability event
   (`identity.ambiguous_skip`) carrying the candidate set, mirroring the
   existing `identity.cross_scope_merge_refused` pattern. Consolidation is left
-  to the background identity re-eval / `cleanup/dedup-sweep`, which *do* have
+  to the background identity re-eval / `cleanup/dedup-sweep`, which _do_ have
   embeddings + claim profiles to disambiguate with.
 - **No blunt self-prior.** `isUserSelf` is recorded in the decision trace for
-  observability and may serve as an *evidence-gated* tiebreak only (see Open
+  observability and may serve as an _evidence-gated_ tiebreak only (see Open
   questions), but is never a default winner — to avoid resurrecting the
   over-merge failure.
 
 Net effect with Components 1+2 in place:
+
 - A third-party bare "Marcel" mention that matches several nodes → split +
   logged (no arbitrary mis-route), instead of silently grabbing `candidates[0]`.
 - A specific "Marcel Samyn" mention (document/conversation, no speaker map) →
@@ -173,7 +174,7 @@ Net effect with Components 1+2 in place:
 - A transcript first-person "I…" → attached to self by subject-wiring
   (Component 2), never reaching the ambiguous name path.
 
-### Component 4 — Prompt injection on all paths  *(cheap insurance)*
+### Component 4 — Prompt injection on all paths _(cheap insurance)_
 
 Inject "who the user is" (primary name + aliases) into the **document** and
 **conversation** extraction prompts too (today only transcripts get speaker
@@ -228,7 +229,7 @@ multi-account-owner cases.
 ## Open questions
 
 1. **Evidence-gated self tiebreak:** should Component 3 ever prefer the
-   self node when it is *one of several* candidates and there is corroborating
+   self node when it is _one of several_ candidates and there is corroborating
    self-evidence, or always split on >1? Default proposal: always split (no
    self tiebreak) for maximum safety.
 2. **Primary-label selection:** longest alias by token count vs an explicit

--- a/docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-17-same-name-identity-disambiguation-design.md
@@ -1,0 +1,239 @@
+# Same-Name Identity Disambiguation & Self-Identity Resolution
+
+**Date:** 2026-06-17
+**Status:** Design — pending plan
+
+## Problem
+
+Multiple people in a user's graph share a name. The account owner is "Marcel
+Samyn" (appears as "Marcel"), and contacts include "Marcel Szenessy" and
+"Marcel Claus". When a WhatsApp conversation was ingested, the user's **own
+first-person statements were attributed to a different "Marcel" node** instead
+of to the user.
+
+The same class of bug applies generally: any two same-named people (e.g. two
+friends named "Sarah") can be conflated, and a bare-first-name mention can be
+routed to the wrong node. The fix must be **general** (same-name
+disambiguation for anyone), with the user's own identity handled as a
+first-class case — but *not* via a blunt "when unsure, assume it's the user"
+heuristic, which is itself a cause of mis-merges.
+
+## Root-cause analysis (code-grounded)
+
+The reported failure ("my words went to another Marcel") is produced by three
+compounding gaps, traced through the transcript ingestion path
+(`POST /ingest/transcript` → `ingestTranscript` → `extractGraph`):
+
+1. **The speaker map carries provenance, not subject.** `speakerMap` is
+   consumed only by `_resolveAssertedByKind` / `_resolveTranscriptProvenance`
+   to set *who asserted* a claim (`src/lib/extract-graph.ts:1352`). It is
+   never registered into `idMap`. So when the user-self speaker says "I'm
+   flying to Lisbon", nothing tells the LLM to make the user the **subject** —
+   it mints a fresh `temp_person` labelled "Marcel".
+
+2. **The user-self node is invisible to name matching.** It is created with
+   `label = userId` and `canonicalLabel = normalizeLabel(userId)`
+   (`src/lib/transcript/resolve-speakers.ts:250`). `setUserSelfAliases` only
+   writes `user_profiles.metadata.userSelfAliases`
+   (`src/lib/user-profile.ts:50`) — it never names the node nor seeds the alias
+   table. In the prompt context the self node shows up as a cryptic id-string
+   the LLM won't recognise as "you".
+
+3. **The resolver breaks same-name ties arbitrarily.** At extraction time
+   `resolveIdentity` runs with no embedding and no claim profile
+   (`src/lib/extract-graph.ts:932`), so only Signal 1 (canonical label) and
+   Signal 2 (alias) can fire — both exact-match, both score `1.0`. On multiple
+   matches the winner is `candidates[0]` with **no tie-break and no
+   self-preference** (`src/lib/identity-resolution.ts:172`,
+   `src/lib/identity-resolution.ts:662`). The minted "Marcel" therefore lands
+   on whichever Person node Postgres returns first — frequently a different
+   Marcel. Signal 1 even short-circuits the one correct path: the
+   `"marcel" → self` alias that `resolveSpeakers` opportunistically wrote
+   (`src/lib/transcript/resolve-speakers.ts:119`).
+
+WhatsApp specifics (from `~/code/whatsapp-memory`): the user's own messages are
+labelled with `SELF_ALIASES[0]` = `"Marcel"` and the payload sets
+`userSelfAliasesOverride = ["Marcel", "Marcel Samyn"]`
+(`src/transcripts.ts:62`, `:74`). Other people use their WhatsApp/contact name.
+So self-speaker resolution itself works (it matches the `userSelfAliases`
+config set directly, `resolve-speakers.ts:114`); the failure is purely in
+subject assignment + ambiguous name resolution downstream.
+
+> Note: this diagnosis is derived from code, not from the live graph. The
+> Petals API key only authorises `ingest/*` and `metrics/*`
+> (`~/code/petals/src/routes/api/memory/`); no query endpoint is proxied.
+> Optional hard-confirmation via the authenticated Petals memory UI is listed
+> under Open questions.
+
+## Decisions (settled during brainstorming)
+
+1. **Scope is general same-name disambiguation**, with the account owner as a
+   first-class case — not a self-only patch.
+2. **Self-preference lives upstream, never as a blunt resolver default.** The
+   user's identity is delivered by (a) subject-wiring in transcripts and
+   (b) specific, unambiguous aliases — *not* by making the resolver prefer the
+   self node on an ambiguous match. A blunt "assume self" rule is the
+   over-merge failure mode and is explicitly rejected.
+3. **Bare first names are inherently ambiguous and must never auto-merge** —
+   not into the self node, not into another same-named node.
+4. **The resolver must never guess on a tie.** A unique same-name match
+   resolves as today; multiple matches split into a distinct node and log for
+   later consolidation, instead of taking `candidates[0]`.
+5. **Build in leverage order 1 → 2 → 3 → 4.** Components 1+2 directly kill the
+   reported bug at low risk; 3 generalises it; 4 is additive insurance.
+
+## Design
+
+Four components, each mapped to a root cause.
+
+### Component 1 — Self-node identity hygiene  *(fixes root cause #2)*
+
+Give the user-self node a real, *distinguishing* identity and keep the alias
+table in sync, without seeding ambiguous bare first names.
+
+- **Primary label.** The self node's `label` / `canonicalLabel` becomes the
+  user's most-specific name — the longest (most tokens) entry in the effective
+  alias list, e.g. `"Marcel Samyn"` rather than `"Marcel"`. Replaces the
+  current `label = userId` behaviour in `ensureUserSelfPersonNode`
+  (`resolve-speakers.ts:250`).
+- **One hygiene helper, two call sites.** Introduce
+  `ensureUserSelfIdentity(db, userId, aliases)` that ensures the self node
+  exists, sets its primary label, and seeds the alias table for the self node
+  with the **multi-token / distinguishing** aliases only (e.g.
+  `"Marcel Samyn"`). Single-token, inherently ambiguous aliases (e.g.
+  `"Marcel"`) are **not** written to the global alias table used by
+  `resolveIdentity`. This helper is called from **both**:
+  - `setUserSelfAliases` (`src/lib/user-profile.ts:50`) — the explicit config
+    path; and
+  - the transcript ingestion path (`ingestTranscript`), using the
+    **effective** alias list `userSelfAliasesOverride ?? stored` — because the
+    WhatsApp client (`~/code/whatsapp-memory`) sends
+    `userSelfAliasesOverride` per request and never calls
+    `/user/self-aliases`, so the persistent list may be empty. Hooking only
+    the config endpoint would miss the real ingestion flow.
+  The single-token aliases remain available for transcript *speaker* matching
+  via the `userSelfAliases` config set (`resolve-speakers.ts:114`); they are
+  just kept out of the identity-resolution alias table.
+- **Stop writing the ambiguous self alias in speaker resolution.**
+  `resolveSpeakers` no longer writes the bare user-self speaker label into the
+  alias table (`resolve-speakers.ts:119`). Speaker resolution already matches
+  self via the `userSelfAliases` config set (`:114`), so this is safe and
+  removes the ambiguity at its source. (Alias writes for *other* participants
+  are unchanged.)
+- **Backfill.** A one-off maintenance route under `src/routes/maintenance/`
+  renames the existing self node to the primary label, seeds distinguishing
+  aliases, and removes the bare-first-name self alias if present.
+
+### Component 2 — Wire user-self as the claim *subject*  *(fixes root cause #1)*
+
+In the transcript path, make the user-self speaker's node the subject of that
+speaker's first-person claims, so "I…" attaches to the user — never to a minted
+node.
+
+- Register every speaker node into `idMap` (real id → node id) so the LLM can
+  reference it as a `subjectId`. The self node's real id is already registered
+  when it appears in `cappedNodes`, but speaker nodes must be registered
+  **unconditionally** (not subject to the 150-node cap), since the self/other
+  speaker nodes are exactly the subjects we care about.
+- Surface the user-self node in the prompt context labelled unambiguously as
+  the user (e.g. `"Marcel Samyn (the user / 'you')"`), and extend the
+  transcript section of the system prompt + few-shot so the model uses the
+  user-self speaker's node id as the **subject** of that speaker's
+  self-referential claims. The speaker section already lists `nodeId` per
+  speaker (`_formatSpeakerMapSection`, `extract-graph.ts:1421`); this makes it
+  usable for subjects, not just provenance.
+- This keeps the byte-identical-system-prompt caching contract: dynamic
+  per-user identity stays in the trailing user message / speaker section.
+
+### Component 3 — Resolver: unique-match-wins, never guess  *(fixes root cause #3; generalises)*
+
+Change the ambiguity behaviour of `resolveIdentity`
+(`src/lib/identity-resolution.ts`) for the exact-match signals (canonical
+label, alias):
+
+- **Exactly one same-scope/same-type candidate → resolve** (unchanged).
+- **More than one candidate → do not auto-merge.** Return a non-resolving
+  decision tagged ambiguous. The caller (`_processAndInsertNewNodes`,
+  `extract-graph.ts:956`) then creates a fresh distinct node (the existing
+  null-path behaviour = "split") and emits a new observability event
+  (`identity.ambiguous_skip`) carrying the candidate set, mirroring the
+  existing `identity.cross_scope_merge_refused` pattern. Consolidation is left
+  to the background identity re-eval / `cleanup/dedup-sweep`, which *do* have
+  embeddings + claim profiles to disambiguate with.
+- **No blunt self-prior.** `isUserSelf` is recorded in the decision trace for
+  observability and may serve as an *evidence-gated* tiebreak only (see Open
+  questions), but is never a default winner — to avoid resurrecting the
+  over-merge failure.
+
+Net effect with Components 1+2 in place:
+- A third-party bare "Marcel" mention that matches several nodes → split +
+  logged (no arbitrary mis-route), instead of silently grabbing `candidates[0]`.
+- A specific "Marcel Samyn" mention (document/conversation, no speaker map) →
+  unique alias match → resolves to the self node correctly.
+- A transcript first-person "I…" → attached to self by subject-wiring
+  (Component 2), never reaching the ambiguous name path.
+
+### Component 4 — Prompt injection on all paths  *(cheap insurance)*
+
+Inject "who the user is" (primary name + aliases) into the **document** and
+**conversation** extraction prompts too (today only transcripts get speaker
+context), in the cache-safe trailing user message. Instruct the model to emit
+the **most specific** label it can for people ("Marcel Szenessy", not bare
+"Marcel") and to not conflate a different same-named person with the user. This
+raises the rate of unique matches in Component 3 and reduces ambiguity at the
+source.
+
+## Data flow (transcript, post-change)
+
+```
+WhatsApp → ingestTranscript
+  ├─ resolveSpeakers: "Marcel"→self via userSelfAliases (no bare alias written)
+  ├─ self node has label "Marcel Samyn", aliases {"Marcel Samyn"}        [C1]
+  ├─ speakerMap → registered into idMap as valid subject ids             [C2]
+  └─ extractGraph
+       ├─ prompt: user-self node shown as "you"; use its id for "I…"     [C2]
+       ├─ first-person claim subject = self node id  → attaches to user  [C2]
+       └─ minted third-party "Marcel" → resolveIdentity
+            ├─ 1 candidate  → resolve                                    [C3]
+            └─ >1 candidate → split + identity.ambiguous_skip log        [C3]
+```
+
+## Testing
+
+- **Unit (resolver):** multiple same-scope/type candidates → no resolution +
+  ambiguous decision; single candidate → resolves; cross-scope unchanged.
+- **Unit (self hygiene):** `setUserSelfAliases` names the self node, seeds only
+  multi-token aliases, never seeds bare first names; `resolveSpeakers` no
+  longer writes the bare self alias.
+- **Integration (transcript):** a user-self utterance "I live in Lisbon"
+  attaches `LIVES_IN Lisbon` to the self node (subject = self), with a separate
+  same-named participant present — assert the claim is **not** on the
+  participant node. Extends the multi-party story
+  (`src/evals/memory/stories/10-multi-party-transcript.ts`) and
+  `ingest-transcript.test.ts`.
+- **Integration (document):** a document naming "Marcel Samyn" resolves to the
+  self node; a bare third-party "Marcel" does not merge into self.
+- Tests run locally against the test DB on `:5431` (CI does not run vitest).
+
+## Scope
+
+**In scope:** Components 1–4 as above; one-off self-node backfill; new
+`identity.ambiguous_skip` event.
+
+**Out of scope (future):** richer extraction-time disambiguation using a
+candidate claim profile built from co-extracted claims; automatic merge of
+`ambiguous_skip` splits beyond the existing dedup-sweep; per-user timezone or
+multi-account-owner cases.
+
+## Open questions
+
+1. **Evidence-gated self tiebreak:** should Component 3 ever prefer the
+   self node when it is *one of several* candidates and there is corroborating
+   self-evidence, or always split on >1? Default proposal: always split (no
+   self tiebreak) for maximum safety.
+2. **Primary-label selection:** longest alias by token count vs an explicit
+   "primary name" field on the profile. Default proposal: longest alias, with
+   an explicit field deferred until needed.
+3. **Live-graph confirmation:** verify against the actual nodes via the
+   authenticated Petals memory UI before implementing, or proceed on the
+   code-grounded diagnosis. Default: proceed; verify opportunistically.

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -224,6 +224,15 @@ export async function extractGraph({
   const { nodesForPromptFormatting, idMap, nodeLabels } =
     _prepareInitialNodeMappings(cappedNodes);
 
+  // Register every resolved speaker node so the LLM can use its real id as a
+  // claim subjectId (e.g. the user-self speaker's first-person statements).
+  // Unconditional — speaker subjects must not be dropped by the 150-node cap.
+  if (speakerMap) {
+    for (const entry of speakerMap.values()) {
+      idMap.set(entry.nodeId.toString(), entry.nodeId);
+    }
+  }
+
   const openCommitmentsPromptSection = _formatOpenCommitmentsSection(
     cappedOpenCommitments,
   );
@@ -296,7 +305,7 @@ ${
 - "Orchard is based in Stockholm and uses a billing system built on the Stripe API." → (Orchard Labs, LOCATED_IN, Stockholm) and (Orchard Labs, USES, Stripe API).
 - "The Starter tier costs €49/month." → do NOT create a "€49" node; if the figure matters use (Starter tier, HAS_ATTRIBUTE, "€49/month"). Use RELATED_TO only when no specific predicate fits.`
     : speakerMap && speakerMap.size > 0
-      ? `- Speaker "Alice" (user-self) says "I shipped the spec." → assertionKind: "user", assertedBySpeakerLabel: "Alice".
+      ? `- Speaker "Alice" (user-self) says "I live in Lisbon." → create the (LIVES_IN, Lisbon) claim with subjectId set to Alice's nodeId from "Speakers in this transcript" (do NOT mint a new "Alice" node), assertionKind: "user", assertedBySpeakerLabel: "Alice".
 - Speaker "Bob" (non user-self) says "I'll send the PR tomorrow." → assertionKind: "participant", assertedBySpeakerLabel: "Bob".
 - Speaker "Bob" says "You're moving to Paris next month." Speaker "Alice" (user-self) replies "Yeah." → for the (Alice, LIVES_IN, Paris) claim use assertionKind: "user_confirmed", assertedBySpeakerLabel: "Alice".`
       : `- User says "I started working at Acme last week." → assertionKind: "user".
@@ -1422,11 +1431,14 @@ function _formatSpeakerMapSection(
 ): string {
   if (!speakerMap || speakerMap.size === 0) return "";
   const lines = [...speakerMap.entries()].map(([label, entry]) => {
-    const role = entry.isUserSelf ? "user-self" : "other-participant";
+    const role = entry.isUserSelf
+      ? "user-self (the user / 'you')"
+      : "other-participant";
     return `- speakerLabel: ${label}; nodeId: ${entry.nodeId}; role: ${role}`;
   });
   return `Speakers in this transcript:
 For each claim, set "assertedBySpeakerLabel" to the speaker who said it, using these labels exactly. Claims whose speaker label is missing or not in this list will be dropped.
+When a speaker states a fact about themselves (first-person "I…/my…"), use that speaker's nodeId above as the claim's subjectId — do NOT mint a new node for a speaker already listed here. In particular, attribute the user-self speaker's self-statements to their nodeId, never to a newly created same-named node.
 ${lines.join("\n")}`;
 }
 

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -119,6 +119,15 @@ interface ExtractGraphParams {
    */
   contentNote?: string;
   /**
+   * Optional "who the user is" note (primary name + aliases) injected into the
+   * trailing user message so the model emits the user's most specific label
+   * and never conflates a same-named other person with the user. Used by
+   * document and conversation ingestion (transcripts use the speaker map
+   * instead). Cache-safe: lives in the dynamic user message, not the system
+   * prompt.
+   */
+  userIdentityNote?: string;
+  /**
    * Debug hook fired exactly once after the LLM call returns, before
    * dedup/identity-resolution runs. Receives the exact prompt sent and the
    * parsed response. Errors thrown by the hook are logged and swallowed so
@@ -142,6 +151,7 @@ export async function extractGraph({
   speakerMap,
   replaceClaimsForSources = true,
   contentNote,
+  userIdentityNote,
   onLlmIO,
 }: ExtractGraphParams) {
   const db = await useDatabase();
@@ -242,6 +252,10 @@ export async function extractGraph({
   );
 
   const speakerMapPromptSection = _formatSpeakerMapSection(speakerMap);
+
+  const userIdentityPromptSection = userIdentityNote
+    ? `${userIdentityNote}\n\n`
+    : "";
 
   const { createCompletionClient } = await import("./ai");
   const client = await createCompletionClient(userId, {
@@ -369,6 +383,7 @@ Rules of the graph:
 - Nodes are unique by type and label
 - Never create new nodes for a node that already exists
 - In node names use full names, eg. "John Doe" instead of "John"
+- If multiple people could share a name, use the most specific distinguishing label available (e.g. a full name) and NEVER merge or conflate two different people who share a first name.
 - Omit unnecessary details in node names, eg. "John Doe" instead of "John Doe (person)"
 - Nodes are independent of context and represent a *single* thing. Bad example: "John - the person taking a walk". Good example: "John" (Person node, no description) linked to [PARTICIPATED_IN] "John's walk on 2025-05-18" (Event node), linked to [OCCURRED_ON] "2025-05-18" (Temporal node).
 - Don't create nodes for things that should be represented by edges.
@@ -404,7 +419,7 @@ ${candidateCommitmentsPromptSection}
 
 ${speakerMapPromptSection}
 
-Extract the graph from the following ${sourceType}:
+${userIdentityPromptSection}Extract the graph from the following ${sourceType}:
 
 Allowed source refs:
 ${sourceRefsForPrompt}

--- a/src/lib/identity-resolution.test.ts
+++ b/src/lib/identity-resolution.test.ts
@@ -643,6 +643,151 @@ describeIfServer("resolveIdentity", () => {
     });
   });
 
+  it("signal 1 — multiple same-scope canonical matches do not resolve (ambiguous)", async () => {
+    await withDb(async (client) => {
+      const userId = "user_ambiguous";
+      const marcelA = newTypeId("node");
+      const marcelB = newTypeId("node");
+      const sourceId = newTypeId("source");
+      await createIdentityTables(client);
+      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+           VALUES ($1,$2,'document','p1','personal')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes"("id","user_id","node_type")
+           VALUES ($1,$3,'Person'),($2,$3,'Person')`,
+        [marcelA, marcelB, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+           VALUES ($1,$3,'Marcel','marcel'),($2,$4,'Marcel','marcel')`,
+        [
+          newTypeId("node_metadata"),
+          newTypeId("node_metadata"),
+          marcelA,
+          marcelB,
+        ],
+      );
+      await client.query(
+        `INSERT INTO "source_links"("id","source_id","node_id")
+           VALUES ($1,$3,$4),($2,$3,$5)`,
+        [
+          newTypeId("source_link"),
+          newTypeId("source_link"),
+          sourceId,
+          marcelA,
+          marcelB,
+        ],
+      );
+
+      const { resolveIdentity } = await import("./identity-resolution");
+      const { setLogSink } = await import("~/lib/observability/log");
+      const captured: Array<Record<string, unknown>> = [];
+      setLogSink((event) => captured.push(event));
+      try {
+        const resolution = await resolveIdentity({
+          userId,
+          candidate: {
+            proposedLabel: "Marcel",
+            normalizedLabel: "marcel",
+            nodeType: "Person",
+            scope: "personal",
+          },
+        });
+        expect(resolution.resolvedNodeId).toBeNull();
+        expect(resolution.decision.signal).toBe("none");
+        const canonical = resolution.decision.trace.find(
+          (t) => t.signal === "canonical_label",
+        );
+        expect(canonical?.fired).toBe(true);
+        expect(canonical?.candidates).toHaveLength(2);
+        expect(
+          canonical?.signal === "canonical_label" && canonical.ambiguous,
+        ).toMatchObject({
+          candidateNodeIds: expect.arrayContaining([marcelA, marcelB]),
+        });
+        const skip = captured.find(
+          (e) => e["event"] === "identity.ambiguous_skip",
+        );
+        expect(skip).toMatchObject({
+          event: "identity.ambiguous_skip",
+          userId,
+          normalizedLabel: "marcel",
+          signal: "canonical_label",
+          candidateCount: 2,
+        });
+      } finally {
+        setLogSink();
+      }
+    });
+  });
+
+  it("self resolves by full name; a bare same-first-name does not merge into self", async () => {
+    await withDb(async (client) => {
+      const userId = "user_self_fullname";
+      await createIdentityTables(client);
+      await client.query(`INSERT INTO "users"("id") VALUES ($1)`, [userId]);
+
+      const { useDatabase } = await import("~/utils/db");
+      const db = await useDatabase();
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const selfNodeId = await ensureUserSelfIdentity(db, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+
+      // A separate third-party "Marcel" with personal-scope support.
+      const otherMarcel = newTypeId("node");
+      const sourceId = newTypeId("source");
+      await client.query(
+        `INSERT INTO "sources"("id","user_id","type","external_id","scope")
+           VALUES ($1,$2,'document','d1','personal')`,
+        [sourceId, userId],
+      );
+      await client.query(
+        `INSERT INTO "nodes"("id","user_id","node_type") VALUES ($1,$2,'Person')`,
+        [otherMarcel, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata"("id","node_id","label","canonical_label")
+           VALUES ($1,$2,'Marcel','marcel')`,
+        [newTypeId("node_metadata"), otherMarcel],
+      );
+      await client.query(
+        `INSERT INTO "source_links"("id","source_id","node_id") VALUES ($1,$2,$3)`,
+        [newTypeId("source_link"), sourceId, otherMarcel],
+      );
+
+      const { resolveIdentity } = await import("./identity-resolution");
+
+      const full = await resolveIdentity({
+        userId,
+        candidate: {
+          proposedLabel: "Marcel Samyn",
+          normalizedLabel: "marcel samyn",
+          nodeType: "Person",
+          scope: "personal",
+        },
+      });
+      expect(full.resolvedNodeId).toBe(selfNodeId);
+
+      const bare = await resolveIdentity({
+        userId,
+        candidate: {
+          proposedLabel: "Marcel",
+          normalizedLabel: "marcel",
+          nodeType: "Person",
+          scope: "personal",
+        },
+      });
+      expect(bare.resolvedNodeId).toBe(otherMarcel);
+      expect(bare.resolvedNodeId).not.toBe(selfNodeId);
+    });
+  });
+
   it("decision trace records every signal attempted, in order", async () => {
     await withDb(async (client) => {
       const userId = "user_trace";

--- a/src/lib/identity-resolution.ts
+++ b/src/lib/identity-resolution.ts
@@ -101,12 +101,16 @@ export type SignalTrace =
       candidates: SignalCandidate[];
       /** Set when a same-label match exists in a different scope. */
       crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+      /** Set when >1 same-scope/type candidate matched; resolver refuses to guess. */
+      ambiguous?: { candidateNodeIds: TypeId<"node">[] };
     }
   | {
       signal: "alias";
       fired: boolean;
       candidates: SignalCandidate[];
       crossScopeRefusal?: { nodeId: TypeId<"node">; otherScope: Scope };
+      /** Set when >1 same-scope/type candidate matched; resolver refuses to guess. */
+      ambiguous?: { candidateNodeIds: TypeId<"node">[] };
     }
   | {
       signal: "embedding_sim";
@@ -169,8 +173,8 @@ export async function resolveIdentity({
   );
   trace.push(canonicalTrace);
   if (canonicalTrace.signal === "canonical_label" && canonicalTrace.fired) {
-    const winner = canonicalTrace.candidates[0];
-    if (winner) {
+    if (canonicalTrace.candidates.length === 1) {
+      const winner = canonicalTrace.candidates[0]!;
       return _resolved(
         winner.nodeId,
         "canonical_label",
@@ -180,6 +184,18 @@ export async function resolveIdentity({
         userId,
       );
     }
+    // More than one same-scope/type candidate: do not guess. Record the
+    // ambiguity, log it, and fall through to later (more discriminating)
+    // signals; at extraction time those are absent, so the caller splits.
+    canonicalTrace.ambiguous = {
+      candidateNodeIds: canonicalTrace.candidates.map((c) => c.nodeId),
+    };
+    _logAmbiguousSkip(
+      userId,
+      candidate,
+      "canonical_label",
+      canonicalTrace.candidates,
+    );
   }
 
   // --- Signal 2: alias match -------------------------------------------
@@ -189,8 +205,8 @@ export async function resolveIdentity({
   );
   trace.push(aliasTrace);
   if (aliasTrace.signal === "alias" && aliasTrace.fired) {
-    const winner = aliasTrace.candidates[0];
-    if (winner) {
+    if (aliasTrace.candidates.length === 1) {
+      const winner = aliasTrace.candidates[0]!;
       return _resolved(
         winner.nodeId,
         "alias",
@@ -200,6 +216,10 @@ export async function resolveIdentity({
         userId,
       );
     }
+    aliasTrace.ambiguous = {
+      candidateNodeIds: aliasTrace.candidates.map((c) => c.nodeId),
+    };
+    _logAmbiguousSkip(userId, candidate, "alias", aliasTrace.candidates);
   }
 
   // --- Signal 3: embedding similarity ----------------------------------
@@ -745,6 +765,24 @@ function _resolved(
     resolvedNodeId: nodeId,
     decision: { signal, confidence, trace },
   };
+}
+
+function _logAmbiguousSkip(
+  userId: string,
+  candidate: IdentityCandidate,
+  signal: "canonical_label" | "alias",
+  candidates: SignalCandidate[],
+): void {
+  logEvent("identity.ambiguous_skip", {
+    userId,
+    candidateLabel: candidate.proposedLabel,
+    normalizedLabel: candidate.normalizedLabel,
+    nodeType: candidate.nodeType,
+    scope: candidate.scope,
+    signal,
+    candidateNodeIds: candidates.map((c) => c.nodeId),
+    candidateCount: candidates.length,
+  });
 }
 
 function _logCrossScopeRefusal(

--- a/src/lib/ingestion/chunked-extract.ts
+++ b/src/lib/ingestion/chunked-extract.ts
@@ -65,6 +65,11 @@ export interface ChunkedExtractionParams {
     title?: string;
     author?: string;
   };
+  /**
+   * "Who the user is" note forwarded verbatim to every chunk's `extractGraph`
+   * call so per-fragment extraction resolves the user's name correctly.
+   */
+  userIdentityNote?: string;
 }
 
 export async function runChunkedExtraction(
@@ -80,6 +85,7 @@ export async function runChunkedExtraction(
     content,
     logLabel,
     documentMetadata,
+    userIdentityNote,
   } = params;
 
   const chunks = chunkMarkdown(content, env.INGEST_CHUNK_MAX_CHARS);
@@ -109,6 +115,7 @@ export async function runChunkedExtraction(
     statedAt,
     linkedNodeId,
     sourceRefs,
+    ...(userIdentityNote ? { userIdentityNote } : {}),
   };
 
   let succeeded = 0;

--- a/src/lib/ingestion/extract-document-graph.ts
+++ b/src/lib/ingestion/extract-document-graph.ts
@@ -8,6 +8,8 @@
 import { runChunkedExtraction } from "./chunked-extract";
 import { ensureSourceNode } from "./ensure-source-node";
 import { DrizzleDB } from "~/db";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import { buildUserIdentityNote } from "~/lib/user-self-identity";
 import { NodeTypeEnum } from "~/types/graph";
 import { TypeId } from "~/types/typeid";
 
@@ -50,6 +52,10 @@ export async function extractDocumentGraph(
     nodeType: NodeTypeEnum.enum.Document,
   });
 
+  const userIdentityNote = buildUserIdentityNote(
+    await getUserSelfAliases(db, userId),
+  );
+
   await runChunkedExtraction({
     userId,
     sourceType: "document",
@@ -63,5 +69,6 @@ export async function extractDocumentGraph(
       ...(title !== undefined && { title }),
       ...(author !== undefined && { author }),
     },
+    ...(userIdentityNote ? { userIdentityNote } : {}),
   });
 }

--- a/src/lib/jobs/backfill-user-self-identity.ts
+++ b/src/lib/jobs/backfill-user-self-identity.ts
@@ -1,0 +1,76 @@
+/**
+ * One-off maintenance: bring an existing user-self Person node up to the
+ * current identity-hygiene contract — distinguishing primary label, seeded
+ * multi-token aliases, and NO ambiguous bare-first-name alias.
+ *
+ * Idempotent. Operates on the explicitly-passed aliases when given, else the
+ * stored `userSelfAliases`.
+ *
+ * Note: an empty effective alias list (none stored and none passed) seeds no
+ * distinguishing aliases and therefore removes ALL existing alias rows on the
+ * self node — the intended clean-slate behavior for this maintenance job.
+ */
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { aliases as aliasesTable } from "~/db/schema";
+import { normalizeAliasText } from "~/lib/alias";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import {
+  distinguishingAliases,
+  ensureUserSelfIdentity,
+} from "~/lib/user-self-identity";
+
+export interface BackfillUserSelfIdentityParams {
+  db: DrizzleDB;
+  userId: string;
+  aliases?: string[];
+}
+
+export interface BackfillUserSelfIdentityResult {
+  selfNodeId: string;
+  primaryAliasesSeeded: string[];
+  removedAmbiguousAliases: number;
+}
+
+export async function backfillUserSelfIdentity(
+  params: BackfillUserSelfIdentityParams,
+): Promise<BackfillUserSelfIdentityResult> {
+  const { db, userId } = params;
+  const effectiveAliases =
+    params.aliases ?? (await getUserSelfAliases(db, userId));
+
+  const selfNodeId = await ensureUserSelfIdentity(db, userId, effectiveAliases);
+  const seeded = distinguishingAliases(effectiveAliases);
+  const keep = new Set(seeded.map((a) => normalizeAliasText(a)));
+
+  // Remove any previously-written single-token (ambiguous) alias rows on the
+  // self node; keep only the multi-token distinguishing aliases.
+  const selfAliasRows = await db
+    .select({
+      id: aliasesTable.id,
+      normalized: aliasesTable.normalizedAliasText,
+    })
+    .from(aliasesTable)
+    .where(
+      and(
+        eq(aliasesTable.userId, userId),
+        eq(aliasesTable.canonicalNodeId, selfNodeId),
+      ),
+    );
+
+  const toDelete = selfAliasRows.filter((row) => !keep.has(row.normalized));
+  if (toDelete.length > 0) {
+    await db.delete(aliasesTable).where(
+      inArray(
+        aliasesTable.id,
+        toDelete.map((row) => row.id),
+      ),
+    );
+  }
+
+  return {
+    selfNodeId,
+    primaryAliasesSeeded: seeded,
+    removedAmbiguousAliases: toDelete.length,
+  };
+}

--- a/src/lib/jobs/ingest-conversation.ts
+++ b/src/lib/jobs/ingest-conversation.ts
@@ -10,10 +10,10 @@ import { safeToISOString } from "../safe-date";
 import { z } from "zod";
 import { DrizzleDB } from "~/db";
 import { type ConversationTurn } from "~/lib/conversation-store";
-import { NodeTypeEnum } from "~/types/graph";
-import { TypeId } from "~/types/typeid";
 import { getUserSelfAliases } from "~/lib/user-profile";
 import { buildUserIdentityNote } from "~/lib/user-self-identity";
+import { NodeTypeEnum } from "~/types/graph";
+import { TypeId } from "~/types/typeid";
 
 export const MessageSchema = z.object({
   id: z.string(),

--- a/src/lib/jobs/ingest-conversation.ts
+++ b/src/lib/jobs/ingest-conversation.ts
@@ -12,6 +12,8 @@ import { DrizzleDB } from "~/db";
 import { type ConversationTurn } from "~/lib/conversation-store";
 import { NodeTypeEnum } from "~/types/graph";
 import { TypeId } from "~/types/typeid";
+import { getUserSelfAliases } from "~/lib/user-profile";
+import { buildUserIdentityNote } from "~/lib/user-self-identity";
 
 export const MessageSchema = z.object({
   id: z.string(),
@@ -66,6 +68,9 @@ export async function ingestConversation({
     timestamp: firstTurn.timestamp,
     nodeType: NodeTypeEnum.enum.Conversation,
   });
+  const userIdentityNote = buildUserIdentityNote(
+    await getUserSelfAliases(db, userId),
+  );
   await extractGraph({
     userId,
     sourceType: "conversation",
@@ -74,6 +79,7 @@ export async function ingestConversation({
     linkedNodeId: conversationNodeId,
     sourceRefs,
     content: formatConversationAsXml(insertedTurns),
+    ...(userIdentityNote ? { userIdentityNote } : {}),
   });
   return { insertedTurns };
 }

--- a/src/lib/jobs/ingest-transcript.test.ts
+++ b/src/lib/jobs/ingest-transcript.test.ts
@@ -788,4 +788,108 @@ describeIfServer("ingestTranscript", () => {
       await client.end();
     }
   });
+
+  it("attributes a user-self first-person claim to the self node, not a same-named participant", async () => {
+    const userId = "user_transcript_subject";
+    const transcriptId = "trans_subject_1";
+    const occurredAt = new Date("2026-05-01T10:00:00.000Z");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const database = drizzle(client, { schema, casing: "snake_case" });
+
+    // Captured so the LLM stub can emit the real self node id as subjectId.
+    let selfNodeIdForStub = "";
+
+    applyCommonMocks(database);
+    vi.doMock("../ai", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../ai")>()),
+      createCompletionClient: async () => ({
+        chat: {
+          completions: {
+            parse: async () => ({
+              choices: [
+                {
+                  message: {
+                    parsed: {
+                      nodes: [
+                        { id: "loc_1", type: "Location", label: "Lisbon" },
+                      ],
+                      relationshipClaims: [
+                        {
+                          subjectId: selfNodeIdForStub,
+                          objectId: "loc_1",
+                          predicate: "LIVES_IN",
+                          statement: "Marcel lives in Lisbon.",
+                          sourceRef: `${transcriptId}:0`,
+                          assertionKind: "user",
+                          assertedBySpeakerLabel: "Marcel",
+                        },
+                      ],
+                      attributeClaims: [],
+                      aliases: [],
+                    },
+                  },
+                },
+              ],
+            }),
+          },
+        },
+      }),
+    }));
+
+    try {
+      await createTranscriptTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+
+      // A different, same-first-name person already in the graph.
+      const otherMarcelId = newTypeId("node");
+      await client.query(
+        `INSERT INTO "nodes" ("id", "user_id", "node_type") VALUES ($1, $2, 'Person')`,
+        [otherMarcelId, userId],
+      );
+      await client.query(
+        `INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label") VALUES ($1, $2, 'Marcel', 'marcel')`,
+        [newTypeId("node_metadata"), otherMarcelId],
+      );
+
+      const { ensureUserSelfIdentity } = await import("../user-self-identity");
+      const selfNodeId = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+      selfNodeIdForStub = selfNodeId;
+
+      const { ingestTranscript } = await import("./ingest-transcript");
+      await ingestTranscript({
+        db: database,
+        userId,
+        transcriptId,
+        scope: "personal",
+        occurredAt,
+        content: {
+          kind: "segmented",
+          utterances: [
+            { speakerLabel: "Marcel", content: "I live in Lisbon now." },
+          ],
+        },
+        userSelfAliasesOverride: ["Marcel", "Marcel Samyn"],
+      });
+
+      const livesIn = await client.query<{
+        subject_node_id: string;
+        asserted_by_kind: string;
+      }>(
+        `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LIVES_IN'`,
+        [userId],
+      );
+      expect(livesIn.rows).toHaveLength(1);
+      expect(livesIn.rows[0]?.subject_node_id).toBe(selfNodeId);
+      expect(livesIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
+      expect(livesIn.rows[0]?.asserted_by_kind).toBe("user");
+    } finally {
+      unmockCommon();
+      await client.end();
+    }
+  });
 });

--- a/src/lib/jobs/ingest-transcript.ts
+++ b/src/lib/jobs/ingest-transcript.ts
@@ -36,6 +36,7 @@ import {
   type SegmentTranscriptClient,
 } from "~/lib/transcript/segment-transcript";
 import { getUserSelfAliases } from "~/lib/user-profile";
+import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
 import { NodeTypeEnum, ScopeEnum } from "~/types/graph";
 import { typeIdSchema, type TypeId } from "~/types/typeid";
 
@@ -114,6 +115,12 @@ export async function ingestTranscript(
 
   const userSelfAliases =
     userSelfAliasesOverride ?? (await getUserSelfAliases(db, userId));
+
+  // WhatsApp (and other transcript hosts) send `userSelfAliasesOverride` per
+  // request and never call /user/self-aliases, so the stored list may be
+  // empty. Use the EFFECTIVE list so the self node still gets a distinguishing
+  // label + aliases on the real ingestion path.
+  await ensureUserSelfIdentity(db, userId, userSelfAliases);
 
   const speakerLabels = utterances.map((u) => u.speakerLabel);
   const speakerMap = await resolveSpeakers({

--- a/src/lib/schemas/backfill-user-self-identity.ts
+++ b/src/lib/schemas/backfill-user-self-identity.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const backfillUserSelfIdentityRequestSchema = z.object({
+  userId: z.string().min(1),
+  /** When omitted, the stored `userSelfAliases` are used. */
+  aliases: z.array(z.string().min(1)).optional(),
+});
+
+export const backfillUserSelfIdentityResponseSchema = z.object({
+  selfNodeId: z.string(),
+  primaryAliasesSeeded: z.array(z.string()),
+  removedAmbiguousAliases: z.number().int().nonnegative(),
+});

--- a/src/lib/schemas/backfill-user-self-identity.ts
+++ b/src/lib/schemas/backfill-user-self-identity.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 
 export const backfillUserSelfIdentityRequestSchema = z.object({
   userId: z.string().min(1),
-  /** When omitted, the stored `userSelfAliases` are used. */
+  /**
+   * When omitted, the stored `userSelfAliases` are used. Destructive edge: if
+   * the effective list (passed or stored) is empty, the self node's existing
+   * alias rows are ALL removed (clean-slate hygiene) — pass a non-empty list to
+   * avoid clearing them.
+   */
   aliases: z.array(z.string().min(1)).optional(),
 });
 

--- a/src/lib/transcript/resolve-speakers.ts
+++ b/src/lib/transcript/resolve-speakers.ts
@@ -11,12 +11,13 @@
  * Common aliases: speaker map, speaker resolution, transcript participant
  * mapping, user-self detection, placeholder Person.
  */
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { DrizzleDB } from "~/db";
 import { aliases, nodeMetadata, nodes, type NodeSelect } from "~/db/schema";
 import { createAlias, normalizeAliasText } from "~/lib/alias";
 import { normalizeLabel } from "~/lib/label";
 import { getEffectiveNodeScopes } from "~/lib/node-scope";
+import { ensureUserSelfPersonNode } from "~/lib/user-self-identity";
 import type { TypeId } from "~/types/typeid";
 
 export type SpeakerResolution =
@@ -110,17 +111,14 @@ export async function resolveSpeakers({
   for (const label of uniqueLabels) {
     const normalized = normalizeAliasText(label);
 
-    // 1. user-self
+    // 1. user-self. Resolution matches against the `userSelfAliases` config
+    // set directly, so we deliberately do NOT write the (often bare,
+    // ambiguous) speaker label into the alias table — that is exactly what let
+    // a same-named contact merge into the user. Distinguishing aliases are
+    // seeded separately via `ensureUserSelfIdentity`.
     if (userSelfNormalized.has(normalized)) {
       const nodeId = await ensureUserSelfNode();
       map.set(label, { nodeId, isUserSelf: true, resolution: "user_self" });
-      // Persist the alias on the user-self node so future identity resolution
-      // picks it up too.
-      await createAlias(db, {
-        userId,
-        canonicalNodeId: nodeId,
-        aliasText: label,
-      });
       continue;
     }
 
@@ -196,65 +194,6 @@ export async function resolveSpeakers({
   }
 
   return map;
-}
-
-/**
- * Ensure the user's own Person node exists. Looked up by
- * `nodeMetadata.additionalData.isUserSelf = true` for the user's Person nodes;
- * created lazily on first transcript ingestion if absent.
- *
- * Concurrency: serialized per-user via a transaction-scoped Postgres advisory
- * lock keyed on `hashtext('user_self_person:' || userId)`. Two concurrent
- * transcript jobs for the same user will queue at the lock and observe each
- * other's INSERT, so only one user-self Person row is ever created. The lock
- * is released automatically at transaction commit.
- */
-async function ensureUserSelfPersonNode(
-  db: DrizzleDB,
-  userId: string,
-): Promise<TypeId<"node">> {
-  return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${"user_self_person:" + userId}))`,
-    );
-
-    const personNodes = await tx
-      .select({
-        id: nodes.id,
-        label: nodeMetadata.label,
-        additionalData: nodeMetadata.additionalData,
-      })
-      .from(nodes)
-      .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
-      .where(and(eq(nodes.userId, userId), eq(nodes.nodeType, "Person")));
-
-    for (const row of personNodes) {
-      const additional = row.additionalData;
-      if (
-        additional &&
-        typeof additional === "object" &&
-        !Array.isArray(additional) &&
-        (additional as Record<string, unknown>)["isUserSelf"] === true
-      ) {
-        return row.id;
-      }
-    }
-
-    const [newNode] = await tx
-      .insert(nodes)
-      .values({ userId, nodeType: "Person" })
-      .returning();
-    if (!newNode) {
-      throw new Error(`Failed to create user-self Person node for ${userId}`);
-    }
-    await tx.insert(nodeMetadata).values({
-      nodeId: newNode.id,
-      label: userId,
-      canonicalLabel: normalizeLabel(userId),
-      additionalData: { isUserSelf: true },
-    });
-    return newNode.id;
-  });
 }
 
 async function createPlaceholderPersonNode(

--- a/src/lib/user-profile.test.ts
+++ b/src/lib/user-profile.test.ts
@@ -42,6 +42,9 @@ const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
 type TestDb = NodePgDatabase<typeof schema>;
 
 async function createTables(client: Client): Promise<void> {
+  // `setUserSelfAliases` now calls `ensureUserSelfIdentity`, which touches the
+  // node/alias tables, so they must exist here too. Truncating `users CASCADE`
+  // in `afterEach` reaches these via their FKs.
   await client.query(`
     CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
     CREATE TABLE IF NOT EXISTS "user_profiles" (
@@ -51,6 +54,32 @@ async function createTables(client: Client): Promise<void> {
       "metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
       "last_updated_at" timestamp with time zone DEFAULT now() NOT NULL,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "aliases" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "alias_text" text NOT NULL,
+      "normalized_alias_text" text NOT NULL,
+      "canonical_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "aliases_user_normalized_canonical_unique"
+        UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
     );
   `);
 }

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -13,8 +13,8 @@ import {
   userProfileMetadataSchema,
   type UserProfileMetadata,
 } from "~/lib/schemas/user-profile-metadata";
-import { newTypeId } from "~/types/typeid";
 import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
+import { newTypeId } from "~/types/typeid";
 
 /** Read `metadata` and parse with the schema. Empty/absent row → empty default. */
 async function readMetadata(

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -14,6 +14,7 @@ import {
   type UserProfileMetadata,
 } from "~/lib/schemas/user-profile-metadata";
 import { newTypeId } from "~/types/typeid";
+import { ensureUserSelfIdentity } from "~/lib/user-self-identity";
 
 /** Read `metadata` and parse with the schema. Empty/absent row → empty default. */
 async function readMetadata(
@@ -67,18 +68,20 @@ export async function setUserSelfAliases(
       content: "",
       metadata: { ...parsed, userSelfAliases: nextAliases },
     });
-    return { aliases: nextAliases };
+  } else {
+    // Merge: replace `userSelfAliases`, preserve catchall keys.
+    const nextMetadata: UserProfileMetadata = {
+      ...existing,
+      userSelfAliases: nextAliases,
+    };
+    await db
+      .update(userProfiles)
+      .set({ metadata: nextMetadata, lastUpdatedAt: sql`now()` })
+      .where(eq(userProfiles.userId, userId));
   }
 
-  // Merge: replace `userSelfAliases`, preserve catchall keys.
-  const nextMetadata: UserProfileMetadata = {
-    ...existing,
-    userSelfAliases: nextAliases,
-  };
-  await db
-    .update(userProfiles)
-    .set({ metadata: nextMetadata, lastUpdatedAt: sql`now()` })
-    .where(eq(userProfiles.userId, userId));
+  // Keep the self node's label + distinguishing aliases in sync with config.
+  await ensureUserSelfIdentity(db, userId, nextAliases);
 
   return { aliases: nextAliases };
 }

--- a/src/lib/user-self-identity.test.ts
+++ b/src/lib/user-self-identity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUserIdentityNote,
+  distinguishingAliases,
+  selectPrimarySelfLabel,
+} from "./user-self-identity";
+
+describe("selectPrimarySelfLabel", () => {
+  it("picks the alias with the most tokens", () => {
+    expect(selectPrimarySelfLabel(["Marcel", "Marcel Samyn"])).toBe(
+      "Marcel Samyn",
+    );
+  });
+
+  it("returns null when only single-token aliases are present", () => {
+    expect(selectPrimarySelfLabel(["Marcel"])).toBeNull();
+  });
+
+  it("returns null for an empty list", () => {
+    expect(selectPrimarySelfLabel([])).toBeNull();
+  });
+
+  it("prefers the longest string when token counts tie", () => {
+    expect(selectPrimarySelfLabel(["Jo Lee", "Joanna Lee"])).toBe("Joanna Lee");
+  });
+});
+
+describe("distinguishingAliases", () => {
+  it("keeps only multi-token aliases, de-duplicated by normalized form", () => {
+    expect(
+      distinguishingAliases(["Marcel", "Marcel Samyn", "marcel samyn"]),
+    ).toEqual(["Marcel Samyn"]);
+  });
+
+  it("drops bare single-token names", () => {
+    expect(distinguishingAliases(["Marcel", "MS"])).toEqual([]);
+  });
+});
+
+describe("buildUserIdentityNote", () => {
+  it("returns null when there are no aliases", () => {
+    expect(buildUserIdentityNote([])).toBeNull();
+  });
+
+  it("names the primary, lists aliases, and warns against conflation", () => {
+    const note = buildUserIdentityNote(["Marcel", "Marcel Samyn"]);
+    expect(note).toContain("Marcel Samyn");
+    expect(note).toContain("most specific");
+    expect(note).toContain("share a first name");
+  });
+});

--- a/src/lib/user-self-identity.test.ts
+++ b/src/lib/user-self-identity.test.ts
@@ -1,12 +1,12 @@
-import { drizzle } from "drizzle-orm/node-postgres";
-import { Client } from "pg";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import * as schema from "~/db/schema";
 import {
   buildUserIdentityNote,
   distinguishingAliases,
   selectPrimarySelfLabel,
 } from "./user-self-identity";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
 
 describe("selectPrimarySelfLabel", () => {
   it("picks the alias with the most tokens", () => {

--- a/src/lib/user-self-identity.test.ts
+++ b/src/lib/user-self-identity.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
 import {
   buildUserIdentityNote,
   distinguishingAliases,
@@ -47,5 +50,167 @@ describe("buildUserIdentityNote", () => {
     expect(note).toContain("Marcel Samyn");
     expect(note).toContain("most specific");
     expect(note).toContain("share a first name");
+  });
+});
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+async function createIdentityHygieneTables(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS "nodes" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "node_type" varchar(50) NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS "node_metadata" (
+      "id" text PRIMARY KEY NOT NULL,
+      "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "label" text,
+      "canonical_label" text,
+      "description" text,
+      "additional_data" jsonb,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+    );
+    CREATE TABLE IF NOT EXISTS "aliases" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL REFERENCES "users"("id"),
+      "alias_text" text NOT NULL,
+      "normalized_alias_text" text NOT NULL,
+      "canonical_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "aliases_user_normalized_canonical_unique"
+        UNIQUE ("user_id", "normalized_alias_text", "canonical_node_id")
+    );
+  `);
+}
+
+describeIfServer("ensureUserSelfIdentity", () => {
+  const dbName = `memory_self_identity_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("names the self node with the full name and seeds only multi-token aliases", async () => {
+    const userId = "user_self_identity_a";
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    try {
+      await createIdentityHygieneTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      const database = drizzle(client, { schema, casing: "snake_case" });
+
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const nodeId = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+
+      const meta = await client.query<{
+        label: string;
+        canonical_label: string;
+        additional_data: Record<string, unknown> | null;
+      }>(
+        `SELECT label, canonical_label, additional_data FROM node_metadata WHERE node_id = $1`,
+        [nodeId],
+      );
+      expect(meta.rows[0]?.label).toBe("Marcel Samyn");
+      expect(meta.rows[0]?.canonical_label).toBe("marcel samyn");
+      expect(meta.rows[0]?.additional_data).toMatchObject({ isUserSelf: true });
+
+      const aliasRows = await client.query<{ normalized_alias_text: string }>(
+        `SELECT normalized_alias_text FROM aliases WHERE user_id = $1 AND canonical_node_id = $2`,
+        [userId, nodeId],
+      );
+      const normalized = aliasRows.rows.map((r) => r.normalized_alias_text);
+      expect(normalized).toContain("marcel samyn");
+      expect(normalized).not.toContain("marcel");
+
+      // Idempotent: a second call adds nothing and keeps a single self node.
+      const nodeId2 = await ensureUserSelfIdentity(database, userId, [
+        "Marcel",
+        "Marcel Samyn",
+      ]);
+      expect(nodeId2).toBe(nodeId);
+      const selfCount = await client.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM node_metadata
+         WHERE (additional_data ->> 'isUserSelf') = 'true'`,
+      );
+      expect(selfCount.rows[0]?.count).toBe("1");
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("leaves the label unchanged when only single-token aliases are given", async () => {
+    const userId = "user_self_identity_b";
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    try {
+      await createIdentityHygieneTables(client);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      const database = drizzle(client, { schema, casing: "snake_case" });
+
+      const { ensureUserSelfIdentity } = await import("./user-self-identity");
+      const nodeId = await ensureUserSelfIdentity(database, userId, ["Marcel"]);
+
+      const meta = await client.query<{ label: string }>(
+        `SELECT label FROM node_metadata WHERE node_id = $1`,
+        [nodeId],
+      );
+      // No multi-token alias → primary label stays the placeholder (userId).
+      expect(meta.rows[0]?.label).toBe(userId);
+
+      const aliasRows = await client.query<{ id: string }>(
+        `SELECT id FROM aliases WHERE user_id = $1 AND canonical_node_id = $2`,
+        [userId, nodeId],
+      );
+      expect(aliasRows.rows).toHaveLength(0);
+    } finally {
+      await client.end();
+    }
   });
 });

--- a/src/lib/user-self-identity.ts
+++ b/src/lib/user-self-identity.ts
@@ -1,0 +1,174 @@
+/**
+ * User-self Person node identity management.
+ *
+ * Centralizes everything about the account owner's own Person node: lazy
+ * creation (advisory-lock-guarded), naming it with a distinguishing label,
+ * and seeding only unambiguous (multi-token) aliases into the global alias
+ * table used by `resolveIdentity`. Bare first names are deliberately kept out
+ * of the alias table so a same-named contact can never be merged into the
+ * user (or vice versa) on a single-token match. Also builds the "who the user
+ * is" note injected into document/conversation extraction prompts.
+ *
+ * Common aliases: user self node, self identity, primary self label,
+ * distinguishing aliases, user identity prompt note, isUserSelf.
+ */
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { nodeMetadata, nodes } from "~/db/schema";
+import { createAlias } from "~/lib/alias";
+import { normalizeLabel } from "~/lib/label";
+import type { TypeId } from "~/types/typeid";
+
+/** Count whitespace-separated tokens in an alias (after trimming). */
+function tokenCount(alias: string): number {
+  return alias
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0).length;
+}
+
+/**
+ * Aliases safe to write to the global alias table and to use as a node label:
+ * multi-token only, de-duplicated by normalized form. Single-token names
+ * (e.g. "Marcel") are inherently ambiguous and are intentionally excluded.
+ */
+export function distinguishingAliases(aliases: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const alias of aliases) {
+    const trimmed = alias.trim();
+    if (tokenCount(trimmed) < 2) continue;
+    const key = normalizeLabel(trimmed);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+/**
+ * Pick the most-specific distinguishing alias to use as the self node's
+ * primary label: most tokens, then longest string. Returns null when no
+ * multi-token alias is available, so the node keeps its existing label rather
+ * than being downgraded to an ambiguous single-token name.
+ */
+export function selectPrimarySelfLabel(aliases: string[]): string | null {
+  const candidates = distinguishingAliases(aliases);
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, current) => {
+    const bestTokens = tokenCount(best);
+    const currentTokens = tokenCount(current);
+    if (currentTokens > bestTokens) return current;
+    if (currentTokens === bestTokens && current.length > best.length) {
+      return current;
+    }
+    return best;
+  });
+}
+
+/**
+ * Build the "who the user is" note injected into document/conversation
+ * extraction prompts. Returns null when no aliases are configured so callers
+ * can omit the section entirely.
+ */
+export function buildUserIdentityNote(aliases: string[]): string | null {
+  const cleaned = aliases.map((a) => a.trim()).filter((a) => a.length > 0);
+  if (cleaned.length === 0) return null;
+  const primary = selectPrimarySelfLabel(cleaned) ?? cleaned[0]!;
+  const seen = new Set<string>();
+  const aliasList = cleaned
+    .filter((a) => {
+      const key = normalizeLabel(a);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .join(", ");
+  return `About the user: the account owner is "${primary}" (also referred to as: ${aliasList}). When the content refers to the user by name, use their most specific name as the node label. Do NOT merge a different person who happens to share a first name with the user, and never attribute a same-named other person's statements to the user.`;
+}
+
+/**
+ * Ensure the user's own Person node exists, returning its id. Looked up by
+ * `nodeMetadata.additionalData.isUserSelf = true`; created lazily on first use.
+ *
+ * Concurrency: serialized per-user via a transaction-scoped Postgres advisory
+ * lock keyed on `hashtext('user_self_person:' || userId)`. Two concurrent
+ * callers for the same user queue at the lock and observe each other's INSERT,
+ * so only one user-self Person row is ever created. The lock releases
+ * automatically at transaction commit.
+ */
+export async function ensureUserSelfPersonNode(
+  db: DrizzleDB,
+  userId: string,
+): Promise<TypeId<"node">> {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${"user_self_person:" + userId}))`,
+    );
+
+    const existing = await tx
+      .select({ id: nodes.id })
+      .from(nodes)
+      .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .where(
+        and(
+          eq(nodes.userId, userId),
+          eq(nodes.nodeType, "Person"),
+          sql`${nodeMetadata.additionalData}->>'isUserSelf' = 'true'`,
+        ),
+      )
+      .limit(1);
+    if (existing[0]) return existing[0].id;
+
+    const [newNode] = await tx
+      .insert(nodes)
+      .values({ userId, nodeType: "Person" })
+      .returning();
+    if (!newNode) {
+      throw new Error(`Failed to create user-self Person node for ${userId}`);
+    }
+    await tx.insert(nodeMetadata).values({
+      nodeId: newNode.id,
+      label: userId,
+      canonicalLabel: normalizeLabel(userId),
+      additionalData: { isUserSelf: true },
+    });
+    return newNode.id;
+  });
+}
+
+/**
+ * Ensure the user-self Person node exists, carries a distinguishing primary
+ * label, and has the user's multi-token aliases seeded into the alias table.
+ * Single-token (ambiguous) aliases are deliberately NOT written to the alias
+ * table — they remain usable for transcript speaker matching via the
+ * `userSelfAliases` config set, but must never drive an identity merge.
+ *
+ * Idempotent: safe to call on every transcript ingest and every config write.
+ */
+export async function ensureUserSelfIdentity(
+  db: DrizzleDB,
+  userId: string,
+  aliases: string[],
+): Promise<TypeId<"node">> {
+  const nodeId = await ensureUserSelfPersonNode(db, userId);
+
+  const primaryLabel = selectPrimarySelfLabel(aliases);
+  if (primaryLabel) {
+    await db
+      .update(nodeMetadata)
+      .set({
+        label: primaryLabel,
+        canonicalLabel: normalizeLabel(primaryLabel),
+      })
+      .where(eq(nodeMetadata.nodeId, nodeId));
+  }
+
+  await Promise.all(
+    distinguishingAliases(aliases).map((alias) =>
+      createAlias(db, { userId, canonicalNodeId: nodeId, aliasText: alias }),
+    ),
+  );
+
+  return nodeId;
+}

--- a/src/lib/user-self-identity.ts
+++ b/src/lib/user-self-identity.ts
@@ -155,13 +155,23 @@ export async function ensureUserSelfIdentity(
 
   const primaryLabel = selectPrimarySelfLabel(aliases);
   if (primaryLabel) {
-    await db
-      .update(nodeMetadata)
-      .set({
-        label: primaryLabel,
-        canonicalLabel: normalizeLabel(primaryLabel),
-      })
-      .where(eq(nodeMetadata.nodeId, nodeId));
+    // Read-before-write: this runs on every transcript ingest, where the label
+    // is almost always already correct. Skip the UPDATE when unchanged to avoid
+    // needless WAL/MVCC churn on the hot path.
+    const [current] = await db
+      .select({ label: nodeMetadata.label })
+      .from(nodeMetadata)
+      .where(eq(nodeMetadata.nodeId, nodeId))
+      .limit(1);
+    if (current?.label !== primaryLabel) {
+      await db
+        .update(nodeMetadata)
+        .set({
+          label: primaryLabel,
+          canonicalLabel: normalizeLabel(primaryLabel),
+        })
+        .where(eq(nodeMetadata.nodeId, nodeId));
+    }
   }
 
   await Promise.all(

--- a/src/routes/maintenance/backfill-user-self-identity.post.ts
+++ b/src/routes/maintenance/backfill-user-self-identity.post.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, readBody } from "h3";
+import { backfillUserSelfIdentity } from "~/lib/jobs/backfill-user-self-identity";
+import {
+  backfillUserSelfIdentityRequestSchema,
+  backfillUserSelfIdentityResponseSchema,
+} from "~/lib/schemas/backfill-user-self-identity";
+import { useDatabase } from "~/utils/db";
+
+export default defineEventHandler(async (event) => {
+  const { userId, aliases } = backfillUserSelfIdentityRequestSchema.parse(
+    await readBody(event),
+  );
+  const db = await useDatabase();
+  const result = await backfillUserSelfIdentity({
+    db,
+    userId,
+    ...(aliases !== undefined ? { aliases } : {}),
+  });
+  return backfillUserSelfIdentityResponseSchema.parse(result);
+});


### PR DESCRIPTION
## What & why

The knowledge graph attributed the account owner's own first-person statements (from an ingested WhatsApp transcript) to a **different same-named person's node** — e.g. the user's "I…" routed to a contact also named "Marcel". This is general **same-name disambiguation** with the account owner as a first-class case — deliberately **not** a blunt "assume the user when unsure" heuristic (which over-merges).

Four components, in leverage order:

1. **Self-node hygiene** — new [`user-self-identity.ts`](src/lib/user-self-identity.ts) names the self node with the user's *most-specific* (multi-token) alias and seeds **only multi-token** aliases into the alias table — bare first names never enter it, so a same-named contact can never merge into the user (or vice versa). `ensureUserSelfIdentity` is idempotent + advisory-lock-guarded; called from `setUserSelfAliases` (config) and `ingestTranscript` (effective aliases — covers WhatsApp, where stored aliases are empty). Plus a backfill route to repair existing self nodes.
2. **Subject-wiring** — `extract-graph.ts` registers resolved speaker nodes into `idMap` and instructs the model to use a speaker's nodeId as the subject of first-person claims. *Load-bearing fix:* claim insertion skips subjects not in `idMap`.
3. **Resolver never guesses** — `resolveIdentity` resolves only on a **unique** canonical/alias match; >1 match records `ambiguous`, logs `identity.ambiguous_skip`, and falls through to split. **No self-prior anywhere.**
4. **Prompt insurance** — a cache-safe "who the user is" note (dynamic user message only, never the cached system prompt) + a static anti-conflation rule for document/conversation extraction.

Result: the bug dies twice over — subject-wiring routes the user's utterance to the self node, and even a bare name reaching the resolver splits rather than guessing.

## How to test

```bash
docker compose up -d db   # Postgres on :5431
pnpm run build:check
pnpm run lint
pnpm run format
pnpm run test -- run \
  src/lib/user-self-identity.test.ts \
  src/lib/transcript/resolve-speakers.test.ts \
  src/lib/jobs/ingest-transcript.test.ts \
  src/lib/identity-resolution.test.ts \
  src/lib/user-profile.test.ts
```

Key tests: `identity-resolution.test.ts` (ambiguous tie → no resolve + `identity.ambiguous_skip`; `Marcel Samyn` → self, bare `Marcel` → the contact), `ingest-transcript.test.ts` (user-self first-person claim attaches to the self node, not a same-named participant).

## Operational note

Existing user-self nodes predate the new contract. Run a one-time backfill per user to give them a distinguishing label + multi-token aliases (and strip any previously-seeded bare alias):

```
POST /maintenance/backfill-user-self-identity   { "userId": "<id>" }
```

Passing an empty/absent effective alias list clears the self node's alias rows (clean-slate) — pass a non-empty list to avoid that.

## Checklist

- [x] `pnpm run build:check` (tsc --noEmit + structured-output schema check)
- [x] `pnpm run lint`
- [x] `pnpm run format`
- [x] Tests: **530/530** on Postgres `:5431` (note: PR CI runs lint/format/build only — vitest is local)
- [x] No unrelated changes
- [ ] One-time backfill run for existing users (operational follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
