### PR TITLE
✨ feat(sdk): sampleNodes endpoint for Explore wander-in starters

### DIFF
--- a/src/lib/query/sample-nodes.test.ts
+++ b/src/lib/query/sample-nodes.test.ts
@@ -1,0 +1,260 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+process.env["DATABASE_URL"] ??= adminDsn();
+process.env["JINA_API_KEY"] ??= "test";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("sampleInterestingNodes", () => {
+  const dbName = `memory_sample_nodes_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  let client: Client;
+  let database: ReturnType<typeof drizzle<typeof schema>>;
+  let testIds: {
+    hub: string;
+    wellLinked: string;
+    thin: string;
+    noisy: string;
+    unlabeled: string;
+  };
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+
+    client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    database = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/utils/db", () => ({ useDatabase: async () => database }));
+
+    await client.query(`
+      CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE "nodes" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "node_type" varchar(50) NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+      CREATE TABLE "node_metadata" (
+        "id" text PRIMARY KEY NOT NULL,
+        "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "label" text,
+        "canonical_label" text,
+        "description" text,
+        "additional_data" jsonb,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+      );
+      CREATE TABLE "sources" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "type" varchar(50) NOT NULL,
+        "external_id" text NOT NULL,
+        "parent_source" text,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "metadata" jsonb,
+        "last_ingested_at" timestamp with time zone,
+        "status" varchar(20) DEFAULT 'pending',
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "deleted_at" timestamp with time zone,
+        "content_type" varchar(100),
+        "content_length" integer
+      );
+      CREATE TABLE "claims" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "object_value" text,
+        "predicate" varchar(80) NOT NULL,
+        "statement" text NOT NULL,
+        "description" text,
+        "metadata" jsonb,
+        "object_instant" timestamp with time zone,
+        "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "asserted_by_kind" varchar(24) NOT NULL,
+        "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+        "superseded_by_claim_id" text,
+        "contradicted_by_claim_id" text,
+        "stated_at" timestamp with time zone NOT NULL,
+        "valid_from" timestamp with time zone,
+        "valid_to" timestamp with time zone,
+        "status" varchar(30) DEFAULT 'active' NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+    `);
+
+    const userId = "user_sample";
+
+    const hub = newTypeId("node"); // Concept, 4 connections -> included
+    const wellLinked = newTypeId("node"); // Person, 3 connections -> included
+    const thin = newTypeId("node"); // Person, 2 connections -> excluded
+    const noisy = newTypeId("node"); // Temporal, 5 connections -> excluded (noise)
+    const unlabeled = newTypeId("node"); // 4 connections but no label -> excluded
+    const spokes = Array.from({ length: 5 }, () => newTypeId("node"));
+    const src = newTypeId("source");
+
+    // Store for assertions in the it blocks.
+    testIds = { hub, wellLinked, thin, noisy, unlabeled };
+
+    await database.insert(schema.users).values({ id: userId });
+    await database.insert(schema.sources).values({
+      id: src,
+      userId,
+      type: "conversation",
+      externalId: "conv:1",
+      scope: "personal",
+      status: "completed",
+    });
+
+    const allNodes = [hub, wellLinked, thin, noisy, unlabeled, ...spokes];
+    await database.insert(schema.nodes).values(
+      allNodes.map((id) => ({
+        id,
+        userId,
+        nodeType:
+          id === hub
+            ? ("Concept" as const)
+            : id === noisy
+              ? ("Temporal" as const)
+              : ("Person" as const),
+      })),
+    );
+
+    // Labels for everything except `unlabeled`.
+    await database.insert(schema.nodeMetadata).values(
+      [hub, wellLinked, thin, noisy, ...spokes].map((id) => ({
+        id: newTypeId("node_metadata"),
+        nodeId: id,
+        label: `label-${id.slice(-4)}`,
+        description: null,
+      })),
+    );
+    await database.insert(schema.nodeMetadata).values({
+      id: newTypeId("node_metadata"),
+      nodeId: unlabeled,
+      label: null,
+      description: null,
+    });
+
+    // Helper: make `count` active claims linking `node` to distinct spokes.
+    const linkClaims = (node: string, count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: newTypeId("claim"),
+        userId,
+        subjectNodeId: node,
+        objectNodeId: spokes[i % spokes.length]!,
+        predicate: "RELATED_TO",
+        statement: "x",
+        sourceId: src,
+        scope: "personal" as const,
+        assertedByKind: "user_stated" as const,
+        statedAt: new Date("2026-01-01T00:00:00.000Z"),
+        status: "active" as const,
+      }));
+
+    await database
+      .insert(schema.claims)
+      .values([
+        ...linkClaims(hub, 4),
+        ...linkClaims(wellLinked, 3),
+        ...linkClaims(thin, 2),
+        ...linkClaims(noisy, 5),
+        ...linkClaims(unlabeled, 4),
+      ]);
+  });
+
+  afterAll(async () => {
+    vi.doUnmock("~/utils/db");
+    vi.resetModules();
+    await client.end();
+
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("returns only labeled, non-noise nodes with >= 3 connections", async () => {
+    const userId = "user_sample";
+    const { hub, wellLinked, thin, noisy, unlabeled } = testIds;
+
+    const { sampleInterestingNodes } = await import("./sample-nodes");
+    const result = await sampleInterestingNodes({ userId, limit: 6 });
+
+    const ids = result.nodes.map((n) => n.id);
+    expect(ids).toContain(hub);
+    expect(ids).toContain(wellLinked);
+    expect(ids).not.toContain(thin);
+    expect(ids).not.toContain(noisy);
+    expect(ids).not.toContain(unlabeled);
+    result.nodes.forEach((n) => {
+      expect(n.connectionCount).toBeGreaterThanOrEqual(3);
+      expect(n.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("respects the nodeTypes filter and the limit", async () => {
+    const { sampleInterestingNodes } = await import("./sample-nodes");
+    const result = await sampleInterestingNodes({
+      userId: "user_sample",
+      limit: 1,
+      nodeTypes: ["Concept"],
+    });
+    expect(result.nodes.length).toBe(1);
+    result.nodes.forEach((n) => expect(n.nodeType).toBe("Concept"));
+  });
+
+  it("returns an empty array when no node qualifies", async () => {
+    const { sampleInterestingNodes } = await import("./sample-nodes");
+    const result = await sampleInterestingNodes({
+      userId: "user_nobody",
+      limit: 6,
+    });
+    expect(result.nodes).toEqual([]);
+  });
+});

--- a/src/lib/query/sample-nodes.ts
+++ b/src/lib/query/sample-nodes.ts
@@ -1,0 +1,119 @@
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  notInArray,
+  sql,
+} from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+import {
+  SampleNodesRequest,
+  SampleNodesResponse,
+} from "~/lib/schemas/sample-nodes";
+import { useDatabase } from "~/utils/db";
+
+/** Node types that are scaffolding/system-owned, never "wander into" targets. */
+const NOISE_NODE_TYPES = ["Temporal", "Atlas", "AssistantDream"];
+const MIN_CONNECTIONS = 3;
+const POOL_SIZE = 60;
+
+/**
+ * Sample a handful of "interesting" nodes for the Explore empty state:
+ * labeled, non-noise nodes with >= 3 active connections. We rank the most
+ * connected into a pool of POOL_SIZE, then draw `limit` at random from it —
+ * so results feel substantive but vary on each call (the UI's "shuffle").
+ */
+export async function sampleInterestingNodes(
+  params: SampleNodesRequest,
+): Promise<SampleNodesResponse> {
+  const { userId, limit, nodeTypes } = params;
+  const db = await useDatabase();
+
+  // A node's "connections" are the active claims it appears in, as subject or
+  // object. We unnest both roles via UNION ALL rather than an `OR` join
+  // predicate — an `OR` across two columns prevents Postgres from using the
+  // per-column indexes, while each UNION ALL branch is a clean equality join
+  // that can.
+  const connections = unionAll(
+    db
+      .select({ nodeId: claims.subjectNodeId, claimId: claims.id })
+      .from(claims)
+      .where(and(eq(claims.userId, userId), eq(claims.status, "active"))),
+    db
+      .select({ nodeId: claims.objectNodeId, claimId: claims.id })
+      .from(claims)
+      .where(
+        and(
+          eq(claims.userId, userId),
+          eq(claims.status, "active"),
+          isNotNull(claims.objectNodeId),
+        ),
+      ),
+  ).as("connections");
+
+  // CTE 1: connection counts for qualifying nodes.
+  const conn = db.$with("conn").as(
+    db
+      .select({
+        id: nodes.id,
+        nodeType: nodes.nodeType,
+        label: nodeMetadata.label,
+        description: nodeMetadata.description,
+        connectionCount: sql<string>`count(${connections.claimId})`.as(
+          "connection_count",
+        ),
+      })
+      .from(nodes)
+      .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+      .innerJoin(connections, eq(connections.nodeId, nodes.id))
+      .where(
+        and(
+          eq(nodes.userId, userId),
+          isNotNull(nodeMetadata.label),
+          notInArray(nodes.nodeType, NOISE_NODE_TYPES),
+          ...(nodeTypes && nodeTypes.length > 0
+            ? [inArray(nodes.nodeType, nodeTypes)]
+            : []),
+        ),
+      )
+      .groupBy(
+        nodes.id,
+        nodes.nodeType,
+        nodeMetadata.label,
+        nodeMetadata.description,
+      )
+      .having(sql`count(${connections.claimId}) >= ${MIN_CONNECTIONS}`),
+  );
+
+  // CTE 2: the top-connected pool.
+  const pool = db
+    .$with("pool")
+    .as(
+      db
+        .select()
+        .from(conn)
+        .orderBy(desc(conn.connectionCount))
+        .limit(POOL_SIZE),
+    );
+
+  // Draw `limit` at random from the pool.
+  const rows = await db
+    .with(conn, pool)
+    .select()
+    .from(pool)
+    .orderBy(sql`random()`)
+    .limit(limit);
+
+  return {
+    nodes: rows.map((r) => ({
+      id: r.id,
+      nodeType: r.nodeType,
+      label: r.label ?? "",
+      description: r.description,
+      connectionCount: Number(r.connectionCount),
+    })),
+  };
+}

--- a/src/lib/schemas/sample-nodes.ts
+++ b/src/lib/schemas/sample-nodes.ts
@@ -1,0 +1,23 @@
+import { NodeTypeEnum } from "../../types/graph.js";
+import { typeIdSchema } from "../../types/typeid.js";
+import { z } from "zod";
+
+export const sampleNodesRequestSchema = z.object({
+  userId: z.string(),
+  limit: z.number().int().min(1).max(24).default(6),
+  nodeTypes: z.array(NodeTypeEnum).optional(),
+});
+export type SampleNodesRequest = z.infer<typeof sampleNodesRequestSchema>;
+
+export const sampleNodeSchema = z.object({
+  id: typeIdSchema("node"),
+  nodeType: NodeTypeEnum,
+  label: z.string(),
+  description: z.string().nullable(),
+  connectionCount: z.number().int(),
+});
+
+export const sampleNodesResponseSchema = z.object({
+  nodes: z.array(sampleNodeSchema),
+});
+export type SampleNodesResponse = z.infer<typeof sampleNodesResponseSchema>;

--- a/src/routes/query/sample-nodes.ts
+++ b/src/routes/query/sample-nodes.ts
@@ -1,0 +1,12 @@
+import { defineEventHandler } from "h3";
+import { sampleInterestingNodes } from "~/lib/query/sample-nodes";
+import {
+  sampleNodesRequestSchema,
+  sampleNodesResponseSchema,
+} from "~/lib/schemas/sample-nodes";
+
+export default defineEventHandler(async (event) => {
+  const params = sampleNodesRequestSchema.parse(await readBody(event));
+  const result = await sampleInterestingNodes(params);
+  return sampleNodesResponseSchema.parse(result);
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -23,6 +23,7 @@ export * from "../lib/schemas/query-day.js";
 export * from "../lib/schemas/query-node-type.js";
 export * from "../lib/schemas/query-recent-changes.js";
 export * from "../lib/schemas/query-graph.js";
+export * from "../lib/schemas/sample-nodes.js";
 export * from "../lib/schemas/query-timeline.js";
 export * from "../lib/schemas/messages.js";
 export * from "../lib/schemas/summarize.js";

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -234,6 +234,11 @@ import {
   type RollupResponse,
 } from "../lib/schemas/rollup.js";
 import {
+  sampleNodesResponseSchema,
+  type SampleNodesRequest,
+  type SampleNodesResponse,
+} from "../lib/schemas/sample-nodes.js";
+import {
   ScratchpadReadRequest,
   ScratchpadWriteRequest,
   ScratchpadEditRequest,
@@ -540,6 +545,15 @@ export class MemoryClient {
       "POST",
       "/query/graph",
       queryGraphResponseSchema,
+      payload,
+    );
+  }
+
+  async sampleNodes(payload: SampleNodesRequest): Promise<SampleNodesResponse> {
+    return this._fetch(
+      "POST",
+      "/query/sample-nodes",
+      sampleNodesResponseSchema,
       payload,
     );
   }


### PR DESCRIPTION
## What & why

Adds a focused `sampleNodes` SDK endpoint that samples a handful of **interesting** (well-connected) nodes — the backing data for Petals' Memory → Explore empty-state "wander in" starters. The existing no-query `queryGraph` returns the *entire* labeled graph, far too heavy to fetch just to render ~6 chips, so this is a dedicated, cheap query.

### Selection logic
- Counts active claims per node where the node is subject **or** object (its "connections").
- Keeps only labeled, `userId`-owned nodes with **`connectionCount >= 3`**.
- Excludes scaffolding node types: `Temporal`, `Atlas`, `AssistantDream`.
- Optional `nodeTypes` filter.
- Ranks the top **K=60** most-connected into a pool, then draws `limit` (default 6, max 24) at random — substantive results that vary per call (the UI's "shuffle").

Single Drizzle query (two CTEs → `ORDER BY random()`); no embeddings, no LLM.

## Changes
- `src/lib/schemas/sample-nodes.ts` — Zod request/response schemas.
- `src/lib/query/sample-nodes.ts` — `sampleInterestingNodes()`.
- `src/routes/query/sample-nodes.ts` — `POST /query/sample-nodes`.
- `src/sdk/memory-client.ts` — `MemoryClient.sampleNodes()`.
- `src/sdk/index.ts` — barrel re-export of the schemas/types.

> **Note:** no version bump in this PR — versioning/publish handled separately after merge to keep version history clean alongside parallel work.

## How to test
- `pnpm test --run src/lib/query/sample-nodes.test.ts` (needs the test Postgres on `localhost:5431`; `docker compose up -d db`). Covers: `>=3` + noise-exclusion + labeled-only filtering, `nodeTypes` + `limit`, and the empty-result case. 3/3 pass.
- `pnpm run build` — clean.

## Checklist
- [x] Build green (`pnpm run build`)
- [x] Tests green (3/3, not skipped)
- [ ] Version bump + publish (intentionally deferred)