### PR TITLE
🐛 fix(mcp): rename tools with spaces to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: MCP tool names normalized to snake_case to satisfy the MCP tool-name format spec.** The SDK now warns at registration when a tool name contains spaces, flagging it as a future compatibility risk (see [SEP: Specify Format for Tool Names](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)). The following tools were renamed to match the snake_case convention already used by `bootstrap_memory`, `search_memory`, `list_open_commitments`, etc. — their schemas, descriptions, and request/response shapes are unchanged:
+
+  | Old | New |
+  | --- | --- |
+  | `save memory` | `save_memory` |
+  | `retrieve memories relevant for today` | `query_day_memories` |
+  | `read scratchpad` / `write scratchpad` / `edit scratchpad` | `read_scratchpad` / `write_scratchpad` / `edit_scratchpad` |
+  | `get node` / `get node sources` | `get_node` / `get_node_sources` |
+  | `update node` / `delete node` | `update_node` / `delete_node` |
+
+  Update any client that calls these tools by name. The `add`, `bootstrap_memory`, `search_memory`, `search_reference`, `get_entity`, and all commitment/metric/claim tools are unaffected.
+
 - **BREAKING: `queryTimeline` date bounds renamed `startDate`/`endDate` → `since`/`until`, with conventional semantics.** `since` is the earliest day (inclusive), `until` the latest (inclusive); both are optional and an omitted bound is open on that side (no more implicit `today` / 90-days-ago defaults). Previously `startDate` meant the _newest_ edge and `endDate` the _oldest_, which silently collapsed a one-sided window — e.g. `endDate: today` returned only today. `includePeriods` now derives week/month/year rollups from the day nodes actually in range, so an open `until: today` feed returns every past period it covers, not just the current one. Update callers: pass `until` for "up to" and `since` for "from".
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING: MCP tool names normalized to snake_case to satisfy the MCP tool-name format spec.** The SDK now warns at registration when a tool name contains spaces, flagging it as a future compatibility risk (see [SEP: Specify Format for Tool Names](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)). The following tools were renamed to match the snake_case convention already used by `bootstrap_memory`, `search_memory`, `list_open_commitments`, etc. — their schemas, descriptions, and request/response shapes are unchanged:
 
-  | Old | New |
-  | --- | --- |
-  | `save memory` | `save_memory` |
-  | `retrieve memories relevant for today` | `query_day_memories` |
+  | Old                                                        | New                                                        |
+  | ---------------------------------------------------------- | ---------------------------------------------------------- |
+  | `save memory`                                              | `save_memory`                                              |
+  | `retrieve memories relevant for today`                     | `query_day_memories`                                       |
   | `read scratchpad` / `write scratchpad` / `edit scratchpad` | `read_scratchpad` / `write_scratchpad` / `edit_scratchpad` |
-  | `get node` / `get node sources` | `get_node` / `get_node_sources` |
-  | `update node` / `delete node` | `update_node` / `delete_node` |
+  | `get node` / `get node sources`                            | `get_node` / `get_node_sources`                            |
+  | `update node` / `delete node`                              | `update_node` / `delete_node`                              |
 
   Update any client that calls these tools by name. The `add`, `bootstrap_memory`, `search_memory`, `search_reference`, `get_entity`, and all commitment/metric/claim tools are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -200,13 +200,13 @@ This is the integration that works with the current code.
 
 MCP connects over `GET /sse` and `POST /messages`. Most current tool names are human-readable strings; the first claims-first read-model tool is already snake_case:
 
-- `save memory`: document ingestion using the `POST /ingest/document` schema.
+- `save_memory`: document ingestion using the `POST /ingest/document` schema.
 - `search memory`: calls the same search path as `POST /query/search`.
-- `retrieve memories relevant for today`: calls the same path as `POST /query/day`.
+- `query_day_memories`: calls the same path as `POST /query/day`.
 - `list_open_commitments`: calls `POST /commitments/open` semantics and returns currently open tasks only. The model should call it before answering about outstanding, next, pending, follow-up, completed, or abandoned work unless an `open_commitments` section was rendered for this same model call.
-- `get node` and `get node sources`: raw graph and linked-source metadata inspection tools.
-- `read scratchpad`, `write scratchpad`, `edit scratchpad`: scratchpad operations.
-- `update node`, `delete node`: raw edit tools; these should be gated by the host.
+- `get_node` and `get_node_sources`: raw graph and linked-source metadata inspection tools.
+- `read_scratchpad`, `write_scratchpad`, `edit_scratchpad`: scratchpad operations.
+- `update_node`, `delete_node`: raw edit tools; these should be gated by the host.
 
 For a tool-using assistant, make `search memory` available on demand for personal lookup and `list_open_commitments` available with the instruction above. The host should still proactively inject bootstrap context at session start because the current MCP server does not yet expose a true bootstrap tool.
 

--- a/docs/sdk-consumer-migration.md
+++ b/docs/sdk-consumer-migration.md
@@ -238,7 +238,7 @@ The legacy space-named tool is gone. Consumers that registered prompts or hard-c
 | —                                                                               | `bootstrap_memory` (new)                                           | Call **once** at conversation start. Returns the `ContextBundle` (pinned, atlas, open_commitments, recent_supersessions, preferences sections). Cached 6h per user; pass `forceRefresh: true` to bypass. Hosts that already render their own startup section may skip this and tell the model not to call it. |
 | —                                                                               | `get_entity` (new)                                                 | Single-entity card lookup by `nodeId`. Use after the model has an id from `search_memory` / `bootstrap_memory` and needs the full picture.                                                                                                                                                                    |
 
-`save memory`, `list_open_commitments`, `retrieve memories relevant for today`, `read scratchpad` / `write scratchpad` / `edit scratchpad`, and the `get node` / `update node` / `delete node` tools are **unchanged**.
+`save_memory`, `list_open_commitments`, `query_day_memories`, `read_scratchpad` / `write_scratchpad` / `edit_scratchpad`, and the `get_node` / `update_node` / `delete_node` tools are **unchanged**.
 
 #### Tool-description text is part of the contract
 

--- a/src/lib/mcp/mcp-server.ts
+++ b/src/lib/mcp/mcp-server.ts
@@ -158,9 +158,9 @@ server.resource(
   }),
 );
 
-// Expose ingest document functionality as "save memory"
+// Expose ingest document functionality as "save_memory"
 server.tool(
-  "save memory",
+  "save_memory",
   ingestDocumentRequestSchema.shape,
   async ({ userId, document }) => {
     await saveMemory({ userId, document, updateExisting: false });
@@ -259,9 +259,9 @@ server.tool(
   },
 );
 
-// Expose day query as "retrieve memories relevant for today"
+// Expose day query as "query_day_memories"
 server.tool(
-  "retrieve memories relevant for today",
+  "query_day_memories",
   queryDayRequestSchema.shape,
   async ({ userId, date }) => {
     const { formattedResult } = await queryDayMemories({
@@ -683,7 +683,7 @@ server.tool(
 
 // Read scratchpad
 server.tool(
-  "read scratchpad",
+  "read_scratchpad",
   scratchpadReadRequestSchema.shape,
   async ({ userId }) => {
     const result = await readScratchpad({ userId });
@@ -695,7 +695,7 @@ server.tool(
 
 // Write scratchpad (overwrite or append)
 server.tool(
-  "write scratchpad",
+  "write_scratchpad",
   scratchpadWriteRequestSchema.shape,
   async (params) => {
     const result = await writeScratchpad(params);
@@ -709,7 +709,7 @@ server.tool(
 
 // Edit scratchpad (replace text with safeguards)
 server.tool(
-  "edit scratchpad",
+  "edit_scratchpad",
   scratchpadEditRequestSchema.shape,
   async (params) => {
     const result = await editScratchpad(params);
@@ -727,7 +727,7 @@ server.tool(
 
 // Get node by ID with edges and source IDs
 server.tool(
-  "get node",
+  "get_node",
   getNodeRequestSchema.shape,
   async ({ userId, nodeId }) => {
     const result = await getNodeById(userId, nodeId);
@@ -745,7 +745,7 @@ server.tool(
 
 // Get source metadata linked to a node
 server.tool(
-  "get node sources",
+  "get_node_sources",
   getNodeSourcesRequestSchema.shape,
   async ({ userId, nodeId }) => {
     const result = await getNodeSources(userId, nodeId);
@@ -762,7 +762,7 @@ server.tool(
 
 // Update node label/type
 server.tool(
-  "update node",
+  "update_node",
   updateNodeRequestSchema.shape,
   async ({ userId, nodeId, label, nodeType }) => {
     const result = await updateNode(userId, nodeId, {
@@ -785,7 +785,7 @@ server.tool(
 
 // Delete node by ID
 server.tool(
-  "delete node",
+  "delete_node",
   deleteNodeRequestSchema.shape,
   async ({ userId, nodeId }) => {
     const { deleted, affectedClaims } = await deleteNode(userId, nodeId);


### PR DESCRIPTION
## What & why

The MCP SDK now warns at registration when a tool name contains spaces, flagging it as a future compatibility risk (see [SEP: Specify Format for Tool Names](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)). On `pnpm dev` this surfaced nine warnings.

Nine tools were renamed to match the snake_case convention already used by `bootstrap_memory`, `search_memory`, `list_open_commitments`, etc. Schemas, descriptions, and request/response shapes are unchanged.

| Old | New |
| --- | --- |
| `save memory` | `save_memory` |
| `retrieve memories relevant for today` | `query_day_memories` |
| `read scratchpad` / `write scratchpad` / `edit scratchpad` | `read_scratchpad` / `write_scratchpad` / `edit_scratchpad` |
| `get node` / `get node sources` | `get_node` / `get_node_sources` |
| `update node` / `delete node` | `update_node` / `delete_node` |

**Breaking** for any client that calls these tools by name. `add`, `bootstrap_memory`, `search_memory`, `search_reference`, `get_entity`, and all commitment/metric/claim tools are unaffected.

## How to test

- `pnpm dev` — confirm the nine "Tool name validation warning" messages no longer appear.
- `pnpm run build:check` — passes (tsc + structured-output check).
- `pnpm run lint` — passes.

## Checklist

- [x] build
- [x] tests / typecheck
- [x] lint
- [x] CHANGELOG entry (under `[Unreleased] → Changed`)
- [x] README + `docs/sdk-consumer-migration.md` updated
