### PR TITLE
feat(graph): add relation taxonomy guardrails

### DIFF
--- a/docs/sdk-consumer-migration.md
+++ b/docs/sdk-consumer-migration.md
@@ -81,7 +81,7 @@ Driven by Petals integration feedback. Five changes; all additive, no breaking c
 - `POST /node/create` now accepts an optional `initialClaims: Array<{ predicate, statement, objectNodeId? | objectValue?, description?, assertedByKind?, assertedByNodeId? }>`.
 - Claims are written sequentially after the node insert. If any claim fails (validation, FK, lifecycle), the node is deleted (FK `ON DELETE CASCADE` removes already-created claims) and the original error re-throws — no half-bootstrapped record survives.
 - Response now also returns `initialClaimIds: TypeId<"claim">[]` in the order claims were supplied. Empty array when no `initialClaims` were sent, so existing callers see `node` exactly as before plus an empty array.
-- Concrete win for Petals' `createCommitment`: collapse the three-call sequence (`createNode(Task)` → `createClaim(HAS_TASK_STATUS)` → `createClaim(OWNED_BY)`) into one `createNode` call where the Task is never observable without its required status claim. Validation errors (e.g. an invalid `HAS_TASK_STATUS` value) surface as `400 InvalidObjectValueError` and the node is rolled back automatically.
+- Concrete win for Petals' `createCommitment`: collapse the three-call sequence (`createNode(Task)` → `createClaim(HAS_TASK_STATUS)` → `createClaim(ASSIGNED_TO)`) into one `createNode` call where the Task is never observable without its required status claim. Validation errors (e.g. an invalid `HAS_TASK_STATUS` value) surface as `400 InvalidObjectValueError` and the node is rolled back automatically.
 - **NEW exports:** `createNodeInitialClaimSchema`, `CreateNodeInitialClaim`.
 
 ### Notes on items NOT shipped from the feedback
@@ -105,7 +105,7 @@ Driven by Petals integration feedback. Five changes; all additive, no breaking c
 - **NEW REST:** `POST /maintenance/prune-orphan-nodes` — deterministic maintenance for broken blob-backed sources and evidence-free legacy/entity nodes. It first removes source rows whose blob payload no longer exists, then prunes nodes made evidence-free by that repair. A node candidate has no claims as subject/object/speaker and no aliases; source links alone do not keep it alive. Request: `{ userId, olderThanDays?, limit?, sourceScanLimit?, sampleLimit?, dryRun?, nodeTypes? }`. `dryRun` defaults to `true`; response includes `hasMore` for node batches and `sourceScanHasMore` when the source scan hit its cap.
 - **NEW SDK method:** `MemoryClient.pruneOrphanNodes(payload)` → `PruneOrphanNodesResponse`.
 - **NEW exports:** `PruneOrphanNodesRequest`, `PruneOrphanNodesResponse`, `pruneOrphanNodesRequestSchema`, `pruneOrphanNodesResponseSchema`.
-- Default scanned node types are entity/task-like only: `Person`, `Location`, `Event`, `Object`, `Emotion`, `Concept`, `Media`, `Feedback`, `Idea`, `Task`. Generated/structural node types (`Conversation`, `Document`, `Temporal`, `Atlas`, `AssistantDream`) are excluded unless explicitly passed in `nodeTypes`.
+- Default scanned node types are entity/task-like only: `Person`, `Organization`, `Location`, `Event`, `Object`, `Emotion`, `Concept`, `Media`, `Feedback`, `Idea`, `Task`. Generated/structural node types (`Conversation`, `Document`, `Temporal`, `Atlas`, `AssistantDream`) are excluded unless explicitly passed in `nodeTypes`.
 - `MemoryClient.cleanup(...)` now runs orphan pruning first by default with `{ dryRun: false, olderThanDays: 7, limit: 10000, sampleLimit: 0 }`. Pass `pruneOrphanNodes: false` only for diagnostics or if an operator is running the standalone endpoint separately.
 
 ---
@@ -275,7 +275,7 @@ Hosts that did string-match on the old XML output need to switch to JSON parsing
 Mostly internal quality improvements; consumer surface mostly stable.
 
 - `3f78288` — **Atlas is now claim-derived.** REST shape (`POST /query/atlas`) unchanged but content quality changed materially. Consumers caching Atlas output should evict on deploy.
-- `1436046` — `(predicate, subjectType)` cardinality axis. No SDK change; consumers reading Task ownership now see at most one current `OWNED_BY` / `DUE_ON` per Task at any time.
+- `1436046` — `(predicate, subjectType)` cardinality axis. No SDK change; consumers reading Task ownership now see at most one current `ASSIGNED_TO` / `DUE_ON` per Task at any time.
 - `c4eb446` — Identity resolution rewritten with four-signal trace (canonical label / alias / embedding / claim profile) and is scope-bounded — cross-scope merges no longer happen. Visible only in extraction outcomes; no API change.
 - `42fcc2b` — Profile synthesis job rewrites node descriptions from active claims. `nodeMetadata.description` content quality changes; shape is unchanged.
 - `28f1fbe`, `fe0ad01` — Internal `ContextBundle` and `NodeCard` synthesis layers. Exposed externally in PR 3-iii.

--- a/docs/sdk/commitments.md
+++ b/docs/sdk/commitments.md
@@ -3,7 +3,7 @@
 Commitments are **Task nodes** in the memory graph. A Task's state lives entirely in claims attached to it:
 
 - `HAS_TASK_STATUS` — the task's current lifecycle position: `pending`, `in_progress`, `done`, or `abandoned`. Exactly one active status claim exists per task at any time; creating a new one automatically supersedes the prior.
-- `OWNED_BY` — points to an owner node (typically a `Person`). Enforced as single-active on Task subjects; reassigning creates a new claim and supersedes the prior.
+- `ASSIGNED_TO` — points to the task owner/assignee node (typically a `Person`). Enforced as single-active on Task subjects; reassigning creates a new claim and supersedes the prior.
 - `DUE_ON` — points to a Temporal day node. Same single-active rule; the server resolves the canonical day node from the `YYYY-MM-DD` string.
 
 The **lifecycle engine** (`single_current_value + supersede_previous` predicate policy) maintains these invariants automatically — callers never manually supersede or retract prior claims when using commitment methods.
@@ -16,7 +16,7 @@ The **lifecycle engine** (`single_current_value + supersede_previous` predicate 
 
 ### `createCommitment`
 
-Opens a new Task node, bootstrapping it with a `HAS_TASK_STATUS` claim and optionally `DUE_ON` and `OWNED_BY` claims in a single round-trip.
+Opens a new Task node, bootstrapping it with a `HAS_TASK_STATUS` claim and optionally `DUE_ON` and `ASSIGNED_TO` claims in a single round-trip.
 
 **Route:** `POST /commitments/create`
 
@@ -176,10 +176,10 @@ Assign, reassign, or clear a Task's owner. A structural twin of `setCommitmentDu
 | ------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `taskId`            | `nodeId`                    |                                                                                                                                        |
 | `owner`             | `{ nodeId, label } \| null` | The new owner, or `null` after a clear.                                                                                                |
-| `claimId`           | `claimId \| null`           | The new `OWNED_BY` claim. `null` on the clear path.                                                                                    |
+| `claimId`           | `claimId \| null`           | The new `ASSIGNED_TO` claim. `null` on the clear path.                                                                                 |
 | `retractedClaimIds` | `claimId[]`                 | Prior claims retracted. Populated only on the clear path (`ownedBy: null`); empty when assigning (lifecycle supersedes automatically). |
 
-**Lifecycle effect:** assign path — creates a new `OWNED_BY` claim; lifecycle supersedes the prior. Clear path — retracts every active `OWNED_BY` claim; no new claim asserted. `NodesNotFoundError` (404) if the owner node does not exist or belongs to a different user.
+**Lifecycle effect:** assign path — creates a new `ASSIGNED_TO` claim; lifecycle supersedes the prior. Clear path — retracts every active `ASSIGNED_TO` claim; no new claim asserted. `NodesNotFoundError` (404) if the owner node does not exist or belongs to a different user.
 
 ```ts
 // Assign
@@ -310,7 +310,7 @@ Paginated, sortable, searchable list across **all four statuses** (open, done, a
 | `statuses`         | `TaskStatus[]`                                                      | no       | all four            | Filter to specific statuses.                                                           |
 | `provenance`       | `"trusted" \| "candidate" \| "all"`                                 | no       | `"trusted"`         | `"trusted"` excludes `assistant_inferred`; `"candidate"` is only `assistant_inferred`. |
 | `ownedBy`          | `nodeId`                                                            | no       |                     | Mutually exclusive with `unowned`.                                                     |
-| `unowned`          | `boolean`                                                           | no       |                     | Only tasks with no active `OWNED_BY`.                                                  |
+| `unowned`          | `boolean`                                                           | no       |                     | Only tasks with no active `ASSIGNED_TO`.                                               |
 | `dueBefore`        | `string` (`YYYY-MM-DD`)                                             | no       |                     | Inclusive upper bound on due date.                                                     |
 | `dueAfter`         | `string` (`YYYY-MM-DD`)                                             | no       |                     | Inclusive lower bound on due date.                                                     |
 | `dueBeforeInstant` | `string` (ISO 8601 instant)                                         | no       |                     | Inclusive upper bound on `dueAt` (UTC instant). Matches timed tasks only.              |
@@ -383,7 +383,7 @@ Detailed read model for a single Task: current state (status, owner, due date) p
 | ---------------- | --------- | -------- | ------- | --------------------------------------------------------------------------------- |
 | `userId`         | `string`  | yes      |         |                                                                                   |
 | `taskId`         | `nodeId`  | yes      |         |                                                                                   |
-| `includeHistory` | `boolean` | no       | `true`  | Include full lifecycle history of `HAS_TASK_STATUS`, `OWNED_BY`, `DUE_ON` claims. |
+| `includeHistory` | `boolean` | no       | `true`  | Include full lifecycle history of `HAS_TASK_STATUS`, `ASSIGNED_TO`, `DUE_ON` claims. |
 | `includeSources` | `boolean` | no       | `true`  | Include distinct evidence sources behind the task's claims.                       |
 
 **Response**
@@ -398,7 +398,7 @@ Detailed read model for a single Task: current state (status, owner, due date) p
 | `statusClaimId`        | `claimId \| null`                    |                                                                       |
 | `statusStatedAt`       | `Date \| null`                       |                                                                       |
 | `statusAssertedByKind` | `AssertedByKind \| null`             |                                                                       |
-| `owner`                | `{ nodeId, label, claimId } \| null` | Includes the active `OWNED_BY` claim id.                              |
+| `owner`                | `{ nodeId, label, claimId } \| null` | Includes the active `ASSIGNED_TO` claim id.                           |
 | `dueOn`                | `string \| null`                     |                                                                       |
 | `dueTime`              | `string \| null`                     | `HH:mm` wall-clock time, or `null` for date-only.                     |
 | `timeZone`             | `string \| null`                     | IANA timezone, or `null` for date-only.                               |
@@ -422,7 +422,7 @@ Each `TaskLifecycleEntry`:
 | Field            | Type                                                        | Notes                                                  |
 | ---------------- | ----------------------------------------------------------- | ------------------------------------------------------ |
 | `claimId`        | `claimId`                                                   |                                                        |
-| `predicate`      | `"HAS_TASK_STATUS" \| "OWNED_BY" \| "DUE_ON"`               |                                                        |
+| `predicate`      | `"HAS_TASK_STATUS" \| "ASSIGNED_TO" \| "DUE_ON"`            |                                                        |
 | `value`          | `string \| null`                                            | `objectValue` for status; `objectLabel` for owner/due. |
 | `objectNodeId`   | `nodeId \| null`                                            |                                                        |
 | `status`         | `"active" \| "superseded" \| "retracted" \| "contradicted"` |                                                        |

--- a/docs/sdk/commitments.md
+++ b/docs/sdk/commitments.md
@@ -379,12 +379,12 @@ Detailed read model for a single Task: current state (status, owner, due date) p
 
 **Request**
 
-| Field            | Type      | Required | Default | Notes                                                                             |
-| ---------------- | --------- | -------- | ------- | --------------------------------------------------------------------------------- |
-| `userId`         | `string`  | yes      |         |                                                                                   |
-| `taskId`         | `nodeId`  | yes      |         |                                                                                   |
+| Field            | Type      | Required | Default | Notes                                                                                |
+| ---------------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------ |
+| `userId`         | `string`  | yes      |         |                                                                                      |
+| `taskId`         | `nodeId`  | yes      |         |                                                                                      |
 | `includeHistory` | `boolean` | no       | `true`  | Include full lifecycle history of `HAS_TASK_STATUS`, `ASSIGNED_TO`, `DUE_ON` claims. |
-| `includeSources` | `boolean` | no       | `true`  | Include distinct evidence sources behind the task's claims.                       |
+| `includeSources` | `boolean` | no       | `true`  | Include distinct evidence sources behind the task's claims.                          |
 
 **Response**
 

--- a/docs/superpowers/specs/2026-06-19-organization-taxonomy-prep.md
+++ b/docs/superpowers/specs/2026-06-19-organization-taxonomy-prep.md
@@ -1,0 +1,78 @@
+# Organization Taxonomy Prep
+
+## Recommended Shape
+
+Add `Organization` as a first-class node type for companies, institutions,
+clubs, agencies, nonprofits, schools, teams, collectives, formal groups, and
+named informal groups such as recurring friend groups or communities. Do not
+use it for a product, project, app, document, event, abstract movement, or
+loose topic unless the product explicitly denotes the organization itself.
+
+`Organization` should be extraction-mintable. Keeping it out of extraction
+would preserve the current failure mode where companies are forced into
+`Person`, `Concept`, or `Object`, which then corrupts predicates such as
+`WORKS_AT`, `FOUNDED`, `AFFILIATED_WITH`, and `LOCATED_IN`.
+
+Organizations should be label-mergeable by the existing exact-label automatic
+merge rule. They are durable referents like people and locations, not occurrence
+records.
+
+## Predicate Shape Updates
+
+Recommended relationship ranges:
+
+- `WORKS_AT`: `Person -> Organization`.
+- `FOUNDED`: `Person -> Organization | Concept | Object`.
+- `CREATED`: `Person | Organization | Concept | Object -> Object | Concept | Media | Document | Task`.
+- `LOCATED_IN`: include `Organization -> Location`.
+- `OWNS`: include `Organization` as an owner and as an owned thing.
+- `AFFILIATED_WITH`: include `Organization` on both sides.
+- `USES`: include `Organization` as a subject.
+- `RELATED_TO`: unchanged fallback.
+
+`Organization` should not make `PARTICIPATED_IN` broader; participation remains
+`Person -> Event | Conversation` unless we later model organization-level
+participation deliberately.
+
+## Prompt And Eval Updates
+
+Extraction prompt should explicitly say:
+
+- companies/employers/clients/schools/nonprofits/named informal groups are
+  `Organization`;
+- products/apps/projects are usually `Object` or `Concept`, not
+  `Organization`, unless the text clearly refers to the organization operating
+  them;
+- do not create fake people for company names.
+
+Eval coverage should include:
+
+- a person works at an organization;
+- a person founded an organization;
+- an organization is located in a city;
+- an organization created/uses a product;
+- a product/project remains `Object`/`Concept`, not `Organization`.
+
+## Migration Prep
+
+Historical retyping should run automatically and invisibly for high-confidence
+cases across all users. Good candidate signals:
+
+- a node appears as the object of `WORKS_AT`, `FOUNDED`, or
+  `AFFILIATED_WITH`;
+- a node has labels with organization suffixes such as "Inc", "LLC", "Ltd",
+  "GmbH", "BV", "University", "Foundation", "Agency", "Studio", or "Bank";
+- a node description explicitly says company, employer, client, organization,
+  institution, nonprofit, school, or team.
+
+Avoid automatic retyping from label alone in the first migration. A term like
+"Bank", "Studio", or a product name can be an object, concept, project, or
+organization depending on context.
+
+## Product Decisions
+
+1. `Organization` includes informal recurring named groups, not only formal
+   legal entities.
+2. `Organization OWNS Organization` is allowed.
+3. Historical retyping is automatic and invisible for high-confidence cases;
+   there is no user review UI for these repairs.

--- a/docs/superpowers/specs/2026-06-19-predicate-guardrails-design.md
+++ b/docs/superpowers/specs/2026-06-19-predicate-guardrails-design.md
@@ -1,0 +1,67 @@
+# Predicate Guardrails Design
+
+## Scope
+
+This slice fixes relation-quality failures without taking on the broader
+organization taxonomy migration. It covers date semantics, deterministic
+invalid-edge repair, prompt/eval guardrails, and a reusable dry-run audit
+surface for imported graph data.
+
+`Organization` is prepared as a follow-up because it affects extraction,
+identity resolution, merge rules, visual styling, and historical retyping.
+
+## Date Semantics
+
+`OCCURRED_ON` means the subject actually happened on the Temporal node date.
+System bookkeeping edges that mean "this node/source was recorded or ingested
+on this date" use a separate predicate, `RECORDED_ON`.
+
+Manual node creation and source-node creation should write `RECORDED_ON` for
+bookkeeping day attachment. Event-like source nodes can still use
+`OCCURRED_ON` only when the source content itself is the event being modeled.
+
+## Deterministic Repair
+
+Invalid relationship shapes are reported and, where safe, repaired without an
+LLM call. Safe repairs are limited to canonical inversions or legacy predicate
+mapping where no semantic judgment is required:
+
+- `Temporal OCCURRED_ON X` becomes `X OCCURRED_ON Temporal` when the inverted
+  shape is valid.
+- `Event PARTICIPATED_IN Person` becomes `Person PARTICIPATED_IN Event`.
+- Legacy `OWNED_BY` maps through the migration split: task assignment becomes
+  `ASSIGNED_TO`; ordinary ownership becomes owner-to-owned `OWNS`; ambiguous
+  cases fall back to `RELATED_TO`.
+
+The repair path first exposes dry-run proposals with before/after counts and
+examples. Applying repairs is a separate operation.
+
+## Prompt And Eval Guardrails
+
+Extraction and cleanup prompts include the predicate table plus generic
+positive/negative examples for the high-volume failures observed in imported
+data:
+
+- interaction moments are events or omitted, not deadlines;
+- preferences are scalar preferences, not location edges;
+- viewing/reading tone is not a personal emotion unless a person expressed it;
+- participants point from person to event;
+- dates point from event-like subject to Temporal;
+- tasks use `ASSIGNED_TO` and `DUE_ON`;
+- `RELATED_TO` is allowed only for durable explicit associations with no better
+  predicate.
+
+Regression coverage should pin both the prompt text and the behavior of the
+deterministic repair proposals.
+
+## Organization Follow-Up Prep
+
+The next taxonomy slice should decide:
+
+- whether `Organization` is extraction-mintable immediately or migration-only
+  first;
+- whether projects/products remain `Concept`/`Object` or get a separate type;
+- how to retype historical company-like nodes without overfitting user data;
+- which predicates should accept `Organization` as subject or object;
+- whether automatic label merge rules should treat organizations like durable
+  entities.

--- a/drizzle/0025_relation_taxonomy_split.sql
+++ b/drizzle/0025_relation_taxonomy_split.sql
@@ -1,0 +1,70 @@
+-- Split overloaded OWNED_BY into task assignment and active ownership.
+--
+-- Canonical forms after this migration:
+--   * Task ASSIGNED_TO Person
+--   * Owner OWNS owned thing
+--
+-- Ambiguous legacy leftovers become RELATED_TO rather than forcing false
+-- ownership semantics.
+
+DROP INDEX IF EXISTS "claims_task_metadata_lookup_idx";--> statement-breakpoint
+
+UPDATE "claims" c
+SET "predicate" = 'ASSIGNED_TO',
+    "updated_at" = now()
+FROM "nodes" subject_node,
+     "nodes" object_node
+WHERE c."predicate" = 'OWNED_BY'
+  AND c."subject_node_id" = subject_node."id"
+  AND c."object_node_id" = object_node."id"
+  AND subject_node."node_type" = 'Task'
+  AND object_node."node_type" = 'Person';--> statement-breakpoint
+
+UPDATE "claims" c
+SET "predicate" = 'ASSIGNED_TO',
+    "subject_node_id" = c."object_node_id",
+    "object_node_id" = c."subject_node_id",
+    "updated_at" = now()
+FROM "nodes" object_node,
+     "nodes" subject_node
+WHERE c."predicate" = 'OWNED_BY'
+  AND c."object_node_id" = object_node."id"
+  AND c."subject_node_id" = subject_node."id"
+  AND object_node."node_type" = 'Task'
+  AND subject_node."node_type" = 'Person';--> statement-breakpoint
+
+UPDATE "claims" c
+SET "predicate" = 'OWNS',
+    "subject_node_id" = c."object_node_id",
+    "object_node_id" = c."subject_node_id",
+    "updated_at" = now()
+FROM "nodes" subject_node,
+     "nodes" object_node
+WHERE c."predicate" = 'OWNED_BY'
+  AND c."subject_node_id" = subject_node."id"
+  AND c."object_node_id" = object_node."id"
+  AND subject_node."node_type" IN ('Location', 'Object', 'Concept', 'Media', 'Atlas')
+  AND object_node."node_type" IN ('Person', 'Concept', 'Object');--> statement-breakpoint
+
+UPDATE "claims" c
+SET "predicate" = 'OWNS',
+    "updated_at" = now()
+FROM "nodes" subject_node,
+     "nodes" object_node
+WHERE c."predicate" = 'OWNED_BY'
+  AND c."subject_node_id" = subject_node."id"
+  AND c."object_node_id" = object_node."id"
+  AND subject_node."node_type" IN ('Person', 'Concept', 'Object')
+  AND object_node."node_type" IN ('Location', 'Object', 'Concept', 'Media', 'Atlas');--> statement-breakpoint
+
+UPDATE "claims"
+SET "predicate" = 'RELATED_TO',
+    "updated_at" = now()
+WHERE "predicate" = 'OWNED_BY';--> statement-breakpoint
+
+CREATE INDEX "claims_task_metadata_lookup_idx"
+  ON "claims" USING btree ("user_id","subject_node_id","predicate","stated_at" DESC NULLS LAST)
+  WHERE "claims"."status" = 'active'
+    AND "claims"."scope" = 'personal'
+    AND "claims"."predicate" IN ('ASSIGNED_TO', 'DUE_ON')
+    AND "claims"."object_node_id" IS NOT NULL;

--- a/drizzle/0026_recorded_on_bookkeeping_dates.sql
+++ b/drizzle/0026_recorded_on_bookkeeping_dates.sql
@@ -1,0 +1,30 @@
+-- Split system bookkeeping dates from real-world occurrence dates.
+--
+-- Before RECORDED_ON existed, createNode/ensureSourceNode wrote generated
+-- system claims shaped as:
+--   * "<NodeType> node occurred on YYYY-MM-DD"
+--   * "<NodeType> source occurred on YYYY-MM-DD"
+--
+-- Only those generated statement forms move to RECORDED_ON. User-authored
+-- OCCURRED_ON facts, and system-authored facts with non-generated statements,
+-- remain untouched.
+
+UPDATE "claims" c
+SET "predicate" = 'RECORDED_ON',
+    "statement" = CASE
+      WHEN c."statement" LIKE '% node occurred on %'
+        THEN replace(c."statement", ' node occurred on ', ' node recorded on ')
+      WHEN c."statement" LIKE '% source occurred on %'
+        THEN replace(c."statement", ' source occurred on ', ' source recorded on ')
+      ELSE c."statement"
+    END,
+    "updated_at" = now()
+FROM "nodes" object_node
+WHERE c."predicate" = 'OCCURRED_ON'
+  AND c."asserted_by_kind" = 'system'
+  AND c."object_node_id" = object_node."id"
+  AND object_node."node_type" = 'Temporal'
+  AND (
+    c."statement" LIKE '% node occurred on %'
+    OR c."statement" LIKE '% source occurred on %'
+  );

--- a/drizzle/0027_organization_node_type.sql
+++ b/drizzle/0027_organization_node_type.sql
@@ -36,23 +36,22 @@ organization_candidates AS (
           SELECT 1
           FROM "claims" c
           WHERE c."status" = 'active'
-            AND (
-              (
-                c."subject_node_id" = nt."id"
-                AND c."predicate" IN (
-                  'EXHIBITED_EMOTION',
-                  'FOUNDED',
-                  'HAS_GOAL',
-                  'HAS_PREFERENCE',
-                  'PARTICIPATED_IN',
-                  'WORKS_AT'
-                )
-              )
-              OR (
-                c."object_node_id" = nt."id"
-                AND c."predicate" = 'ASSIGNED_TO'
-              )
+            AND c."subject_node_id" = nt."id"
+            AND c."predicate" IN (
+              'EXHIBITED_EMOTION',
+              'FOUNDED',
+              'HAS_GOAL',
+              'HAS_PREFERENCE',
+              'PARTICIPATED_IN',
+              'WORKS_AT'
             )
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "claims" c
+          WHERE c."status" = 'active'
+            AND c."object_node_id" = nt."id"
+            AND c."predicate" = 'ASSIGNED_TO'
         )
       )
     )

--- a/drizzle/0027_organization_node_type.sql
+++ b/drizzle/0027_organization_node_type.sql
@@ -1,0 +1,108 @@
+-- Introduce Organization as a first-class node type and retype
+-- high-confidence historical organization nodes across all users.
+--
+-- Strong signal:
+--   * an org-ish active WORKS_AT object is an employer organization.
+--
+-- Secondary signal:
+--   * org-ish label/description plus an organization-compatible predicate
+--     position (founded entity, affiliation endpoint, located/owning/using/
+--     creating entity). This catches named friend groups and companies that
+--     were previously squeezed into Person, Concept, or Object while avoiding
+--     broad label-only rewrites.
+
+WITH node_text AS (
+  SELECT
+    n."id",
+    n."node_type",
+    coalesce(nm."label", '') || ' ' ||
+      coalesce(nm."canonical_label", '') AS "label_text",
+    coalesce(nm."label", '') || ' ' ||
+      coalesce(nm."canonical_label", '') || ' ' ||
+      coalesce(nm."description", '') AS "search_text"
+  FROM "nodes" n
+  LEFT JOIN "node_metadata" nm ON nm."node_id" = n."id"
+),
+organization_candidates AS (
+  SELECT DISTINCT nt."id"
+  FROM node_text nt
+  WHERE nt."node_type" IN ('Person', 'Concept', 'Object')
+    AND nt."search_text" ~* '(^|[^[:alnum:]])(agency|association|bank|b\.?v\.?|business|chapter|club|collective|college|committee|community|company|cooperative|corp\.?|corporation|council|crew|department|employer|firm|foundation|gmbh|group|guild|inc\.?|institution|institute|labs?|llc|ltd\.?|ngo|non-?profit|office|org|organisation|organization|partnership|school|society|startup|studio|team|university)([^[:alnum:]]|$)'
+    AND (
+      nt."node_type" <> 'Person'
+      OR (
+        nt."label_text" ~* '(^|[^[:alnum:]])(agency|association|bank|b\.?v\.?|business|chapter|club|collective|college|committee|community|company|cooperative|corp\.?|corporation|council|crew|department|employer|firm|foundation|gmbh|group|guild|inc\.?|institution|institute|labs?|llc|ltd\.?|ngo|non-?profit|office|org|organisation|organization|partnership|school|society|startup|studio|team|university)([^[:alnum:]]|$)'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "claims" c
+          WHERE c."status" = 'active'
+            AND (
+              (
+                c."subject_node_id" = nt."id"
+                AND c."predicate" IN (
+                  'EXHIBITED_EMOTION',
+                  'FOUNDED',
+                  'HAS_GOAL',
+                  'HAS_PREFERENCE',
+                  'PARTICIPATED_IN',
+                  'WORKS_AT'
+                )
+              )
+              OR (
+                c."object_node_id" = nt."id"
+                AND c."predicate" = 'ASSIGNED_TO'
+              )
+            )
+        )
+      )
+    )
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM "claims" c
+        WHERE c."status" = 'active'
+          AND c."predicate" = 'WORKS_AT'
+          AND c."object_node_id" = nt."id"
+      )
+      OR (
+        EXISTS (
+          SELECT 1
+          FROM "claims" c
+          WHERE c."status" = 'active'
+            AND c."object_node_id" = nt."id"
+            AND (
+              c."predicate" IN ('FOUNDED', 'AFFILIATED_WITH')
+              OR (
+                c."predicate" = 'OWNS'
+                AND nt."label_text" ~* '(^|[^[:alnum:]])(agency|association|bank|b\.?v\.?|business|chapter|club|collective|college|committee|community|company|cooperative|corp\.?|corporation|council|crew|department|employer|firm|foundation|gmbh|group|guild|inc\.?|institution|institute|labs?|llc|ltd\.?|ngo|non-?profit|office|org|organisation|organization|partnership|school|society|startup|studio|team|university)([^[:alnum:]]|$)'
+              )
+            )
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM "claims" c
+          WHERE c."status" = 'active'
+            AND c."subject_node_id" = nt."id"
+            AND c."predicate" IN (
+              'AFFILIATED_WITH',
+              'CREATED',
+              'LOCATED_IN',
+              'OWNS',
+              'USES'
+            )
+            AND nt."label_text" ~* '(^|[^[:alnum:]])(agency|association|bank|b\.?v\.?|business|chapter|club|collective|college|committee|community|company|cooperative|corp\.?|corporation|council|crew|department|employer|firm|foundation|gmbh|group|guild|inc\.?|institution|institute|labs?|llc|ltd\.?|ngo|non-?profit|office|org|organisation|organization|partnership|school|society|startup|studio|team|university)([^[:alnum:]]|$)'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "claims" event_claim
+              WHERE event_claim."status" = 'active'
+                AND event_claim."predicate" = 'PARTICIPATED_IN'
+                AND event_claim."object_node_id" = nt."id"
+            )
+        )
+      )
+    )
+)
+UPDATE "nodes" n
+SET "node_type" = 'Organization'
+FROM organization_candidates oc
+WHERE n."id" = oc."id";

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2242 @@
+{
+  "id": "d1f07b57-5f16-418b-a389-74b52af63b92",
+  "prevId": "87a73260-8af0-4f9b-acd8-5ff531787c59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('ASSIGNED_TO', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commitment_presentations": {
+      "name": "commitment_presentations",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commitment_presentations_user_id_idx": {
+          "name": "commitment_presentations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "commitment_presentations_task_id_nodes_id_fk": {
+          "name": "commitment_presentations_task_id_nodes_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "commitment_presentations_user_id_users_id_fk": {
+          "name": "commitment_presentations_user_id_users_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "commitment_presentations_source_id_sources_id_fk": {
+          "name": "commitment_presentations_source_id_sources_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "columns": [
+            "metric_definition_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "columns": [
+            "user_id",
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "columns": [
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "columns": [
+            "source_id",
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,2242 @@
+{
+  "id": "d1f07b57-5f16-418b-a389-74b52af63b92",
+  "prevId": "87a73260-8af0-4f9b-acd8-5ff531787c59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('ASSIGNED_TO', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commitment_presentations": {
+      "name": "commitment_presentations",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commitment_presentations_user_id_idx": {
+          "name": "commitment_presentations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "commitment_presentations_task_id_nodes_id_fk": {
+          "name": "commitment_presentations_task_id_nodes_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "commitment_presentations_user_id_users_id_fk": {
+          "name": "commitment_presentations_user_id_users_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "commitment_presentations_source_id_sources_id_fk": {
+          "name": "commitment_presentations_source_id_sources_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "columns": [
+            "metric_definition_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "columns": [
+            "user_id",
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "columns": [
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "columns": [
+            "source_id",
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,2242 @@
+{
+  "id": "d1f07b57-5f16-418b-a389-74b52af63b92",
+  "prevId": "87a73260-8af0-4f9b-acd8-5ff531787c59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_text": {
+          "name": "alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_alias_text": {
+          "name": "normalized_alias_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_node_id": {
+          "name": "canonical_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "aliases_user_id_users_id_fk": {
+          "name": "aliases_user_id_users_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "aliases_canonical_node_id_nodes_id_fk": {
+          "name": "aliases_canonical_node_id_nodes_id_fk",
+          "tableFrom": "aliases",
+          "columnsFrom": [
+            "canonical_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "aliases_user_normalized_canonical_unique": {
+          "name": "aliases_user_normalized_canonical_unique",
+          "columns": [
+            "user_id",
+            "normalized_alias_text",
+            "canonical_node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claim_embeddings": {
+      "name": "claim_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_embeddings_embedding_idx": {
+          "name": "claim_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "claim_embeddings_claim_id_idx": {
+          "name": "claim_embeddings_claim_id_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claim_embeddings_claim_id_claims_id_fk": {
+          "name": "claim_embeddings_claim_id_claims_id_fk",
+          "tableFrom": "claim_embeddings",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claims": {
+      "name": "claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_node_id": {
+          "name": "subject_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_node_id": {
+          "name": "object_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicate": {
+          "name": "predicate",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_instant": {
+          "name": "object_instant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "asserted_by_kind": {
+          "name": "asserted_by_kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asserted_by_node_id": {
+          "name": "asserted_by_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_claim_id": {
+          "name": "superseded_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contradicted_by_claim_id": {
+          "name": "contradicted_by_claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_at": {
+          "name": "stated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claims_user_id_subject_node_id_idx": {
+          "name": "claims_user_id_subject_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_node_id_idx": {
+          "name": "claims_user_id_object_node_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_predicate_idx": {
+          "name": "claims_user_id_predicate_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_status_stated_at_idx": {
+          "name": "claims_user_scope_status_stated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_scope_kind_status_idx": {
+          "name": "claims_user_scope_kind_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asserted_by_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_subject_status_idx": {
+          "name": "claims_user_id_subject_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claims_user_id_object_status_idx": {
+          "name": "claims_user_id_object_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_trusted_open_task_status_idx": {
+          "name": "claims_trusted_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" <> 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_candidate_open_task_status_idx": {
+          "name": "claims_candidate_open_task_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'HAS_TASK_STATUS' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"asserted_by_kind\" = 'assistant_inferred' AND \"claims\".\"object_value\" IN ('pending', 'in_progress')",
+          "concurrently": false
+        },
+        "claims_task_metadata_lookup_idx": {
+          "name": "claims_task_metadata_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "predicate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"predicate\" IN ('ASSIGNED_TO', 'DUE_ON') AND \"claims\".\"object_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_due_instant_idx": {
+          "name": "claims_due_instant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_instant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'DUE_ON' AND \"claims\".\"status\" = 'active' AND \"claims\".\"scope\" = 'personal' AND \"claims\".\"object_instant\" IS NOT NULL",
+          "concurrently": false
+        },
+        "claims_occurred_on_discovery_idx": {
+          "name": "claims_occurred_on_discovery_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"claims\".\"predicate\" = 'OCCURRED_ON' AND \"claims\".\"status\" = 'active'",
+          "concurrently": false
+        },
+        "claims_source_id_idx": {
+          "name": "claims_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claims_user_id_users_id_fk": {
+          "name": "claims_user_id_users_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "claims_subject_node_id_nodes_id_fk": {
+          "name": "claims_subject_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "subject_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_object_node_id_nodes_id_fk": {
+          "name": "claims_object_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "object_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_source_id_sources_id_fk": {
+          "name": "claims_source_id_sources_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "claims_asserted_by_node_id_nodes_id_fk": {
+          "name": "claims_asserted_by_node_id_nodes_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "asserted_by_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_superseded_by_claim_id_claims_id_fk": {
+          "name": "claims_superseded_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "superseded_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "claims_contradicted_by_claim_id_claims_id_fk": {
+          "name": "claims_contradicted_by_claim_id_claims_id_fk",
+          "tableFrom": "claims",
+          "columnsFrom": [
+            "contradicted_by_claim_id"
+          ],
+          "tableTo": "claims",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claims_object_shape_xor_ck": {
+          "name": "claims_object_shape_xor_ck",
+          "value": "((\"object_node_id\" IS NOT NULL AND \"object_value\" IS NULL) OR (\"object_node_id\" IS NULL AND \"object_value\" IS NOT NULL))"
+        },
+        "claims_scope_ck": {
+          "name": "claims_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        },
+        "claims_asserted_by_kind_ck": {
+          "name": "claims_asserted_by_kind_ck",
+          "value": "\"asserted_by_kind\" IN ('user', 'user_confirmed', 'assistant_inferred', 'participant', 'document_author', 'system')"
+        },
+        "claims_asserted_by_node_consistency_ck": {
+          "name": "claims_asserted_by_node_consistency_ck",
+          "value": "((\"asserted_by_kind\" = 'participant' AND \"asserted_by_node_id\" IS NOT NULL) OR \"asserted_by_kind\" <> 'participant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commitment_presentations": {
+      "name": "commitment_presentations",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why": {
+          "name": "why",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commitment_presentations_user_id_idx": {
+          "name": "commitment_presentations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "commitment_presentations_task_id_nodes_id_fk": {
+          "name": "commitment_presentations_task_id_nodes_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "commitment_presentations_user_id_users_id_fk": {
+          "name": "commitment_presentations_user_id_users_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "commitment_presentations_source_id_sources_id_fk": {
+          "name": "commitment_presentations_source_id_sources_id_fk",
+          "tableFrom": "commitment_presentations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definition_embeddings": {
+      "name": "metric_definition_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_def_emb_idx": {
+          "name": "metric_def_emb_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "metric_def_emb_def_id_idx": {
+          "name": "metric_def_emb_def_id_idx",
+          "columns": [
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_definition_embeddings_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_definition_embeddings",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_def_emb_def_unique": {
+          "name": "metric_def_emb_def_unique",
+          "columns": [
+            "metric_definition_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_definitions": {
+      "name": "metric_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_hint": {
+          "name": "aggregation_hint",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_range_min": {
+          "name": "valid_range_min",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_range_max": {
+          "name": "valid_range_max",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_task_node_id": {
+          "name": "review_task_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_definitions_user_id_idx": {
+          "name": "metric_definitions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_definitions_user_needs_review_idx": {
+          "name": "metric_definitions_user_needs_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_definitions\".\"needs_review\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_definitions_user_id_users_id_fk": {
+          "name": "metric_definitions_user_id_users_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_definitions_review_task_node_id_nodes_id_fk": {
+          "name": "metric_definitions_review_task_node_id_nodes_id_fk",
+          "tableFrom": "metric_definitions",
+          "columnsFrom": [
+            "review_task_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "metric_definitions_user_slug_unique": {
+          "name": "metric_definitions_user_slug_unique",
+          "columns": [
+            "user_id",
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "metric_definitions_aggregation_hint_ck": {
+          "name": "metric_definitions_aggregation_hint_ck",
+          "value": "\"aggregation_hint\" IN ('avg','sum','min','max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metric_observations": {
+      "name": "metric_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_definition_id": {
+          "name": "metric_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_node_id": {
+          "name": "event_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "metric_observations_user_def_occurred_idx": {
+          "name": "metric_observations_user_def_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_user_occurred_idx": {
+          "name": "metric_observations_user_occurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_observations_event_node_idx": {
+          "name": "metric_observations_event_node_idx",
+          "columns": [
+            {
+              "expression": "event_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"metric_observations\".\"event_node_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "metric_observations_source_id_idx": {
+          "name": "metric_observations_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "metric_observations_user_id_users_id_fk": {
+          "name": "metric_observations_user_id_users_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "metric_observations_metric_definition_id_metric_definitions_id_fk": {
+          "name": "metric_observations_metric_definition_id_metric_definitions_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "metric_definition_id"
+          ],
+          "tableTo": "metric_definitions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "metric_observations_event_node_id_nodes_id_fk": {
+          "name": "metric_observations_event_node_id_nodes_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "event_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "metric_observations_source_id_sources_id_fk": {
+          "name": "metric_observations_source_id_sources_id_fk",
+          "tableFrom": "metric_observations",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_embeddings": {
+      "name": "node_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_embeddings_embedding_idx": {
+          "name": "node_embeddings_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "hnsw",
+          "concurrently": false
+        },
+        "node_embeddings_node_id_idx": {
+          "name": "node_embeddings_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_embeddings_node_id_nodes_id_fk": {
+          "name": "node_embeddings_node_id_nodes_id_fk",
+          "tableFrom": "node_embeddings",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_metadata": {
+      "name": "node_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_label": {
+          "name": "canonical_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_metadata_node_id_idx": {
+          "name": "node_metadata_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "node_metadata_canonical_label_idx": {
+          "name": "node_metadata_canonical_label_idx",
+          "columns": [
+            {
+              "expression": "canonical_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_metadata_node_id_nodes_id_fk": {
+          "name": "node_metadata_node_id_nodes_id_fk",
+          "tableFrom": "node_metadata",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_metadata_nodeId_unique": {
+          "name": "node_metadata_nodeId_unique",
+          "columns": [
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_redirects": {
+      "name": "node_redirects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_node_id": {
+          "name": "from_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_node_id": {
+          "name": "to_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_redirects_user_to_node_idx": {
+          "name": "node_redirects_user_to_node_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "node_redirects_user_id_users_id_fk": {
+          "name": "node_redirects_user_id_users_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "node_redirects_to_node_id_nodes_id_fk": {
+          "name": "node_redirects_to_node_id_nodes_id_fk",
+          "tableFrom": "node_redirects",
+          "columnsFrom": [
+            "to_node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_redirects_user_id_from_node_id_pk": {
+          "name": "node_redirects_user_id_from_node_id_pk",
+          "columns": [
+            "user_id",
+            "from_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nodes_user_id_idx": {
+          "name": "nodes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nodes_user_id_node_type_idx": {
+          "name": "nodes_user_id_node_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nodes_user_id_users_id_fk": {
+          "name": "nodes_user_id_users_id_fk",
+          "tableFrom": "nodes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollup_state": {
+      "name": "rollup_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_periods": {
+          "name": "pending_periods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollup_state_user_id_users_id_fk": {
+          "name": "rollup_state_user_id_users_id_fk",
+          "tableFrom": "rollup_state",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scratchpads": {
+      "name": "scratchpads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scratchpads_user_id_idx": {
+          "name": "scratchpads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "scratchpads_user_id_users_id_fk": {
+          "name": "scratchpads_user_id_users_id_fk",
+          "tableFrom": "scratchpads",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scratchpads_userId_unique": {
+          "name": "scratchpads_userId_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_location": {
+          "name": "specific_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_links_source_id_idx": {
+          "name": "source_links_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_links_node_id_idx": {
+          "name": "source_links_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "source_links_source_id_sources_id_fk": {
+          "name": "source_links_source_id_sources_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "source_links_node_id_nodes_id_fk": {
+          "name": "source_links_node_id_nodes_id_fk",
+          "tableFrom": "source_links",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "tableTo": "nodes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_links_sourceId_nodeId_unique": {
+          "name": "source_links_sourceId_nodeId_unique",
+          "columns": [
+            "source_id",
+            "node_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_source": {
+          "name": "parent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sources_user_id_idx": {
+          "name": "sources_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sources_status_idx": {
+          "name": "sources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sources_user_id_users_id_fk": {
+          "name": "sources_user_id_users_id_fk",
+          "tableFrom": "sources",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sources_userId_type_externalId_unique": {
+          "name": "sources_userId_type_externalId_unique",
+          "columns": [
+            "user_id",
+            "type",
+            "external_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sources_scope_ck": {
+          "name": "sources_scope_ck",
+          "value": "\"scope\" IN ('personal', 'reference')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,27 @@
       "when": 1781612744997,
       "tag": "0024_hybrid_search_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1781865600000,
+      "tag": "0025_relation_taxonomy_split",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1781869200000,
+      "tag": "0026_recorded_on_bookkeeping_dates",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1781872800000,
+      "tag": "0027_organization_node_type",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "drizzle:studio": "drizzle-kit studio",
     "eval:memory": "tsx src/evals/memory/run-all.ts",
     "eval:ingest": "tsx src/evals/memory/probe-ingestion.ts",
-    "eval:identity-thresholds": "tsx src/evals/memory/threshold-calibration.ts"
+    "eval:identity-thresholds": "tsx src/evals/memory/threshold-calibration.ts",
+    "audit:predicate-health": "tsx scripts/audit-predicate-health.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/scripts/audit-predicate-health.ts
+++ b/scripts/audit-predicate-health.ts
@@ -1,0 +1,34 @@
+import "dotenv/config";
+
+import { auditRelationshipPredicateHealth } from "../src/lib/claims/predicate-shape-audit";
+import { z } from "zod";
+import { useDatabase } from "../src/utils/db";
+
+const argsSchema = z.object({
+  userId: z.string().min(1),
+  exampleLimit: z.coerce.number().int().positive().max(200).default(20),
+});
+
+async function main(): Promise<void> {
+  const [userId, exampleLimit] = process.argv.slice(2).filter((arg) => arg !== "--");
+  const args = argsSchema.parse({
+    userId,
+    exampleLimit,
+  });
+
+  const db = await useDatabase();
+  const report = await auditRelationshipPredicateHealth(db, args.userId, {
+    exampleLimit: args.exampleLimit,
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/audit-predicate-health.ts
+++ b/scripts/audit-predicate-health.ts
@@ -1,8 +1,7 @@
-import "dotenv/config";
-
 import { auditRelationshipPredicateHealth } from "../src/lib/claims/predicate-shape-audit";
-import { z } from "zod";
 import { useDatabase } from "../src/utils/db";
+import "dotenv/config";
+import { z } from "zod";
 
 const argsSchema = z.object({
   userId: z.string().min(1),
@@ -10,7 +9,9 @@ const argsSchema = z.object({
 });
 
 async function main(): Promise<void> {
-  const [userId, exampleLimit] = process.argv.slice(2).filter((arg) => arg !== "--");
+  const [userId, exampleLimit] = process.argv
+    .slice(2)
+    .filter((arg) => arg !== "--");
   const args = argsSchema.parse({
     userId,
     exampleLimit,

--- a/src/db/migrations-claims.test.ts
+++ b/src/db/migrations-claims.test.ts
@@ -156,7 +156,7 @@ describeIfServer("migration 0010 (claims layer, PR 1a)", () => {
             VALUES ('sln_conversation_____________', 'src_realconversation________', 'node_cccccccccccccccccccccccccc', '2026-02-01T00:00:00Z');
           INSERT INTO "edges" ("id", "user_id", "source_node_id", "target_node_id", "edge_type", "description", "created_at")
             VALUES
-              ('edge_keepowned_________________', 'user_A', 'node_aaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_bbbbbbbbbbbbbbbbbbbbbbbbbb', 'OWNED_BY',     'owns the laptop', '2026-02-01T00:00:00Z'),
+              ('edge_keepowned_________________', 'user_A', 'node_aaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_bbbbbbbbbbbbbbbbbbbbbbbbbb', 'OWNED_BY', 'owns the laptop', '2026-02-01T00:00:00Z'),
               ('edge_dropmention_______________', 'user_A', 'node_aaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_cccccccccccccccccccccccccc', 'MENTIONED_IN', NULL,              '2026-02-02T00:00:00Z'),
               ('edge_keeptagged________________', 'user_A', 'node_aaaaaaaaaaaaaaaaaaaaaaaaaa', 'node_bbbbbbbbbbbbbbbbbbbbbbbbbb', 'TAGGED_WITH',  NULL,              '2026-02-03T00:00:00Z');
           INSERT INTO "edge_embeddings" ("id", "edge_id", "embedding", "model_name")
@@ -817,6 +817,578 @@ describeIfServer("migration 0011 (claims phase 2b foundation)", () => {
       await client.query("BEGIN");
       await applyMigration();
       await client.query("COMMIT");
+    } finally {
+      await client.end();
+    }
+  });
+});
+
+describeIfServer("migration 0025 (relationship taxonomy split)", () => {
+  const dbName = `memory_claims_mig_0025_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("rewrites OWNED_BY into ASSIGNED_TO, OWNS, or RELATED_TO by node shape", async () => {
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id"),
+          "object_node_id" text REFERENCES "nodes"("id"),
+          "object_value" text,
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "stated_at" timestamp with time zone NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE INDEX "claims_task_metadata_lookup_idx"
+          ON "claims" USING btree ("user_id","subject_node_id","predicate","stated_at" DESC NULLS LAST)
+          WHERE "claims"."status" = 'active'
+            AND "claims"."scope" = 'personal'
+            AND "claims"."predicate" IN ('OWNED_BY', 'DUE_ON')
+            AND "claims"."object_node_id" IS NOT NULL;
+
+        INSERT INTO "users" ("id") VALUES ('user_A');
+        INSERT INTO "nodes" ("id", "user_id", "node_type")
+          VALUES
+            ('node_task_direct______________', 'user_A', 'Task'),
+            ('node_task_inverted____________', 'user_A', 'Task'),
+            ('node_owner_alex_______________', 'user_A', 'Person'),
+            ('node_owner_blair______________', 'user_A', 'Person'),
+            ('node_owner_casey______________', 'user_A', 'Person'),
+            ('node_object_mug_______________', 'user_A', 'Object'),
+            ('node_object_bike______________', 'user_A', 'Object'),
+            ('node_emotion_anxiety__________', 'user_A', 'Emotion'),
+            ('node_person_ambiguous_________', 'user_A', 'Person');
+        INSERT INTO "claims" (
+          "id", "user_id", "subject_node_id", "object_node_id", "object_value",
+          "predicate", "statement", "stated_at", "status", "scope"
+        )
+        VALUES
+          (
+            'claim_task_direct______________',
+            'user_A',
+            'node_task_direct______________',
+            'node_owner_alex_______________',
+            NULL,
+            'OWNED_BY',
+            'The task is assigned to Alex.',
+            '2026-06-01T00:00:00Z',
+            'active',
+            'personal'
+          ),
+          (
+            'claim_task_inverted____________',
+            'user_A',
+            'node_owner_blair______________',
+            'node_task_inverted____________',
+            NULL,
+            'OWNED_BY',
+            'Blair is responsible for the task.',
+            '2026-06-02T00:00:00Z',
+            'active',
+            'personal'
+          ),
+          (
+            'claim_passive_ordinary_________',
+            'user_A',
+            'node_object_mug_______________',
+            'node_owner_casey______________',
+            NULL,
+            'OWNED_BY',
+            'The mug belongs to Casey.',
+            '2026-06-03T00:00:00Z',
+            'active',
+            'personal'
+          ),
+          (
+            'claim_active_ordinary__________',
+            'user_A',
+            'node_owner_alex_______________',
+            'node_object_bike______________',
+            NULL,
+            'OWNED_BY',
+            'Alex owns the bike.',
+            '2026-06-04T00:00:00Z',
+            'active',
+            'personal'
+          ),
+          (
+            'claim_ambiguous_______________',
+            'user_A',
+            'node_owner_alex_______________',
+            'node_person_ambiguous_________',
+            NULL,
+            'OWNED_BY',
+            'Ambiguous legacy ownership.',
+            '2026-06-05T00:00:00Z',
+            'active',
+            'personal'
+          ),
+          (
+            'claim_task_non_person__________',
+            'user_A',
+            'node_task_direct______________',
+            'node_emotion_anxiety__________',
+            NULL,
+            'OWNED_BY',
+            'The task is assigned to anxiety.',
+            '2026-06-06T00:00:00Z',
+            'active',
+            'personal'
+          );
+      `);
+
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const migrationSql = await fs.readFile(
+        path.join(process.cwd(), "drizzle", "0025_relation_taxonomy_split.sql"),
+        "utf8",
+      );
+      const statements = migrationSql
+        .split("--> statement-breakpoint")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
+      for (const statement of statements) {
+        await client.query(statement);
+      }
+
+      const rows = await client.query<{
+        id: string;
+        predicate: string;
+        subject_node_id: string;
+        object_node_id: string;
+      }>(
+        `SELECT id, predicate, subject_node_id, object_node_id
+           FROM claims
+           ORDER BY id`,
+      );
+      expect(rows.rows).toEqual([
+        {
+          id: "claim_active_ordinary__________",
+          predicate: "OWNS",
+          subject_node_id: "node_owner_alex_______________",
+          object_node_id: "node_object_bike______________",
+        },
+        {
+          id: "claim_ambiguous_______________",
+          predicate: "RELATED_TO",
+          subject_node_id: "node_owner_alex_______________",
+          object_node_id: "node_person_ambiguous_________",
+        },
+        {
+          id: "claim_passive_ordinary_________",
+          predicate: "OWNS",
+          subject_node_id: "node_owner_casey______________",
+          object_node_id: "node_object_mug_______________",
+        },
+        {
+          id: "claim_task_direct______________",
+          predicate: "ASSIGNED_TO",
+          subject_node_id: "node_task_direct______________",
+          object_node_id: "node_owner_alex_______________",
+        },
+        {
+          id: "claim_task_inverted____________",
+          predicate: "ASSIGNED_TO",
+          subject_node_id: "node_task_inverted____________",
+          object_node_id: "node_owner_blair______________",
+        },
+        {
+          id: "claim_task_non_person__________",
+          predicate: "RELATED_TO",
+          subject_node_id: "node_task_direct______________",
+          object_node_id: "node_emotion_anxiety__________",
+        },
+      ]);
+
+      const indexes = await client.query<{ indexdef: string }>(
+        `SELECT indexdef
+           FROM pg_indexes
+           WHERE schemaname = 'public'
+             AND tablename = 'claims'
+             AND indexname = 'claims_task_metadata_lookup_idx'`,
+      );
+      expect(indexes.rows[0]?.indexdef).toContain("ASSIGNED_TO");
+      expect(indexes.rows[0]?.indexdef).not.toContain("OWNED_BY");
+    } finally {
+      await client.end();
+    }
+  });
+});
+
+describeIfServer("migration 0026 (recorded-on bookkeeping dates)", () => {
+  const dbName = `memory_claims_mig_0026_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("rewrites generated bookkeeping OCCURRED_ON claims to RECORDED_ON only", async () => {
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id"),
+          "object_node_id" text REFERENCES "nodes"("id"),
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "asserted_by_kind" varchar(24) NOT NULL,
+          "stated_at" timestamp with time zone NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+
+        INSERT INTO "users" ("id") VALUES ('user_A');
+        INSERT INTO "nodes" ("id", "user_id", "node_type")
+          VALUES
+            ('node_person___________________', 'user_A', 'Person'),
+            ('node_document_________________', 'user_A', 'Document'),
+            ('node_event____________________', 'user_A', 'Event'),
+            ('node_day______________________', 'user_A', 'Temporal');
+        INSERT INTO "claims" (
+          "id", "user_id", "subject_node_id", "object_node_id",
+          "predicate", "statement", "status", "scope", "asserted_by_kind", "stated_at"
+        )
+        VALUES
+          (
+            'claim_manual_node______________',
+            'user_A',
+            'node_person___________________',
+            'node_day______________________',
+            'OCCURRED_ON',
+            'Person node occurred on 2026-06-19',
+            'active',
+            'personal',
+            'system',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_source_node______________',
+            'user_A',
+            'node_document_________________',
+            'node_day______________________',
+            'OCCURRED_ON',
+            'Document source occurred on 2026-06-19',
+            'active',
+            'personal',
+            'system',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_real_event______________',
+            'user_A',
+            'node_event____________________',
+            'node_day______________________',
+            'OCCURRED_ON',
+            'The event happened on 2026-06-19.',
+            'active',
+            'personal',
+            'user',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_system_real_event_______',
+            'user_A',
+            'node_event____________________',
+            'node_day______________________',
+            'OCCURRED_ON',
+            'The system-generated event happened on 2026-06-19.',
+            'active',
+            'personal',
+            'system',
+            '2026-06-19T00:00:00Z'
+          );
+      `);
+
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const migrationSql = await fs.readFile(
+        path.join(
+          process.cwd(),
+          "drizzle",
+          "0026_recorded_on_bookkeeping_dates.sql",
+        ),
+        "utf8",
+      );
+      const statements = migrationSql
+        .split("--> statement-breakpoint")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
+      for (const statement of statements) {
+        await client.query(statement);
+      }
+
+      const rows = await client.query<{ id: string; predicate: string }>(
+        `SELECT id, predicate FROM claims ORDER BY id`,
+      );
+      expect(rows.rows).toEqual([
+        { id: "claim_manual_node______________", predicate: "RECORDED_ON" },
+        { id: "claim_real_event______________", predicate: "OCCURRED_ON" },
+        { id: "claim_source_node______________", predicate: "RECORDED_ON" },
+        { id: "claim_system_real_event_______", predicate: "OCCURRED_ON" },
+      ]);
+    } finally {
+      await client.end();
+    }
+  });
+});
+
+describeIfServer("migration 0027 (organization node type)", () => {
+  const dbName = `memory_claims_mig_0027_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("retypes high-confidence historical organization nodes without user review", async () => {
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_metadata" (
+          "id" text PRIMARY KEY NOT NULL,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "label" text,
+          "canonical_label" text,
+          "description" text,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id"),
+          "object_node_id" text REFERENCES "nodes"("id"),
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "stated_at" timestamp with time zone NOT NULL
+        );
+
+        INSERT INTO "users" ("id") VALUES ('user_A');
+        INSERT INTO "nodes" ("id", "user_id", "node_type")
+          VALUES
+            ('node_person_worker___________', 'user_A', 'Person'),
+            ('node_person_employer_________', 'user_A', 'Person'),
+            ('node_concept_employer________', 'user_A', 'Concept'),
+            ('node_group___________________', 'user_A', 'Concept'),
+            ('node_founded_company_________', 'user_A', 'Concept'),
+            ('node_founded_project_________', 'user_A', 'Concept'),
+            ('node_person_founder__________', 'user_A', 'Person'),
+            ('node_person_company_behavior_', 'user_A', 'Person'),
+            ('node_friend__________________', 'user_A', 'Person');
+        INSERT INTO "node_metadata" ("id", "node_id", "label", "canonical_label", "description")
+          VALUES
+            ('meta_person_worker___________', 'node_person_worker___________', 'Ari', 'ari', NULL),
+            ('meta_person_employer_________', 'node_person_employer_________', 'Orchard Labs', 'orchard labs', NULL),
+            ('meta_concept_employer________', 'node_concept_employer________', 'Northstar Bank', 'northstar bank', NULL),
+            ('meta_group___________________', 'node_group___________________', 'Saturday Supper Club', 'saturday supper club', 'Named friend group.'),
+            ('meta_founded_company_________', 'node_founded_company_________', 'Blue Harbor Studio', 'blue harbor studio', 'Independent design company.'),
+            ('meta_founded_project_________', 'node_founded_project_________', 'Launch Checklist', 'launch checklist', 'A reusable project checklist.'),
+            ('meta_person_founder__________', 'node_person_founder__________', 'Casey', 'casey', 'Casey founded a company and leads a community.'),
+            ('meta_person_company_behavior_', 'node_person_company_behavior_', 'River Company', 'river company', 'A person-like node with misleading company text.'),
+            ('meta_friend__________________', 'node_friend__________________', 'Riley', 'riley', NULL);
+        INSERT INTO "claims" (
+          "id", "user_id", "subject_node_id", "object_node_id",
+          "predicate", "statement", "status", "stated_at"
+        )
+        VALUES
+          (
+            'claim_work_person____________',
+            'user_A',
+            'node_person_worker___________',
+            'node_person_employer_________',
+            'WORKS_AT',
+            'Ari works at Orchard Labs.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_work_concept___________',
+            'user_A',
+            'node_person_worker___________',
+            'node_concept_employer________',
+            'WORKS_AT',
+            'Ari works at Northstar Bank.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_affiliated_group_______',
+            'user_A',
+            'node_person_worker___________',
+            'node_group___________________',
+            'AFFILIATED_WITH',
+            'Ari is affiliated with Saturday Supper Club.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_founded_company________',
+            'user_A',
+            'node_person_worker___________',
+            'node_founded_company_________',
+            'FOUNDED',
+            'Ari founded Blue Harbor Studio.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_founded_project________',
+            'user_A',
+            'node_person_worker___________',
+            'node_founded_project_________',
+            'FOUNDED',
+            'Ari founded Launch Checklist.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_affiliated_person______',
+            'user_A',
+            'node_person_worker___________',
+            'node_friend__________________',
+            'AFFILIATED_WITH',
+            'Ari is affiliated with Riley.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_person_founder_________',
+            'user_A',
+            'node_person_founder__________',
+            'node_founded_company_________',
+            'FOUNDED',
+            'Casey founded Blue Harbor Studio.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          ),
+          (
+            'claim_person_behavior________',
+            'user_A',
+            'node_person_company_behavior_',
+            'node_founded_project_________',
+            'HAS_PREFERENCE',
+            'River Company prefers quiet mornings.',
+            'active',
+            '2026-06-19T00:00:00Z'
+          );
+      `);
+
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const migrationSql = await fs.readFile(
+        path.join(process.cwd(), "drizzle", "0027_organization_node_type.sql"),
+        "utf8",
+      );
+      const statements = migrationSql
+        .split("--> statement-breakpoint")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
+      for (const statement of statements) {
+        await client.query(statement);
+      }
+
+      const rows = await client.query<{ id: string; node_type: string }>(
+        `SELECT id, node_type FROM nodes ORDER BY id`,
+      );
+      expect(rows.rows).toEqual([
+        { id: "node_concept_employer________", node_type: "Organization" },
+        { id: "node_founded_company_________", node_type: "Organization" },
+        { id: "node_founded_project_________", node_type: "Concept" },
+        { id: "node_friend__________________", node_type: "Person" },
+        { id: "node_group___________________", node_type: "Organization" },
+        { id: "node_person_company_behavior_", node_type: "Person" },
+        { id: "node_person_employer_________", node_type: "Organization" },
+        { id: "node_person_founder__________", node_type: "Person" },
+        { id: "node_person_worker___________", node_type: "Person" },
+      ]);
     } finally {
       await client.end();
     }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -210,7 +210,7 @@ export const claims = pgTable(
         table.statedAt.desc(),
       )
       .where(
-        sql`${table.status} = 'active' AND ${table.scope} = 'personal' AND ${table.predicate} IN ('OWNED_BY', 'DUE_ON') AND ${table.objectNodeId} IS NOT NULL`,
+        sql`${table.status} = 'active' AND ${table.scope} = 'personal' AND ${table.predicate} IN ('ASSIGNED_TO', 'DUE_ON') AND ${table.objectNodeId} IS NOT NULL`,
       ),
     index("claims_due_instant_idx")
       .on(table.userId, table.objectInstant)

--- a/src/evals/memory/run-all.test.ts
+++ b/src/evals/memory/run-all.test.ts
@@ -8,10 +8,26 @@
  *
  * Common aliases: memory eval suite, run-all tests, harness vitest.
  */
-import { isServerReachable } from "./db-fixture";
-import { runIngestionEval } from "./runIngestionEval";
-import { ALL_STORIES } from "./stories";
 import { describe, expect, it } from "vitest";
+
+process.env["DATABASE_URL"] ??=
+  "postgres://postgres:postgres@localhost:5431/postgres";
+process.env["MEMORY_OPENAI_API_KEY"] ??= "test";
+process.env["MEMORY_OPENAI_API_BASE_URL"] ??= "http://localhost";
+process.env["MODEL_ID_GRAPH_EXTRACTION"] ??= "test";
+process.env["JINA_API_KEY"] ??= "test";
+process.env["REDIS_URL"] ??= "redis://localhost:6380";
+process.env["MINIO_ENDPOINT"] ??= "localhost";
+process.env["MINIO_ACCESS_KEY"] ??= "test";
+process.env["MINIO_SECRET_KEY"] ??= "test";
+process.env["SOURCES_BUCKET"] ??= "test";
+
+const [{ isServerReachable }, { runIngestionEval }, { ALL_STORIES }] =
+  await Promise.all([
+    import("./db-fixture"),
+    import("./runIngestionEval"),
+    import("./stories"),
+  ]);
 
 const SERVER_AVAILABLE = await isServerReachable();
 const ENABLED = process.env["RUN_EVALS"] !== "0";

--- a/src/evals/memory/run-all.ts
+++ b/src/evals/memory/run-all.ts
@@ -11,18 +11,15 @@
  *
  * Common aliases: eval runner, regression CI script, memory eval artifacts.
  */
-// Provide harmless defaults for env vars the harness never exercises (Redis,
-// MinIO, OpenAI). The harness reaches Postgres directly via the test DSN; no
-// other service is contacted. These defaults must be set before any module
-// imports `~/utils/env`.
-import { isServerReachable } from "./db-fixture";
-import { runIngestionEval } from "./runIngestionEval";
-import { ALL_STORIES } from "./stories";
 import type { EvalResult } from "./types";
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
+// Provide harmless defaults for env vars the harness never exercises (Redis,
+// MinIO, OpenAI). The harness reaches Postgres directly via the test DSN; no
+// other service is contacted. Env-dependent modules are imported dynamically
+// inside `runAll()` after these defaults are installed.
 process.env["DATABASE_URL"] ??=
   "postgres://postgres:postgres@localhost:5431/postgres";
 process.env["MEMORY_OPENAI_API_KEY"] ??= "test";
@@ -91,6 +88,12 @@ function renderMarkdown(summary: RunSummary): string {
 }
 
 export async function runAll(): Promise<RunSummary> {
+  const [{ isServerReachable }, { runIngestionEval }, { ALL_STORIES }] =
+    await Promise.all([
+      import("./db-fixture"),
+      import("./runIngestionEval"),
+      import("./stories"),
+    ]);
   const start = Date.now();
   const results: EvalResult[] = [];
 

--- a/src/evals/memory/runIngestionEval.ts
+++ b/src/evals/memory/runIngestionEval.ts
@@ -51,6 +51,7 @@ import {
   resetTestOverrides,
   setExtractionClientOverride,
   setSkipEmbeddingPersistence,
+  setSkipJobEnqueue,
   setSkipSemanticSearch,
   setSourceServiceOverride,
 } from "~/utils/test-overrides";
@@ -91,6 +92,7 @@ export async function runIngestionEval(
     setTestDatabase(harnessDb as unknown as typeof db);
     setSourceServiceOverride(createStubSourceService(harnessDb));
     setSkipEmbeddingPersistence(true);
+    setSkipJobEnqueue(true);
     setSkipSemanticSearch(true);
 
     const userId = `eval_user_${fixture.name}`;

--- a/src/evals/memory/stories/15-commitments-lifecycle.ts
+++ b/src/evals/memory/stories/15-commitments-lifecycle.ts
@@ -6,7 +6,7 @@
  *  1. HAS_TASK_STATUS lifecycle: pending → in_progress → done. Each
  *     transition should be a registry-driven supersession; once done the
  *     task disappears from the open list.
- *  2. `ownedBy` filter: returns only tasks whose active OWNED_BY claim points
+ *  2. `ownedBy` filter: returns only tasks whose active ASSIGNED_TO claim points
  *     at the requested node id.
  *  3. `dueBefore` filter: drops tasks whose active DUE_ON falls outside the
  *     requested ceiling.
@@ -163,7 +163,7 @@ export const story15CommitmentsLifecycle: EvalFixture = {
           name: "bobOwned",
           subjectName: "bobTask",
           objectName: "bob",
-          predicate: "OWNED_BY",
+          predicate: "ASSIGNED_TO",
           sourceName: "sessionFilters",
           statement: "Bob owns the report.",
           assertedByKind: "user",

--- a/src/evals/memory/stories/16-cleanup-ops-surface.ts
+++ b/src/evals/memory/stories/16-cleanup-ops-surface.ts
@@ -121,7 +121,7 @@ export const story16CleanupOpsSurface: EvalFixture = {
         },
       ],
     },
-    // Step 2 — add_claim. HAS_PREFERENCE marcel → fresh idea.
+    // Step 2 — add_claim. HAS_PREFERENCE marcel → scalar preference value.
     {
       kind: "applyCleanupOperations",
       seedNodeIds: (ctx) => [
@@ -132,9 +132,9 @@ export const story16CleanupOpsSurface: EvalFixture = {
         ctx.nodes.get("doomed")!,
       ],
       operations: () => [
-        // Re-create the fresh node in this step's mapper so we can reference
-        // it in add_claim. The previous step already inserted it; this op
-        // adds a *second* fresh node and we then write the claim to it.
+        // The previous step already inserted one fresh node. This op adds a
+        // second fresh node so the final node-count assertion still proves
+        // create_node works when composed with another operation.
         {
           kind: "create_node",
           tempId: "fresh2",
@@ -145,8 +145,8 @@ export const story16CleanupOpsSurface: EvalFixture = {
         {
           kind: "add_claim",
           subjectTempId: "temp_node_0", // marcel
-          objectTempId: "fresh2",
-          objectValue: null,
+          objectTempId: null,
+          objectValue: "likes the fresh idea",
           predicate: "HAS_PREFERENCE",
           statement: "Marcel likes the fresh idea.",
           sourceClaimId: null,

--- a/src/evals/memory/stories/18-day-node-attachment.ts
+++ b/src/evals/memory/stories/18-day-node-attachment.ts
@@ -5,7 +5,7 @@
  * skip the temporal-graph attachment that ingestion paths uphold via
  * `ensureSourceNode`. After the fix, every non-Temporal node created via
  * `createNode` must:
- *  - have exactly one `OCCURRED_ON` claim with `assertedByKind === "system"`
+ *  - have exactly one `RECORDED_ON` claim with `assertedByKind === "system"`
  *    where `subjectNodeId === newNodeId`,
  *  - the object node must be a `Temporal` node whose `metadata.label` is
  *    today's date in `yyyy-MM-dd` format,
@@ -13,9 +13,9 @@
  *
  * Negative regression: when `createNode` is invoked with `nodeType="Temporal"`
  * the function deliberately skips the day-node attachment to avoid a self-edge
- * / cycle. We assert no `OCCURRED_ON` claim is created for that path.
+ * / cycle. We assert no `RECORDED_ON` claim is created for that path.
  *
- * Common aliases: createNode day-node, OCCURRED_ON regression, manual source
+ * Common aliases: createNode day-node, RECORDED_ON regression, manual source
  * attach, temporal attach.
  */
 import { ensureUser } from "../seed";
@@ -28,7 +28,7 @@ import { setSkipEmbeddingPersistence } from "~/utils/test-overrides";
 export const story18DayNodeAttachment: EvalFixture = {
   name: "18-day-node-attachment",
   description:
-    "createNode wires a non-Temporal node to today's day node via OCCURRED_ON sourced from the per-user manual source; Temporal nodes skip the self-attachment.",
+    "createNode wires a non-Temporal node to today's day node via RECORDED_ON sourced from the per-user manual source; Temporal nodes skip the self-attachment.",
   setup: async (ctx) => {
     await ensureUser(ctx);
   },
@@ -37,7 +37,7 @@ export const story18DayNodeAttachment: EvalFixture = {
     custom: [
       {
         description:
-          "createNode('Concept', 'foo') attaches exactly one OCCURRED_ON claim to today's Temporal node, sourced from a manual system source",
+          "createNode('Concept', 'foo') attaches exactly one RECORDED_ON claim to today's Temporal node, sourced from a manual system source",
         run: async (ctx) => {
           // The harness already enables the embedding-skip seam globally, but
           // we set it again here defensively in case the order ever changes;
@@ -50,7 +50,7 @@ export const story18DayNodeAttachment: EvalFixture = {
 
             const today = format(new Date(), "yyyy-MM-dd");
 
-            const occurredRows = await ctx.db
+            const recordedRows = await ctx.db
               .select({
                 id: claims.id,
                 subjectNodeId: claims.subjectNodeId,
@@ -62,31 +62,31 @@ export const story18DayNodeAttachment: EvalFixture = {
               .where(
                 and(
                   eq(claims.userId, ctx.userId),
-                  eq(claims.predicate, "OCCURRED_ON"),
+                  eq(claims.predicate, "RECORDED_ON"),
                   eq(claims.subjectNodeId, created.id),
                 ),
               );
-            if (occurredRows.length !== 1) {
+            if (recordedRows.length !== 1) {
               return {
                 pass: false,
-                message: `expected 1 OCCURRED_ON claim for new node, got ${occurredRows.length}`,
+                message: `expected 1 RECORDED_ON claim for new node, got ${recordedRows.length}`,
               };
             }
-            const [row] = occurredRows;
+            const [row] = recordedRows;
             if (!row) {
-              return { pass: false, message: "OCCURRED_ON row missing" };
+              return { pass: false, message: "RECORDED_ON row missing" };
             }
             if (row.assertedByKind !== "system") {
               return {
                 pass: false,
-                message: `OCCURRED_ON.assertedByKind=${row.assertedByKind}, expected system`,
+                message: `RECORDED_ON.assertedByKind=${row.assertedByKind}, expected system`,
               };
             }
             if (!row.objectNodeId) {
               return {
                 pass: false,
                 message:
-                  "OCCURRED_ON.objectNodeId is null; expected a Temporal node",
+                  "RECORDED_ON.objectNodeId is null; expected a Temporal node",
               };
             }
 
@@ -102,7 +102,7 @@ export const story18DayNodeAttachment: EvalFixture = {
             if (!dayNode) {
               return {
                 pass: false,
-                message: "OCCURRED_ON object node missing from DB",
+                message: "RECORDED_ON object node missing from DB",
               };
             }
             if (dayNode.nodeType !== "Temporal") {
@@ -125,13 +125,13 @@ export const story18DayNodeAttachment: EvalFixture = {
             if (!source) {
               return {
                 pass: false,
-                message: "OCCURRED_ON source missing",
+                message: "RECORDED_ON source missing",
               };
             }
             if (source.type !== "manual") {
               return {
                 pass: false,
-                message: `OCCURRED_ON source type=${source.type}, expected manual`,
+                message: `RECORDED_ON source type=${source.type}, expected manual`,
               };
             }
             return { pass: true };
@@ -142,7 +142,7 @@ export const story18DayNodeAttachment: EvalFixture = {
       },
       {
         description:
-          "createNode('Temporal', '2026-04-30') does NOT create a self-OCCURRED_ON edge",
+          "createNode('Temporal', '2026-04-30') does NOT create a self-RECORDED_ON edge",
         run: async (ctx) => {
           setSkipEmbeddingPersistence(true);
           try {
@@ -161,14 +161,14 @@ export const story18DayNodeAttachment: EvalFixture = {
               .where(
                 and(
                   eq(claims.userId, ctx.userId),
-                  eq(claims.predicate, "OCCURRED_ON"),
+                  eq(claims.predicate, "RECORDED_ON"),
                   eq(claims.subjectNodeId, created.id),
                 ),
               );
             if (rows.length !== 0) {
               return {
                 pass: false,
-                message: `expected 0 OCCURRED_ON claims for Temporal node, got ${rows.length}`,
+                message: `expected 0 RECORDED_ON claims for Temporal node, got ${rows.length}`,
               };
             }
             return { pass: true };

--- a/src/evals/memory/stories/19-predicate-shape-guardrails.ts
+++ b/src/evals/memory/stories/19-predicate-shape-guardrails.ts
@@ -1,0 +1,225 @@
+/**
+ * Story 19 — Relationship predicate shape guardrails.
+ *
+ * A canned extractor response tries the generic bad-shape cases that prompted
+ * the relation-taxonomy work: person-to-person deadline, person located in an
+ * object, person exhibiting a non-emotion account/media node, reversed event
+ * participants, reversed dates, content emotion, and reversed involved items.
+ * The real ingestion path must drop those relationship claims while keeping
+ * valid scalar preferences and an allowed RELATED_TO fallback.
+ *
+ * Common aliases: predicate shape eval, invalid edge guardrail, relation taxonomy regression.
+ */
+import type { EvalFixture } from "../types";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { claims } from "~/db/schema";
+
+export const story19PredicateShapeGuardrails: EvalFixture = {
+  name: "19-predicate-shape-guardrails",
+  description:
+    "Extraction drops invalid relationship predicate shapes while preserving a valid scalar preference and RELATED_TO fallback.",
+  steps: [
+    {
+      kind: "ingestConversation",
+      conversationId: "conv-predicate-shape-guardrails",
+      messages: [
+        {
+          id: "msg-predicate-shape-1",
+          role: "user",
+          content:
+            "Ada thanked Lee, liked the ceramic mug, viewed a social account, and compared two products in an article.",
+          timestamp: new Date("2026-06-18T09:00:00Z"),
+        },
+      ],
+      extractionStubs: [
+        {
+          nodes: [
+            {
+              id: "temp_person",
+              type: "Person",
+              label: "Ada",
+              description: "The user in this fixture.",
+            },
+            {
+              id: "temp_friend",
+              type: "Person",
+              label: "Lee",
+              description: "Person Ada thanked.",
+            },
+            {
+              id: "temp_mug",
+              type: "Object",
+              label: "ceramic mug",
+              description: "Object Ada likes.",
+            },
+            {
+              id: "temp_account",
+              type: "Media",
+              label: "social account",
+              description: "Viewed account.",
+            },
+            {
+              id: "temp_article",
+              type: "Media",
+              label: "comparison article",
+              description: "Article comparing products.",
+            },
+            {
+              id: "temp_workshop",
+              type: "Event",
+              label: "planning workshop",
+              description: "Event used for predicate direction checks.",
+            },
+            {
+              id: "temp_day",
+              type: "Temporal",
+              label: "2026-06-18",
+              description: "Date used for predicate direction checks.",
+            },
+            {
+              id: "temp_tone",
+              type: "Emotion",
+              label: "urgency",
+              description: "Tone conveyed by content, not a person emotion.",
+            },
+            {
+              id: "temp_product",
+              type: "Object",
+              label: "reference product",
+              description: "Product compared in the article.",
+            },
+          ],
+          relationshipClaims: [
+            {
+              subjectId: "temp_person",
+              objectId: "temp_friend",
+              predicate: "DUE_ON",
+              statement: "Ada thanked Lee.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_person",
+              objectId: "temp_mug",
+              predicate: "LOCATED_IN",
+              statement: "Ada likes the ceramic mug.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_person",
+              objectId: "temp_account",
+              predicate: "EXHIBITED_EMOTION",
+              statement: "Ada viewed the social account.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_workshop",
+              objectId: "temp_person",
+              predicate: "PARTICIPATED_IN",
+              statement: "Ada participated in the planning workshop.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_day",
+              objectId: "temp_workshop",
+              predicate: "OCCURRED_ON",
+              statement: "The planning workshop happened on 2026-06-18.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_article",
+              objectId: "temp_tone",
+              predicate: "EXHIBITED_EMOTION",
+              statement: "The article conveys urgency.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_product",
+              objectId: "temp_workshop",
+              predicate: "INVOLVED_ITEM",
+              statement: "The workshop involved the reference product.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_article",
+              objectId: "temp_product",
+              predicate: "RELATED_TO",
+              statement:
+                "The comparison article explicitly references the product.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+          ],
+          attributeClaims: [
+            {
+              subjectId: "temp_person",
+              predicate: "HAS_PREFERENCE",
+              objectValue: "likes ceramic mugs",
+              statement: "Ada likes ceramic mugs.",
+              sourceRef: "msg-predicate-shape-1",
+              assertionKind: "user",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  expectations: {
+    custom: [
+      {
+        description:
+          "bad relationship predicates are dropped while valid preference and RELATED_TO claims remain",
+        run: async (ctx) => {
+          const [badRows] = await ctx.db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(claims)
+            .where(
+              and(
+                eq(claims.userId, ctx.userId),
+                eq(claims.status, "active"),
+                inArray(claims.predicate, [
+                  "DUE_ON",
+                  "LOCATED_IN",
+                  "EXHIBITED_EMOTION",
+                  "PARTICIPATED_IN",
+                  "OCCURRED_ON",
+                  "INVOLVED_ITEM",
+                ]),
+              ),
+            );
+          if ((badRows?.count ?? 0) !== 0) {
+            return {
+              pass: false,
+              message: `expected 0 active bad-shape claims, got ${badRows?.count ?? 0}`,
+            };
+          }
+
+          const [goodRows] = await ctx.db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(claims)
+            .where(
+              and(
+                eq(claims.userId, ctx.userId),
+                eq(claims.status, "active"),
+                inArray(claims.predicate, ["HAS_PREFERENCE", "RELATED_TO"]),
+              ),
+            );
+          if ((goodRows?.count ?? 0) !== 2) {
+            return {
+              pass: false,
+              message: `expected 2 active valid claims, got ${goodRows?.count ?? 0}`,
+            };
+          }
+
+          return { pass: true };
+        },
+      },
+    ],
+  },
+};

--- a/src/evals/memory/stories/20-organization-taxonomy.ts
+++ b/src/evals/memory/stories/20-organization-taxonomy.ts
@@ -118,7 +118,8 @@ export const story20OrganizationTaxonomy: EvalFixture = {
   expectations: {
     nodeCounts: [
       {
-        description: "organization nodes are minted for formal and informal groups",
+        description:
+          "organization nodes are minted for formal and informal groups",
         type: "Organization",
         exactCount: 4,
       },
@@ -169,7 +170,8 @@ export const story20OrganizationTaxonomy: EvalFixture = {
           if ((misclassifiedProductRows?.count ?? 0) !== 0) {
             return {
               pass: false,
-              message: "expected Northstar app to remain Object, not Organization",
+              message:
+                "expected Northstar app to remain Object, not Organization",
             };
           }
 

--- a/src/evals/memory/stories/20-organization-taxonomy.ts
+++ b/src/evals/memory/stories/20-organization-taxonomy.ts
@@ -1,0 +1,181 @@
+/**
+ * Story 20 — Organization taxonomy.
+ *
+ * A canned extractor response uses Organization for a formal employer and a
+ * named informal group, while leaving a product as Object. Valid organization
+ * edges must survive extraction.
+ *
+ * Common aliases: organization node type eval, employer taxonomy regression, named group regression.
+ */
+import type { EvalFixture } from "../types";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+
+export const story20OrganizationTaxonomy: EvalFixture = {
+  name: "20-organization-taxonomy",
+  description:
+    "Extraction accepts Organization nodes for employers and named groups without misclassifying products.",
+  steps: [
+    {
+      kind: "ingestConversation",
+      conversationId: "conv-organization-taxonomy",
+      messages: [
+        {
+          id: "msg-organization-1",
+          role: "user",
+          content:
+            "Ari works at Orchard Labs, founded Blue Harbor Studio, is part of Saturday Supper Club, and the studio owns Northstar Collective.",
+          timestamp: new Date("2026-06-19T10:00:00Z"),
+        },
+      ],
+      extractionStubs: [
+        {
+          nodes: [
+            {
+              id: "temp_person",
+              type: "Person",
+              label: "Ari",
+              description: "Person mentioned in the source.",
+            },
+            {
+              id: "temp_employer",
+              type: "Organization",
+              label: "Orchard Labs",
+              description: "Ari's employer.",
+            },
+            {
+              id: "temp_studio",
+              type: "Organization",
+              label: "Blue Harbor Studio",
+              description: "Organization Ari founded.",
+            },
+            {
+              id: "temp_group",
+              type: "Organization",
+              label: "Saturday Supper Club",
+              description: "Named informal group.",
+            },
+            {
+              id: "temp_collective",
+              type: "Organization",
+              label: "Northstar Collective",
+              description: "Organization owned by another organization.",
+            },
+            {
+              id: "temp_product",
+              type: "Object",
+              label: "Northstar app",
+              description: "Product, not the operating organization.",
+            },
+          ],
+          relationshipClaims: [
+            {
+              subjectId: "temp_person",
+              objectId: "temp_employer",
+              predicate: "WORKS_AT",
+              statement: "Ari works at Orchard Labs.",
+              sourceRef: "msg-organization-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_person",
+              objectId: "temp_studio",
+              predicate: "FOUNDED",
+              statement: "Ari founded Blue Harbor Studio.",
+              sourceRef: "msg-organization-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_person",
+              objectId: "temp_group",
+              predicate: "AFFILIATED_WITH",
+              statement: "Ari is affiliated with Saturday Supper Club.",
+              sourceRef: "msg-organization-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_studio",
+              objectId: "temp_collective",
+              predicate: "OWNS",
+              statement: "Blue Harbor Studio owns Northstar Collective.",
+              sourceRef: "msg-organization-1",
+              assertionKind: "user",
+            },
+            {
+              subjectId: "temp_studio",
+              objectId: "temp_product",
+              predicate: "CREATED",
+              statement: "Blue Harbor Studio created the Northstar app.",
+              sourceRef: "msg-organization-1",
+              assertionKind: "user",
+            },
+          ],
+          attributeClaims: [],
+        },
+      ],
+    },
+  ],
+  expectations: {
+    nodeCounts: [
+      {
+        description: "organization nodes are minted for formal and informal groups",
+        type: "Organization",
+        exactCount: 4,
+      },
+      {
+        description: "the product remains an object",
+        type: "Object",
+        exactCount: 1,
+      },
+    ],
+    custom: [
+      {
+        description: "organization relationships survive shape validation",
+        run: async (ctx) => {
+          const [relationshipRows] = await ctx.db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(claims)
+            .where(
+              and(
+                eq(claims.userId, ctx.userId),
+                eq(claims.status, "active"),
+                inArray(claims.predicate, [
+                  "AFFILIATED_WITH",
+                  "CREATED",
+                  "FOUNDED",
+                  "OWNS",
+                  "WORKS_AT",
+                ]),
+              ),
+            );
+          if ((relationshipRows?.count ?? 0) !== 5) {
+            return {
+              pass: false,
+              message: `expected 5 active organization relationships, got ${relationshipRows?.count ?? 0}`,
+            };
+          }
+
+          const [misclassifiedProductRows] = await ctx.db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(nodes)
+            .innerJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+            .where(
+              and(
+                eq(nodes.userId, ctx.userId),
+                eq(nodes.nodeType, "Organization"),
+                eq(nodeMetadata.label, "Northstar app"),
+              ),
+            );
+          if ((misclassifiedProductRows?.count ?? 0) !== 0) {
+            return {
+              pass: false,
+              message: "expected Northstar app to remain Object, not Organization",
+            };
+          }
+
+          return { pass: true };
+        },
+      },
+    ],
+  },
+};

--- a/src/evals/memory/stories/index.ts
+++ b/src/evals/memory/stories/index.ts
@@ -21,6 +21,8 @@ import { story15CommitmentsLifecycle } from "./15-commitments-lifecycle";
 import { story16CleanupOpsSurface } from "./16-cleanup-ops-surface";
 import { story17TrustHierarchyMatrix } from "./17-trust-hierarchy-matrix";
 import { story18DayNodeAttachment } from "./18-day-node-attachment";
+import { story19PredicateShapeGuardrails } from "./19-predicate-shape-guardrails";
+import { story20OrganizationTaxonomy } from "./20-organization-taxonomy";
 
 export const ALL_STORIES: readonly EvalFixture[] = [
   story01ProjectLifecycle,
@@ -40,4 +42,6 @@ export const ALL_STORIES: readonly EvalFixture[] = [
   story16CleanupOpsSurface,
   story17TrustHierarchyMatrix,
   story18DayNodeAttachment,
+  story19PredicateShapeGuardrails,
+  story20OrganizationTaxonomy,
 ];

--- a/src/lib/atlas.ts
+++ b/src/lib/atlas.ts
@@ -179,10 +179,10 @@ export async function ensureAssistantAtlasNode(
     .onConflictDoNothing();
   await db.insert(claims).values({
     userId,
-    subjectNodeId: atlasNodeId,
-    objectNodeId: assistantNodeId,
-    predicate: "OWNED_BY",
-    statement: `Atlas ${assistantId} is owned by assistant ${assistantId}.`,
+    subjectNodeId: assistantNodeId,
+    objectNodeId: atlasNodeId,
+    predicate: "OWNS",
+    statement: `Assistant ${assistantId} owns atlas ${assistantId}.`,
     sourceId,
     scope: "personal",
     assertedByKind: "system",

--- a/src/lib/claim.test.ts
+++ b/src/lib/claim.test.ts
@@ -267,7 +267,7 @@ describeIfServer("claim operations", () => {
 
       const subjectId = newTypeId("node");
       await client.query(
-        `INSERT INTO "nodes" ("id","user_id","node_type") VALUES ($1,$2,'Entity')`,
+        `INSERT INTO "nodes" ("id","user_id","node_type") VALUES ($1,$2,'Task')`,
         [subjectId, userId],
       );
 
@@ -460,7 +460,7 @@ describeIfServer("reattributeClaim", () => {
         userId,
         subjectNodeId: oldSubjectId,
         objectNodeId: objectId,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Bob owns a MacBook Pro.",
         description: "ownership note",
         sourceId,
@@ -486,7 +486,7 @@ describeIfServer("reattributeClaim", () => {
         subjectNodeId: newSubjectId,
         objectNodeId: objectId,
         objectValue: null,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Bob owns a MacBook Pro.",
         description: "ownership note",
         sourceId,
@@ -569,7 +569,7 @@ describeIfServer("reattributeClaim", () => {
         userId,
         subjectNodeId: subjectId,
         objectNodeId: oldObjectId,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Alice owns a laptop.",
         sourceId,
         scope: "personal",
@@ -723,7 +723,7 @@ describeIfServer("reattributeClaim", () => {
         userId,
         subjectNodeId: subjectId,
         objectNodeId: objectId,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Alice owns a laptop.",
         sourceId: personalSourceId,
         scope: "personal",
@@ -791,7 +791,7 @@ describeIfServer("reattributeClaim", () => {
         userId,
         subjectNodeId: subjectId,
         objectNodeId: objectId,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Alice owns a laptop.",
         sourceId,
         scope: "personal",
@@ -888,7 +888,7 @@ describeIfServer("reattributeClaim", () => {
           userId,
           subjectNodeId: oldSubjectId,
           objectNodeId: objectId,
-          predicate: "OWNED_BY",
+          predicate: "OWNS",
           statement: "Bob owns a laptop.",
           sourceId,
           scope: "personal",

--- a/src/lib/claim.ts
+++ b/src/lib/claim.ts
@@ -220,16 +220,10 @@ export async function createClaim(
   );
   const attributePredicate = AttributePredicateEnum.safeParse(input.predicate);
   if (relationshipPredicate.success && !hasObjectNode) {
-    throw new InvalidPredicateObjectShapeError(
-      input.predicate,
-      "objectNodeId",
-    );
+    throw new InvalidPredicateObjectShapeError(input.predicate, "objectNodeId");
   }
   if (attributePredicate.success && !hasObjectValue) {
-    throw new InvalidPredicateObjectShapeError(
-      input.predicate,
-      "objectValue",
-    );
+    throw new InvalidPredicateObjectShapeError(input.predicate, "objectValue");
   }
 
   // HAS_TASK_STATUS carries a canonical vocabulary that the open-commitments

--- a/src/lib/claim.ts
+++ b/src/lib/claim.ts
@@ -2,15 +2,19 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { claims, claimEmbeddings, nodeMetadata, nodes } from "~/db/schema";
 import { applyClaimLifecycle, fetchClaimsByIds } from "~/lib/claims/lifecycle";
+import { assertRelationshipPredicateShape } from "~/lib/claims/predicate-shapes";
 import { generateEmbeddings } from "~/lib/embeddings";
 import { CrossScopeMergeError } from "~/lib/node";
 import { getEffectiveNodeScopes } from "~/lib/node-scope";
 import { logEvent } from "~/lib/observability/log";
 import { ensureSystemSource } from "~/lib/sources";
 import {
+  AttributePredicateEnum,
+  RelationshipPredicateEnum,
   TaskStatusEnum,
   type AssertedByKind,
   type ClaimStatus,
+  type NodeType,
   type Predicate,
   type ReattributeReplace,
   type Scope,
@@ -45,6 +49,22 @@ export class InvalidObjectValueError extends Error {
     this.predicate = predicate;
     this.objectValue = objectValue;
     this.allowedValues = allowedValues;
+  }
+}
+
+/**
+ * Thrown when a claim's predicate does not match its object representation:
+ * attribute predicates require `objectValue`, relationship predicates require
+ * `objectNodeId`.
+ */
+export class InvalidPredicateObjectShapeError extends Error {
+  readonly predicate: Predicate;
+  readonly expected: "objectValue" | "objectNodeId";
+  constructor(predicate: Predicate, expected: "objectValue" | "objectNodeId") {
+    super(`Predicate ${predicate} requires ${expected}`);
+    this.name = "InvalidPredicateObjectShapeError";
+    this.predicate = predicate;
+    this.expected = expected;
   }
 }
 
@@ -127,16 +147,20 @@ export function claimEmbeddingText(claim: {
   return `${claim.predicate} ${claim.statement} status=${claim.status} statedAt=${claim.statedAt.toISOString()}`;
 }
 
-async function fetchOwnedNodeLabels(
+async function fetchOwnedNodes(
   db: Database,
   userId: string,
   nodeIds: TypeId<"node">[],
-): Promise<Map<TypeId<"node">, string | null>> {
+): Promise<Map<TypeId<"node">, { label: string | null; nodeType: NodeType }>> {
   const uniqueNodeIds = [...new Set(nodeIds)];
   if (uniqueNodeIds.length === 0) return new Map();
 
   const found = await db
-    .select({ id: nodes.id, label: nodeMetadata.label })
+    .select({
+      id: nodes.id,
+      label: nodeMetadata.label,
+      nodeType: nodes.nodeType,
+    })
     .from(nodes)
     .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
     .where(and(eq(nodes.userId, userId), inArray(nodes.id, uniqueNodeIds)));
@@ -147,7 +171,12 @@ async function fetchOwnedNodeLabels(
     throw new NodesNotFoundError(userId, missing);
   }
 
-  return new Map(found.map((node) => [node.id, node.label ?? null]));
+  return new Map(
+    found.map((node) => [
+      node.id,
+      { label: node.label ?? null, nodeType: node.nodeType },
+    ]),
+  );
 }
 
 async function insertClaimEmbedding(
@@ -186,6 +215,23 @@ export async function createClaim(
     throw new Error("Exactly one of objectNodeId or objectValue is required");
   }
 
+  const relationshipPredicate = RelationshipPredicateEnum.safeParse(
+    input.predicate,
+  );
+  const attributePredicate = AttributePredicateEnum.safeParse(input.predicate);
+  if (relationshipPredicate.success && !hasObjectNode) {
+    throw new InvalidPredicateObjectShapeError(
+      input.predicate,
+      "objectNodeId",
+    );
+  }
+  if (attributePredicate.success && !hasObjectValue) {
+    throw new InvalidPredicateObjectShapeError(
+      input.predicate,
+      "objectValue",
+    );
+  }
+
   // HAS_TASK_STATUS carries a canonical vocabulary that the open-commitments
   // read model relies on. Reject anything outside `TaskStatusEnum` at the
   // write boundary so different SDK consumers can't drift apart on labels
@@ -204,10 +250,22 @@ export async function createClaim(
     }
   }
 
-  const nodeLabels = await fetchOwnedNodeLabels(db, input.userId, [
+  const ownedNodes = await fetchOwnedNodes(db, input.userId, [
     input.subjectNodeId,
     ...(input.objectNodeId !== undefined ? [input.objectNodeId] : []),
   ]);
+
+  if (relationshipPredicate.success && input.objectNodeId !== undefined) {
+    const subject = ownedNodes.get(input.subjectNodeId);
+    const object = ownedNodes.get(input.objectNodeId);
+    if (subject && object) {
+      assertRelationshipPredicateShape({
+        predicate: relationshipPredicate.data,
+        subjectType: subject.nodeType,
+        objectType: object.nodeType,
+      });
+    }
+  }
 
   const sourceId =
     input.sourceId ?? (await ensureSystemSource(db, input.userId, "manual"));
@@ -258,10 +316,10 @@ export async function createClaim(
   await insertClaimEmbedding(db, finalized);
   return {
     ...finalized,
-    subjectLabel: nodeLabels.get(input.subjectNodeId) ?? null,
+    subjectLabel: ownedNodes.get(input.subjectNodeId)?.label ?? null,
     objectLabel:
       input.objectNodeId !== undefined
-        ? (nodeLabels.get(input.objectNodeId) ?? null)
+        ? (ownedNodes.get(input.objectNodeId)?.label ?? null)
         : null,
   };
 }
@@ -388,7 +446,7 @@ export async function reattributeClaim(
 
   // Validate the new endpoint node exists and is owned by the user. Reuse the
   // same ownership check createClaim uses so the error surface is identical.
-  await fetchOwnedNodeLabels(db, input.userId, [input.newNodeId]);
+  await fetchOwnedNodes(db, input.userId, [input.newNodeId]);
 
   // Compute the resulting endpoint pair and refuse a cross-scope inconsistency,
   // mirroring the guard merge enforces. For an attribute claim the object is a
@@ -477,17 +535,17 @@ export async function reattributeClaim(
 
   await insertClaimEmbedding(db, finalized);
 
-  const labelMap = await fetchOwnedNodeLabels(db, input.userId, [
+  const nodeMap = await fetchOwnedNodes(db, input.userId, [
     finalized.subjectNodeId,
     ...(finalized.objectNodeId !== null ? [finalized.objectNodeId] : []),
   ]);
 
   return {
     ...finalized,
-    subjectLabel: labelMap.get(finalized.subjectNodeId) ?? null,
+    subjectLabel: nodeMap.get(finalized.subjectNodeId)?.label ?? null,
     objectLabel:
       finalized.objectNodeId !== null
-        ? (labelMap.get(finalized.objectNodeId) ?? null)
+        ? (nodeMap.get(finalized.objectNodeId)?.label ?? null)
         : null,
   };
 }

--- a/src/lib/claims/lifecycle.test.ts
+++ b/src/lib/claims/lifecycle.test.ts
@@ -764,7 +764,7 @@ describeIfServer("applyClaimLifecycle", () => {
     }
   });
 
-  it("supersedes prior OWNED_BY claims on Task subjects", async () => {
+  it("supersedes prior ASSIGNED_TO claims on Task subjects", async () => {
     const userId = "user_H";
     const taskNodeId = newTypeId("node");
     const ownerANodeId = newTypeId("node");
@@ -803,7 +803,7 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: taskNodeId,
             objectNodeId: ownerANodeId,
-            predicate: "OWNED_BY",
+            predicate: "ASSIGNED_TO",
             statement: "Task owned by A.",
             sourceId,
             assertedByKind: "user",
@@ -815,7 +815,7 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: taskNodeId,
             objectNodeId: ownerBNodeId,
-            predicate: "OWNED_BY",
+            predicate: "ASSIGNED_TO",
             statement: "Task reassigned to B.",
             sourceId,
             assertedByKind: "user",
@@ -952,7 +952,7 @@ describeIfServer("applyClaimLifecycle", () => {
     }
   });
 
-  it("keeps multiple OWNED_BY claims active on non-Task subjects", async () => {
+  it("keeps multiple OWNS claims active on non-Task subjects", async () => {
     const userId = "user_J";
     const conceptNodeId = newTypeId("node");
     const ownerANodeId = newTypeId("node");
@@ -971,7 +971,7 @@ describeIfServer("applyClaimLifecycle", () => {
       await client.query(
         `
           INSERT INTO "nodes" ("id", "user_id", "node_type")
-            VALUES ($1, $4, 'Concept'), ($2, $4, 'Person'), ($3, $4, 'Person')
+            VALUES ($1, $4, 'Concept'), ($2, $4, 'Object'), ($3, $4, 'Object')
         `,
         [conceptNodeId, ownerANodeId, ownerBNodeId, userId],
       );
@@ -991,8 +991,8 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: conceptNodeId,
             objectNodeId: ownerANodeId,
-            predicate: "OWNED_BY",
-            statement: "Concept co-owned by A.",
+            predicate: "OWNS",
+            statement: "Concept owns object A.",
             sourceId,
             assertedByKind: "user",
             statedAt: new Date("2026-04-10T00:00:00.000Z"),
@@ -1003,8 +1003,8 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: conceptNodeId,
             objectNodeId: ownerBNodeId,
-            predicate: "OWNED_BY",
-            statement: "Concept co-owned by B.",
+            predicate: "OWNS",
+            statement: "Concept owns object B.",
             sourceId,
             assertedByKind: "user",
             statedAt: new Date("2026-04-12T00:00:00.000Z"),
@@ -1046,7 +1046,7 @@ describeIfServer("applyClaimLifecycle", () => {
     }
   });
 
-  it("trust rule still applies to OWNED_BY on Tasks", async () => {
+  it("trust rule still applies to ASSIGNED_TO on Tasks", async () => {
     const userId = "user_K";
     const taskNodeId = newTypeId("node");
     const ownerANodeId = newTypeId("node");
@@ -1085,7 +1085,7 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: taskNodeId,
             objectNodeId: ownerANodeId,
-            predicate: "OWNED_BY",
+            predicate: "ASSIGNED_TO",
             statement: "User asserted owner A.",
             sourceId,
             assertedByKind: "user",
@@ -1097,7 +1097,7 @@ describeIfServer("applyClaimLifecycle", () => {
             userId,
             subjectNodeId: taskNodeId,
             objectNodeId: ownerBNodeId,
-            predicate: "OWNED_BY",
+            predicate: "ASSIGNED_TO",
             statement: "Assistant inferred owner B.",
             sourceId,
             assertedByKind: "assistant_inferred",

--- a/src/lib/claims/predicate-policies.test.ts
+++ b/src/lib/claims/predicate-policies.test.ts
@@ -64,7 +64,7 @@ describe("resolvePredicatePolicy", () => {
   });
 
   it("returns the base policy for unknown / null subject type", () => {
-    expect(resolvePredicatePolicy("OWNED_BY", null)).toMatchObject({
+    expect(resolvePredicatePolicy("OWNS", null)).toMatchObject({
       cardinality: "multi_value",
       lifecycle: "none",
     });
@@ -74,9 +74,9 @@ describe("resolvePredicatePolicy", () => {
     });
   });
 
-  it("upgrades OWNED_BY on Task subjects to single_current_value", () => {
-    expect(resolvePredicatePolicy("OWNED_BY", "Task")).toMatchObject({
-      predicate: "OWNED_BY",
+  it("keeps ASSIGNED_TO single_current_value", () => {
+    expect(resolvePredicatePolicy("ASSIGNED_TO", "Task")).toMatchObject({
+      predicate: "ASSIGNED_TO",
       cardinality: "single_current_value",
       lifecycle: "supersede_previous",
       feedsAtlas: false,
@@ -94,12 +94,12 @@ describe("resolvePredicatePolicy", () => {
     });
   });
 
-  it("preserves multi_value OWNED_BY for non-Task subjects", () => {
-    expect(resolvePredicatePolicy("OWNED_BY", "Concept")).toMatchObject({
+  it("preserves multi_value OWNS across subject types", () => {
+    expect(resolvePredicatePolicy("OWNS", "Concept")).toMatchObject({
       cardinality: "multi_value",
       lifecycle: "none",
     });
-    expect(resolvePredicatePolicy("OWNED_BY", "Atlas")).toMatchObject({
+    expect(resolvePredicatePolicy("OWNS", "Person")).toMatchObject({
       cardinality: "multi_value",
       lifecycle: "none",
     });

--- a/src/lib/claims/predicate-policies.ts
+++ b/src/lib/claims/predicate-policies.ts
@@ -119,6 +119,14 @@ export const PREDICATE_POLICIES: PredicatePolicyMap = {
     retrievalSection: "evidence",
     forceRefreshOnSupersede: false,
   },
+  RECORDED_ON: {
+    predicate: "RECORDED_ON",
+    cardinality: "multi_value",
+    lifecycle: "none",
+    feedsAtlas: false,
+    retrievalSection: "evidence",
+    forceRefreshOnSupersede: false,
+  },
   INVOLVED_ITEM: {
     predicate: "INVOLVED_ITEM",
     cardinality: "multi_value",
@@ -143,22 +151,13 @@ export const PREDICATE_POLICIES: PredicatePolicyMap = {
     retrievalSection: "evidence",
     forceRefreshOnSupersede: false,
   },
-  OWNED_BY: {
-    predicate: "OWNED_BY",
-    cardinality: "multi_value",
-    lifecycle: "none",
+  ASSIGNED_TO: {
+    predicate: "ASSIGNED_TO",
+    cardinality: "single_current_value",
+    lifecycle: "supersede_previous",
     feedsAtlas: false,
     retrievalSection: "evidence",
     forceRefreshOnSupersede: false,
-    // A Task has exactly one current owner — reassignment supersedes the
-    // prior claim. Non-Task subjects (atlas co-owners, shared artifacts)
-    // keep multi_value semantics.
-    subjectTypeOverrides: {
-      Task: {
-        cardinality: "single_current_value",
-        lifecycle: "supersede_previous",
-      },
-    },
   },
   DUE_ON: {
     predicate: "DUE_ON",
@@ -246,6 +245,14 @@ export const PREDICATE_POLICIES: PredicatePolicyMap = {
   },
   USES: {
     predicate: "USES",
+    cardinality: "multi_value",
+    lifecycle: "none",
+    feedsAtlas: false,
+    retrievalSection: "evidence",
+    forceRefreshOnSupersede: false,
+  },
+  OWNS: {
+    predicate: "OWNS",
     cardinality: "multi_value",
     lifecycle: "none",
     feedsAtlas: false,

--- a/src/lib/claims/predicate-shape-audit.test.ts
+++ b/src/lib/claims/predicate-shape-audit.test.ts
@@ -1,0 +1,202 @@
+import { auditRelationshipPredicateHealth } from "./predicate-shape-audit";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("auditRelationshipPredicateHealth", () => {
+  const dbName = `memory_predicate_health_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("reports shape violations, deprecated predicates, repair proposals, and prompt size", async () => {
+    const userId = "user_predicate_health";
+    const sourceId = newTypeId("source");
+    const person = newTypeId("node");
+    const event = newTypeId("node");
+    const day = newTypeId("node");
+    const object = newTypeId("node");
+    const claimIds = {
+      invertedDate: newTypeId("claim"),
+      deprecatedOwnership: newTypeId("claim"),
+      invalidLocation: newTypeId("claim"),
+      validDate: newTypeId("claim"),
+    };
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_metadata" (
+          "id" text PRIMARY KEY NOT NULL,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "label" text,
+          "canonical_label" text,
+          "description" text,
+          "additional_data" jsonb,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "sources" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "type" varchar(50) NOT NULL,
+          "external_id" text NOT NULL,
+          "parent_source" text,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "metadata" jsonb,
+          "last_ingested_at" timestamp with time zone,
+          "status" varchar(20) DEFAULT 'completed',
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "deleted_at" timestamp with time zone,
+          "content_type" varchar(100),
+          "content_length" integer
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_value" text,
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "description" text,
+          "metadata" jsonb,
+          "object_instant" timestamp with time zone,
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "asserted_by_kind" varchar(24) NOT NULL,
+          "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+          "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+          "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+          "stated_at" timestamp with time zone NOT NULL,
+          "valid_from" timestamp with time zone,
+          "valid_to" timestamp with time zone,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "claims_object_shape_xor_ck"
+            CHECK (num_nonnulls("object_node_id", "object_value") = 1)
+        );
+      `);
+
+      await db.insert(schema.users).values({ id: userId });
+      await db.insert(schema.sources).values({
+        id: sourceId,
+        userId,
+        type: "manual",
+        externalId: "manual:user_predicate_health",
+        scope: "personal",
+        status: "completed",
+      });
+      await db.insert(schema.nodes).values([
+        { id: person, userId, nodeType: "Person" },
+        { id: event, userId, nodeType: "Event" },
+        { id: day, userId, nodeType: "Temporal" },
+        { id: object, userId, nodeType: "Object" },
+      ]);
+      await db.insert(schema.nodeMetadata).values([
+        { id: newTypeId("node_metadata"), nodeId: person, label: "Taylor" },
+        { id: newTypeId("node_metadata"), nodeId: event, label: "Workshop" },
+        { id: newTypeId("node_metadata"), nodeId: day, label: "2026-06-19" },
+        { id: newTypeId("node_metadata"), nodeId: object, label: "Notebook" },
+      ]);
+      await client.query(
+        `INSERT INTO "claims"
+          ("id", "user_id", "subject_node_id", "object_node_id", "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status")
+         VALUES
+          ($1, $5, $9, $8, 'OCCURRED_ON', 'The workshop happened on 2026-06-19.', $6, 'personal', 'user', now(), 'active'),
+          ($2, $5, $8, $9, 'OCCURRED_ON', 'The workshop happened on 2026-06-19.', $6, 'personal', 'user', now(), 'active'),
+          ($3, $5, $7, $10, 'LOCATED_IN', 'Taylor likes the notebook.', $6, 'personal', 'user', now(), 'active'),
+          ($4, $5, $10, $7, 'OWNED_BY', 'The notebook is owned by Taylor.', $6, 'personal', 'user', now(), 'active')`,
+        [
+          claimIds.invertedDate,
+          claimIds.validDate,
+          claimIds.invalidLocation,
+          claimIds.deprecatedOwnership,
+          userId,
+          sourceId,
+          person,
+          event,
+          day,
+          object,
+        ],
+      );
+
+      const report = await auditRelationshipPredicateHealth(db, userId, {
+        exampleLimit: 10,
+      });
+
+      expect(report.invalidShapes.totalInvalid).toBe(2);
+      expect(report.deprecatedPredicates).toEqual([
+        { predicate: "OWNED_BY", count: 1 },
+      ]);
+      expect(report.repairProposals).toHaveLength(2);
+      expect(report.repairProposals.map((proposal) => proposal.claimId)).toEqual(
+        expect.arrayContaining([
+          claimIds.invertedDate,
+          claimIds.deprecatedOwnership,
+        ]),
+      );
+      expect(report.promptGuide.characterCount).toBeGreaterThan(1000);
+      expect(report.promptGuide.approximateTokenCount).toBeGreaterThan(250);
+      expect(report.promptGuide.lineCount).toBeGreaterThan(10);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/src/lib/claims/predicate-shape-audit.test.ts
+++ b/src/lib/claims/predicate-shape-audit.test.ts
@@ -186,7 +186,9 @@ describeIfServer("auditRelationshipPredicateHealth", () => {
         { predicate: "OWNED_BY", count: 1 },
       ]);
       expect(report.repairProposals).toHaveLength(2);
-      expect(report.repairProposals.map((proposal) => proposal.claimId)).toEqual(
+      expect(
+        report.repairProposals.map((proposal) => proposal.claimId),
+      ).toEqual(
         expect.arrayContaining([
           claimIds.invertedDate,
           claimIds.deprecatedOwnership,

--- a/src/lib/claims/predicate-shape-audit.ts
+++ b/src/lib/claims/predicate-shape-audit.ts
@@ -111,10 +111,7 @@ export async function auditInvalidRelationshipPredicateShapes(
     })
     .from(claims)
     .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
-    .leftJoin(
-      subjectMetadata,
-      eq(subjectMetadata.nodeId, claims.subjectNodeId),
-    )
+    .leftJoin(subjectMetadata, eq(subjectMetadata.nodeId, claims.subjectNodeId))
     .leftJoin(objectNodes, eq(objectNodes.id, claims.objectNodeId))
     .leftJoin(objectMetadata, eq(objectMetadata.nodeId, claims.objectNodeId))
     .where(
@@ -227,10 +224,7 @@ async function loadDeprecatedPredicateRepairProposals(
     })
     .from(claims)
     .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
-    .leftJoin(
-      subjectMetadata,
-      eq(subjectMetadata.nodeId, claims.subjectNodeId),
-    )
+    .leftJoin(subjectMetadata, eq(subjectMetadata.nodeId, claims.subjectNodeId))
     .where(
       and(
         eq(claims.userId, userId),
@@ -258,10 +252,7 @@ async function loadDeprecatedPredicateRepairProposals(
             and(eq(nodes.userId, userId), inArray(nodes.id, objectNodeIds)),
           );
   const objectsById = new Map(
-    objectRows.map((row) => [
-      row.nodeId,
-      { type: row.type, label: row.label },
-    ]),
+    objectRows.map((row) => [row.nodeId, { type: row.type, label: row.label }]),
   );
 
   return rows.flatMap((row) => {
@@ -307,11 +298,7 @@ export async function auditRelationshipPredicateHealth(
     await Promise.all([
       auditInvalidRelationshipPredicateShapes(db, userId, options),
       loadDeprecatedPredicateCounts(db, userId),
-      loadDeprecatedPredicateRepairProposals(
-        db,
-        userId,
-        options.exampleLimit,
-      ),
+      loadDeprecatedPredicateRepairProposals(db, userId, options.exampleLimit),
     ]);
 
   const invalidRepairProposals = invalidShapes.examples.flatMap((example) => {
@@ -336,10 +323,7 @@ export async function auditRelationshipPredicateHealth(
   return {
     invalidShapes,
     deprecatedPredicates,
-    repairProposals: [
-      ...invalidRepairProposals,
-      ...deprecatedRepairProposals,
-    ],
+    repairProposals: [...invalidRepairProposals, ...deprecatedRepairProposals],
     promptGuide: promptGuideStats(),
   };
 }

--- a/src/lib/claims/predicate-shape-audit.ts
+++ b/src/lib/claims/predicate-shape-audit.ts
@@ -15,14 +15,13 @@ import {
   RelationshipPredicateEnum,
   type AssertedByKind,
   type NodeType,
+  type Predicate,
   type RelationshipPredicate,
   type Scope,
 } from "~/types/graph";
 import type { TypeId } from "~/types/typeid";
 
-const DEPRECATED_RELATIONSHIP_PREDICATES = ["OWNED_BY"] as const;
-type DeprecatedRelationshipPredicate =
-  (typeof DEPRECATED_RELATIONSHIP_PREDICATES)[number];
+type DeprecatedRelationshipPredicate = "OWNED_BY";
 
 export interface InvalidRelationshipPredicateShapeClaim {
   claimId: TypeId<"claim">;
@@ -71,6 +70,20 @@ export interface RelationshipPredicateHealthAudit {
   promptGuide: RelationshipPredicateGuideStats;
 }
 
+interface InvalidRelationshipPredicateShapeRow {
+  claimId: TypeId<"claim">;
+  predicate: Predicate;
+  statement: string;
+  assertedByKind: AssertedByKind;
+  scope: Scope;
+  subjectNodeId: TypeId<"node">;
+  subjectType: NodeType;
+  subjectLabel: string | null;
+  objectNodeId: TypeId<"node"> | null;
+  objectType: NodeType | null;
+  objectLabel: string | null;
+}
+
 export async function auditInvalidRelationshipPredicateShapes(
   db: DrizzleDB,
   userId: string,
@@ -79,8 +92,10 @@ export async function auditInvalidRelationshipPredicateShapes(
   },
 ): Promise<InvalidRelationshipPredicateShapeAudit> {
   const subjectMetadata = aliasedTable(nodeMetadata, "shapeAuditSubjectMeta");
+  const objectNodes = aliasedTable(nodes, "shapeAuditObjectNodes");
+  const objectMetadata = aliasedTable(nodeMetadata, "shapeAuditObjectMeta");
 
-  const rows = await db
+  const rows: InvalidRelationshipPredicateShapeRow[] = await db
     .select({
       claimId: claims.id,
       predicate: claims.predicate,
@@ -91,6 +106,8 @@ export async function auditInvalidRelationshipPredicateShapes(
       subjectType: nodes.nodeType,
       subjectLabel: subjectMetadata.label,
       objectNodeId: claims.objectNodeId,
+      objectType: objectNodes.nodeType,
+      objectLabel: objectMetadata.label,
     })
     .from(claims)
     .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
@@ -98,6 +115,8 @@ export async function auditInvalidRelationshipPredicateShapes(
       subjectMetadata,
       eq(subjectMetadata.nodeId, claims.subjectNodeId),
     )
+    .leftJoin(objectNodes, eq(objectNodes.id, claims.objectNodeId))
+    .leftJoin(objectMetadata, eq(objectMetadata.nodeId, claims.objectNodeId))
     .where(
       and(
         eq(claims.userId, userId),
@@ -106,30 +125,6 @@ export async function auditInvalidRelationshipPredicateShapes(
       ),
     );
 
-  const objectNodeIds = rows
-    .map((row) => row.objectNodeId)
-    .filter((nodeId): nodeId is TypeId<"node"> => nodeId !== null);
-  const objectRows =
-    objectNodeIds.length === 0
-      ? []
-      : await db
-          .select({
-            nodeId: nodes.id,
-            type: nodes.nodeType,
-            label: nodeMetadata.label,
-          })
-          .from(nodes)
-          .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
-          .where(
-            and(eq(nodes.userId, userId), inArray(nodes.id, objectNodeIds)),
-          );
-  const objectsById = new Map(
-    objectRows.map((row) => [
-      row.nodeId,
-      { type: row.type, label: row.label },
-    ]),
-  );
-
   const counts = new Map<RelationshipPredicate, number>();
   const examples: InvalidRelationshipPredicateShapeClaim[] = [];
   const seedNodeIds = new Set<TypeId<"node">>();
@@ -137,12 +132,10 @@ export async function auditInvalidRelationshipPredicateShapes(
   for (const row of rows) {
     const predicate = relationshipPredicateFrom(row.predicate);
     if (predicate === null) continue;
-    const object =
-      row.objectNodeId === null ? undefined : objectsById.get(row.objectNodeId);
     const invalid = isInvalidRelationshipPredicateClaimShape({
       predicate,
       subjectType: row.subjectType,
-      objectType: object?.type ?? null,
+      objectType: row.objectType ?? null,
     });
     if (!invalid) continue;
 
@@ -162,12 +155,12 @@ export async function auditInvalidRelationshipPredicateShapes(
           label: row.subjectLabel,
         },
         object:
-          row.objectNodeId === null || object === undefined
+          row.objectNodeId === null || row.objectType === null
             ? null
             : {
                 nodeId: row.objectNodeId,
-                type: object.type,
-                label: object.label,
+                type: row.objectType,
+                label: row.objectLabel,
               },
       });
     }

--- a/src/lib/claims/predicate-shape-audit.ts
+++ b/src/lib/claims/predicate-shape-audit.ts
@@ -1,0 +1,352 @@
+/** Database audit for invalid relationship predicate shapes. Common aliases: invalid edge audit, predicate shape audit, graph relation audit. */
+import { aliasedTable, and, eq, inArray, sql } from "drizzle-orm";
+import type { DrizzleDB } from "~/db";
+import { claims, nodeMetadata, nodes } from "~/db/schema";
+import {
+  type PredicateShapeRepairProposal,
+  proposeRelationshipPredicateShapeRepair,
+} from "~/lib/claims/predicate-shape-repair";
+import {
+  formatRelationshipPredicateGuide,
+  isInvalidRelationshipPredicateClaimShape,
+  relationshipPredicateFrom,
+} from "~/lib/claims/predicate-shapes";
+import {
+  RelationshipPredicateEnum,
+  type AssertedByKind,
+  type NodeType,
+  type RelationshipPredicate,
+  type Scope,
+} from "~/types/graph";
+import type { TypeId } from "~/types/typeid";
+
+const DEPRECATED_RELATIONSHIP_PREDICATES = ["OWNED_BY"] as const;
+type DeprecatedRelationshipPredicate =
+  (typeof DEPRECATED_RELATIONSHIP_PREDICATES)[number];
+
+export interface InvalidRelationshipPredicateShapeClaim {
+  claimId: TypeId<"claim">;
+  predicate: RelationshipPredicate;
+  statement: string;
+  assertedByKind: AssertedByKind;
+  scope: Scope;
+  subject: {
+    nodeId: TypeId<"node">;
+    type: NodeType;
+    label: string | null;
+  };
+  object: {
+    nodeId: TypeId<"node">;
+    type: NodeType;
+    label: string | null;
+  } | null;
+}
+
+export interface InvalidRelationshipPredicateShapeAudit {
+  totalInvalid: number;
+  counts: Array<{ predicate: RelationshipPredicate; count: number }>;
+  examples: InvalidRelationshipPredicateShapeClaim[];
+  seedNodeIds: TypeId<"node">[];
+}
+
+export interface AuditInvalidRelationshipPredicateShapesOptions {
+  exampleLimit: number;
+}
+
+export interface DeprecatedRelationshipPredicateCount {
+  predicate: DeprecatedRelationshipPredicate;
+  count: number;
+}
+
+export interface RelationshipPredicateGuideStats {
+  characterCount: number;
+  approximateTokenCount: number;
+  lineCount: number;
+}
+
+export interface RelationshipPredicateHealthAudit {
+  invalidShapes: InvalidRelationshipPredicateShapeAudit;
+  deprecatedPredicates: DeprecatedRelationshipPredicateCount[];
+  repairProposals: PredicateShapeRepairProposal[];
+  promptGuide: RelationshipPredicateGuideStats;
+}
+
+export async function auditInvalidRelationshipPredicateShapes(
+  db: DrizzleDB,
+  userId: string,
+  options: AuditInvalidRelationshipPredicateShapesOptions = {
+    exampleLimit: 20,
+  },
+): Promise<InvalidRelationshipPredicateShapeAudit> {
+  const subjectMetadata = aliasedTable(nodeMetadata, "shapeAuditSubjectMeta");
+
+  const rows = await db
+    .select({
+      claimId: claims.id,
+      predicate: claims.predicate,
+      statement: claims.statement,
+      assertedByKind: claims.assertedByKind,
+      scope: claims.scope,
+      subjectNodeId: claims.subjectNodeId,
+      subjectType: nodes.nodeType,
+      subjectLabel: subjectMetadata.label,
+      objectNodeId: claims.objectNodeId,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+    .leftJoin(
+      subjectMetadata,
+      eq(subjectMetadata.nodeId, claims.subjectNodeId),
+    )
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.status, "active"),
+        inArray(claims.predicate, RelationshipPredicateEnum.options),
+      ),
+    );
+
+  const objectNodeIds = rows
+    .map((row) => row.objectNodeId)
+    .filter((nodeId): nodeId is TypeId<"node"> => nodeId !== null);
+  const objectRows =
+    objectNodeIds.length === 0
+      ? []
+      : await db
+          .select({
+            nodeId: nodes.id,
+            type: nodes.nodeType,
+            label: nodeMetadata.label,
+          })
+          .from(nodes)
+          .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+          .where(
+            and(eq(nodes.userId, userId), inArray(nodes.id, objectNodeIds)),
+          );
+  const objectsById = new Map(
+    objectRows.map((row) => [
+      row.nodeId,
+      { type: row.type, label: row.label },
+    ]),
+  );
+
+  const counts = new Map<RelationshipPredicate, number>();
+  const examples: InvalidRelationshipPredicateShapeClaim[] = [];
+  const seedNodeIds = new Set<TypeId<"node">>();
+
+  for (const row of rows) {
+    const predicate = relationshipPredicateFrom(row.predicate);
+    if (predicate === null) continue;
+    const object =
+      row.objectNodeId === null ? undefined : objectsById.get(row.objectNodeId);
+    const invalid = isInvalidRelationshipPredicateClaimShape({
+      predicate,
+      subjectType: row.subjectType,
+      objectType: object?.type ?? null,
+    });
+    if (!invalid) continue;
+
+    counts.set(predicate, (counts.get(predicate) ?? 0) + 1);
+    seedNodeIds.add(row.subjectNodeId);
+    if (row.objectNodeId !== null) seedNodeIds.add(row.objectNodeId);
+    if (examples.length < options.exampleLimit) {
+      examples.push({
+        claimId: row.claimId,
+        predicate,
+        statement: row.statement,
+        assertedByKind: row.assertedByKind,
+        scope: row.scope,
+        subject: {
+          nodeId: row.subjectNodeId,
+          type: row.subjectType,
+          label: row.subjectLabel,
+        },
+        object:
+          row.objectNodeId === null || object === undefined
+            ? null
+            : {
+                nodeId: row.objectNodeId,
+                type: object.type,
+                label: object.label,
+              },
+      });
+    }
+  }
+
+  return {
+    totalInvalid: Array.from(counts.values()).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+    counts: RelationshipPredicateEnum.options.flatMap((predicate) => {
+      const count = counts.get(predicate) ?? 0;
+      return count > 0 ? [{ predicate, count }] : [];
+    }),
+    examples,
+    seedNodeIds: Array.from(seedNodeIds),
+  };
+}
+
+async function loadDeprecatedPredicateCounts(
+  db: DrizzleDB,
+  userId: string,
+): Promise<DeprecatedRelationshipPredicateCount[]> {
+  const rows = await db
+    .select({
+      predicate: sql<DeprecatedRelationshipPredicate>`${claims.predicate}`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(claims)
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.status, "active"),
+        sql`${claims.predicate} = 'OWNED_BY'`,
+      ),
+    )
+    .groupBy(claims.predicate);
+
+  return rows.map((row) => ({
+    predicate: row.predicate,
+    count: row.count,
+  }));
+}
+
+async function loadDeprecatedPredicateRepairProposals(
+  db: DrizzleDB,
+  userId: string,
+  limit: number,
+): Promise<PredicateShapeRepairProposal[]> {
+  const subjectMetadata = aliasedTable(
+    nodeMetadata,
+    "deprecatedPredicateSubjectMeta",
+  );
+
+  const rows = await db
+    .select({
+      claimId: claims.id,
+      predicate: sql<DeprecatedRelationshipPredicate>`${claims.predicate}`,
+      statement: claims.statement,
+      subjectNodeId: claims.subjectNodeId,
+      subjectType: nodes.nodeType,
+      subjectLabel: subjectMetadata.label,
+      objectNodeId: claims.objectNodeId,
+    })
+    .from(claims)
+    .innerJoin(nodes, eq(nodes.id, claims.subjectNodeId))
+    .leftJoin(
+      subjectMetadata,
+      eq(subjectMetadata.nodeId, claims.subjectNodeId),
+    )
+    .where(
+      and(
+        eq(claims.userId, userId),
+        eq(claims.status, "active"),
+        sql`${claims.predicate} = 'OWNED_BY'`,
+      ),
+    )
+    .limit(limit);
+
+  const objectNodeIds = rows
+    .map((row) => row.objectNodeId)
+    .filter((nodeId): nodeId is TypeId<"node"> => nodeId !== null);
+  const objectRows =
+    objectNodeIds.length === 0
+      ? []
+      : await db
+          .select({
+            nodeId: nodes.id,
+            type: nodes.nodeType,
+            label: nodeMetadata.label,
+          })
+          .from(nodes)
+          .leftJoin(nodeMetadata, eq(nodeMetadata.nodeId, nodes.id))
+          .where(
+            and(eq(nodes.userId, userId), inArray(nodes.id, objectNodeIds)),
+          );
+  const objectsById = new Map(
+    objectRows.map((row) => [
+      row.nodeId,
+      { type: row.type, label: row.label },
+    ]),
+  );
+
+  return rows.flatMap((row) => {
+    const object =
+      row.objectNodeId === null ? undefined : objectsById.get(row.objectNodeId);
+    if (row.objectNodeId === null || object === undefined) return [];
+
+    const proposal = proposeRelationshipPredicateShapeRepair({
+      claimId: row.claimId,
+      predicate: row.predicate,
+      statement: row.statement,
+      subject: {
+        nodeId: row.subjectNodeId,
+        type: row.subjectType,
+      },
+      object: {
+        nodeId: row.objectNodeId,
+        type: object.type,
+      },
+    });
+
+    return proposal === null ? [] : [proposal];
+  });
+}
+
+function promptGuideStats(): RelationshipPredicateGuideStats {
+  const guide = formatRelationshipPredicateGuide();
+  return {
+    characterCount: guide.length,
+    approximateTokenCount: Math.ceil(guide.length / 4),
+    lineCount: guide.split("\n").length,
+  };
+}
+
+export async function auditRelationshipPredicateHealth(
+  db: DrizzleDB,
+  userId: string,
+  options: AuditInvalidRelationshipPredicateShapesOptions = {
+    exampleLimit: 20,
+  },
+): Promise<RelationshipPredicateHealthAudit> {
+  const [invalidShapes, deprecatedPredicates, deprecatedRepairProposals] =
+    await Promise.all([
+      auditInvalidRelationshipPredicateShapes(db, userId, options),
+      loadDeprecatedPredicateCounts(db, userId),
+      loadDeprecatedPredicateRepairProposals(
+        db,
+        userId,
+        options.exampleLimit,
+      ),
+    ]);
+
+  const invalidRepairProposals = invalidShapes.examples.flatMap((example) => {
+    if (example.object === null) return [];
+    const proposal = proposeRelationshipPredicateShapeRepair({
+      claimId: example.claimId,
+      predicate: example.predicate,
+      statement: example.statement,
+      subject: {
+        nodeId: example.subject.nodeId,
+        type: example.subject.type,
+      },
+      object: {
+        nodeId: example.object.nodeId,
+        type: example.object.type,
+      },
+    });
+
+    return proposal === null ? [] : [proposal];
+  });
+
+  return {
+    invalidShapes,
+    deprecatedPredicates,
+    repairProposals: [
+      ...invalidRepairProposals,
+      ...deprecatedRepairProposals,
+    ],
+    promptGuide: promptGuideStats(),
+  };
+}

--- a/src/lib/claims/predicate-shape-repair.test.ts
+++ b/src/lib/claims/predicate-shape-repair.test.ts
@@ -1,0 +1,150 @@
+import { proposeRelationshipPredicateShapeRepair } from "./predicate-shape-repair";
+import { describe, expect, it } from "vitest";
+import type { NodeType } from "~/types/graph";
+import { newTypeId, type TypeId } from "~/types/typeid";
+
+const node = (type: NodeType): { nodeId: TypeId<"node">; type: NodeType } => ({
+  nodeId: newTypeId("node"),
+  type,
+});
+
+describe("proposeRelationshipPredicateShapeRepair", () => {
+  it("inverts invalid relationships when the same predicate is valid in the opposite direction", () => {
+    const event = node("Event");
+    const temporal = node("Temporal");
+    const participant = node("Person");
+
+    const occurredOnRepair = proposeRelationshipPredicateShapeRepair({
+      claimId: newTypeId("claim"),
+      predicate: "OCCURRED_ON",
+      statement: "The workshop happened on 2026-06-19.",
+      subject: temporal,
+      object: event,
+    });
+
+    expect(occurredOnRepair?.replacement).toMatchObject({
+      predicate: "OCCURRED_ON",
+      subjectNodeId: event.nodeId,
+      objectNodeId: temporal.nodeId,
+    });
+
+    const participatedInRepair = proposeRelationshipPredicateShapeRepair({
+      claimId: newTypeId("claim"),
+      predicate: "PARTICIPATED_IN",
+      statement: "Taylor joined the workshop.",
+      subject: event,
+      object: participant,
+    });
+
+    expect(participatedInRepair?.replacement).toMatchObject({
+      predicate: "PARTICIPATED_IN",
+      subjectNodeId: participant.nodeId,
+      objectNodeId: event.nodeId,
+    });
+  });
+
+  it("maps legacy OWNED_BY claims through the ownership and assignment split", () => {
+    const task = node("Task");
+    const person = node("Person");
+    const object = node("Object");
+    const studio = node("Organization");
+    const chapter = node("Organization");
+    const emotion = node("Emotion");
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "The task is owned by Taylor.",
+        subject: task,
+        object: person,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "ASSIGNED_TO",
+      subjectNodeId: task.nodeId,
+      objectNodeId: person.nodeId,
+    });
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "Taylor owns the task.",
+        subject: person,
+        object: task,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "ASSIGNED_TO",
+      subjectNodeId: task.nodeId,
+      objectNodeId: person.nodeId,
+    });
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "The notebook is owned by Taylor.",
+        subject: object,
+        object: person,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "OWNS",
+      subjectNodeId: person.nodeId,
+      objectNodeId: object.nodeId,
+    });
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "Taylor owns the notebook.",
+        subject: person,
+        object,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "OWNS",
+      subjectNodeId: person.nodeId,
+        objectNodeId: object.nodeId,
+      });
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "The community chapter is owned by the studio.",
+        subject: chapter,
+        object: studio,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "OWNS",
+      subjectNodeId: studio.nodeId,
+      objectNodeId: chapter.nodeId,
+    });
+
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "OWNED_BY",
+        statement: "The task is owned by a mood.",
+        subject: task,
+        object: emotion,
+      })?.replacement,
+    ).toMatchObject({
+      predicate: "RELATED_TO",
+      subjectNodeId: task.nodeId,
+      objectNodeId: emotion.nodeId,
+    });
+  });
+
+  it("returns no proposal when an invalid shape cannot be repaired deterministically", () => {
+    expect(
+      proposeRelationshipPredicateShapeRepair({
+        claimId: newTypeId("claim"),
+        predicate: "LOCATED_IN",
+        statement: "Taylor likes the notebook.",
+        subject: node("Person"),
+        object: node("Object"),
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/claims/predicate-shape-repair.test.ts
+++ b/src/lib/claims/predicate-shape-repair.test.ts
@@ -104,8 +104,8 @@ describe("proposeRelationshipPredicateShapeRepair", () => {
     ).toMatchObject({
       predicate: "OWNS",
       subjectNodeId: person.nodeId,
-        objectNodeId: object.nodeId,
-      });
+      objectNodeId: object.nodeId,
+    });
 
     expect(
       proposeRelationshipPredicateShapeRepair({

--- a/src/lib/claims/predicate-shape-repair.ts
+++ b/src/lib/claims/predicate-shape-repair.ts
@@ -93,7 +93,10 @@ function proposeOwnedByRepair(
     };
   }
 
-  if (OWNABLE_TYPES.has(input.subject.type) && OWNER_TYPES.has(input.object.type)) {
+  if (
+    OWNABLE_TYPES.has(input.subject.type) &&
+    OWNER_TYPES.has(input.object.type)
+  ) {
     return {
       claimId: input.claimId,
       reason: "legacy_passive_ownership",
@@ -106,7 +109,10 @@ function proposeOwnedByRepair(
     };
   }
 
-  if (OWNER_TYPES.has(input.subject.type) && OWNABLE_TYPES.has(input.object.type)) {
+  if (
+    OWNER_TYPES.has(input.subject.type) &&
+    OWNABLE_TYPES.has(input.object.type)
+  ) {
     return {
       claimId: input.claimId,
       reason: "legacy_active_ownership",

--- a/src/lib/claims/predicate-shape-repair.ts
+++ b/src/lib/claims/predicate-shape-repair.ts
@@ -1,0 +1,170 @@
+/** Deterministic relationship-shape repair proposals. Common aliases: invalid edge repair, predicate inversion, ownership split dry-run. */
+import {
+  isRelationshipPredicateShapeAllowed,
+  relationshipPredicateFrom,
+} from "./predicate-shapes";
+import type { NodeType, Predicate, RelationshipPredicate } from "~/types/graph";
+import type { TypeId } from "~/types/typeid";
+
+export interface PredicateShapeRepairEndpoint {
+  nodeId: TypeId<"node">;
+  type: NodeType;
+}
+
+export interface PredicateShapeRepairInput {
+  claimId: TypeId<"claim">;
+  predicate: Predicate | "OWNED_BY";
+  statement: string;
+  subject: PredicateShapeRepairEndpoint;
+  object: PredicateShapeRepairEndpoint | null;
+}
+
+export interface PredicateShapeRepairReplacement {
+  predicate: RelationshipPredicate;
+  subjectNodeId: TypeId<"node">;
+  objectNodeId: TypeId<"node">;
+  statement: string;
+}
+
+export interface PredicateShapeRepairProposal {
+  claimId: TypeId<"claim">;
+  reason: string;
+  replacement: PredicateShapeRepairReplacement;
+}
+
+const OWNER_TYPES: ReadonlySet<NodeType> = new Set([
+  "Person",
+  "Organization",
+  "Concept",
+  "Object",
+]);
+
+const OWNABLE_TYPES: ReadonlySet<NodeType> = new Set([
+  "Organization",
+  "Location",
+  "Object",
+  "Concept",
+  "Media",
+  "Atlas",
+]);
+
+function replacementFor(input: {
+  predicate: RelationshipPredicate;
+  subject: PredicateShapeRepairEndpoint;
+  object: PredicateShapeRepairEndpoint;
+  statement: string;
+}): PredicateShapeRepairReplacement {
+  return {
+    predicate: input.predicate,
+    subjectNodeId: input.subject.nodeId,
+    objectNodeId: input.object.nodeId,
+    statement: input.statement,
+  };
+}
+
+function proposeOwnedByRepair(
+  input: PredicateShapeRepairInput & {
+    object: PredicateShapeRepairEndpoint;
+  },
+): PredicateShapeRepairProposal {
+  if (input.subject.type === "Task" && input.object.type === "Person") {
+    return {
+      claimId: input.claimId,
+      reason: "legacy_task_assignment",
+      replacement: replacementFor({
+        predicate: "ASSIGNED_TO",
+        subject: input.subject,
+        object: input.object,
+        statement: input.statement,
+      }),
+    };
+  }
+
+  if (input.subject.type === "Person" && input.object.type === "Task") {
+    return {
+      claimId: input.claimId,
+      reason: "legacy_task_assignment_inverted",
+      replacement: replacementFor({
+        predicate: "ASSIGNED_TO",
+        subject: input.object,
+        object: input.subject,
+        statement: input.statement,
+      }),
+    };
+  }
+
+  if (OWNABLE_TYPES.has(input.subject.type) && OWNER_TYPES.has(input.object.type)) {
+    return {
+      claimId: input.claimId,
+      reason: "legacy_passive_ownership",
+      replacement: replacementFor({
+        predicate: "OWNS",
+        subject: input.object,
+        object: input.subject,
+        statement: input.statement,
+      }),
+    };
+  }
+
+  if (OWNER_TYPES.has(input.subject.type) && OWNABLE_TYPES.has(input.object.type)) {
+    return {
+      claimId: input.claimId,
+      reason: "legacy_active_ownership",
+      replacement: replacementFor({
+        predicate: "OWNS",
+        subject: input.subject,
+        object: input.object,
+        statement: input.statement,
+      }),
+    };
+  }
+
+  return {
+    claimId: input.claimId,
+    reason: "legacy_ambiguous_ownership",
+    replacement: replacementFor({
+      predicate: "RELATED_TO",
+      subject: input.subject,
+      object: input.object,
+      statement: input.statement,
+    }),
+  };
+}
+
+export function proposeRelationshipPredicateShapeRepair(
+  input: PredicateShapeRepairInput,
+): PredicateShapeRepairProposal | null {
+  if (input.object === null) return null;
+
+  if (input.predicate === "OWNED_BY") {
+    return proposeOwnedByRepair({ ...input, object: input.object });
+  }
+
+  const predicate = relationshipPredicateFrom(input.predicate);
+  if (predicate === null) return null;
+
+  const currentShapeIsValid = isRelationshipPredicateShapeAllowed({
+    predicate,
+    subjectType: input.subject.type,
+    objectType: input.object.type,
+  });
+  if (currentShapeIsValid) return null;
+
+  const invertedShapeIsValid = isRelationshipPredicateShapeAllowed({
+    predicate,
+    subjectType: input.object.type,
+    objectType: input.subject.type,
+  });
+  if (!invertedShapeIsValid) return null;
+
+  return {
+    claimId: input.claimId,
+    reason: "valid_when_inverted",
+    replacement: replacementFor({
+      predicate,
+      subject: input.object,
+      object: input.subject,
+      statement: input.statement,
+    }),
+  };
+}

--- a/src/lib/claims/predicate-shapes.test.ts
+++ b/src/lib/claims/predicate-shapes.test.ts
@@ -1,0 +1,161 @@
+import {
+  assertRelationshipPredicateShape,
+  assertRelationshipPredicateShapeCoverage,
+  formatRelationshipPredicateGuide,
+  isInvalidRelationshipPredicateClaimShape,
+  isRelationshipPredicateShapeAllowed,
+} from "./predicate-shapes";
+import { describe, expect, it } from "vitest";
+
+describe("relationship predicate shapes", () => {
+  it("covers every relationship predicate", () => {
+    expect(() => assertRelationshipPredicateShapeCoverage()).not.toThrow();
+  });
+
+  it("rejects predicates whose node types do not match their domain and range", () => {
+    expect(() =>
+      assertRelationshipPredicateShape({
+        predicate: "DUE_ON",
+        subjectType: "Person",
+        objectType: "Person",
+      }),
+    ).toThrow("Invalid DUE_ON relationship shape");
+
+    expect(() =>
+      assertRelationshipPredicateShape({
+        predicate: "LOCATED_IN",
+        subjectType: "Person",
+        objectType: "Object",
+      }),
+    ).toThrow("Invalid LOCATED_IN relationship shape");
+
+    expect(() =>
+      assertRelationshipPredicateShape({
+        predicate: "EXHIBITED_EMOTION",
+        subjectType: "Person",
+        objectType: "Media",
+      }),
+    ).toThrow("Invalid EXHIBITED_EMOTION relationship shape");
+  });
+
+  it("uses active ownership direction and task assignment as separate shapes", () => {
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "OWNS",
+        subjectType: "Person",
+        objectType: "Object",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "OWNS",
+        subjectType: "Object",
+        objectType: "Person",
+      }),
+    ).toBe(false);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "ASSIGNED_TO",
+        subjectType: "Task",
+        objectType: "Person",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats formal organizations and named groups as first-class entities", () => {
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "WORKS_AT",
+        subjectType: "Person",
+        objectType: "Organization",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "AFFILIATED_WITH",
+        subjectType: "Person",
+        objectType: "Organization",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "OWNS",
+        subjectType: "Organization",
+        objectType: "Organization",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "LOCATED_IN",
+        subjectType: "Organization",
+        objectType: "Location",
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies relationship object-value rows as invalid without rejecting attributes", () => {
+    expect(
+      isInvalidRelationshipPredicateClaimShape({
+        predicate: "RELATED_TO",
+        subjectType: "Person",
+        objectType: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      isInvalidRelationshipPredicateClaimShape({
+        predicate: "HAS_PREFERENCE",
+        subjectType: "Person",
+        objectType: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("separates real-world occurrence dates from recorded bookkeeping dates", () => {
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "OCCURRED_ON",
+        subjectType: "Person",
+        objectType: "Temporal",
+      }),
+    ).toBe(false);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "RECORDED_ON",
+        subjectType: "Person",
+        objectType: "Temporal",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "RECORDED_ON",
+        subjectType: "Temporal",
+        objectType: "Temporal",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps RELATED_TO available as an explicit fallback without restoring OWNED_BY", () => {
+    expect(
+      isRelationshipPredicateShapeAllowed({
+        predicate: "RELATED_TO",
+        subjectType: "Person",
+        objectType: "Object",
+      }),
+    ).toBe(true);
+
+    const guide = formatRelationshipPredicateGuide();
+    expect(guide).toContain("RELATED_TO");
+    expect(guide).toContain("RECORDED_ON");
+    expect(guide).toContain("OWNS");
+    expect(guide).toContain("ASSIGNED_TO");
+    expect(guide).not.toContain("OWNED_BY");
+  });
+});

--- a/src/lib/claims/predicate-shapes.ts
+++ b/src/lib/claims/predicate-shapes.ts
@@ -1,0 +1,352 @@
+/** Relationship predicate domain/range rules. Common aliases: edge taxonomy, relation ontology, predicate prompt guide. */
+import {
+  NodeTypeEnum,
+  RelationshipPredicateEnum,
+  type NodeType,
+  type Predicate,
+  type RelationshipPredicate,
+} from "~/types/graph";
+
+type NodeTypeConstraint = readonly NodeType[] | "any";
+
+interface RelationshipPredicateShape<P extends RelationshipPredicate> {
+  predicate: P;
+  subjectTypes: NodeTypeConstraint;
+  objectTypes: NodeTypeConstraint;
+  meaning: string;
+  useWhen: string;
+}
+
+type RelationshipPredicateShapeMap = {
+  [P in RelationshipPredicate]: RelationshipPredicateShape<P>;
+};
+
+const EVENT_TYPES = [
+  "Event",
+  "Conversation",
+  "Document",
+  "AssistantDream",
+] as const satisfies readonly NodeType[];
+
+const ENTITY_TYPES = [
+  "Person",
+  "Organization",
+  "Location",
+  "Event",
+  "Object",
+  "Concept",
+  "Media",
+  "Feedback",
+  "Idea",
+  "Task",
+] as const satisfies readonly NodeType[];
+
+const OWNER_TYPES = [
+  "Person",
+  "Organization",
+  "Concept",
+  "Object",
+] as const satisfies readonly NodeType[];
+
+const OWNABLE_TYPES = [
+  "Organization",
+  "Location",
+  "Object",
+  "Concept",
+  "Media",
+  "Atlas",
+] as const satisfies readonly NodeType[];
+
+const WORK_OR_PRODUCT_TYPES = [
+  "Object",
+  "Concept",
+  "Media",
+  "Document",
+  "Task",
+] as const satisfies readonly NodeType[];
+
+const SEQUENCE_TYPES = [
+  "Event",
+  "Task",
+  "Temporal",
+] as const satisfies readonly NodeType[];
+
+const RECORDABLE_TYPES = [
+  "Person",
+  "Organization",
+  "Location",
+  "Event",
+  "Object",
+  "Emotion",
+  "Concept",
+  "Media",
+  "Conversation",
+  "Atlas",
+  "AssistantDream",
+  "Document",
+  "Feedback",
+  "Idea",
+  "Task",
+] as const satisfies readonly NodeType[];
+
+export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
+  PARTICIPATED_IN: {
+    predicate: "PARTICIPATED_IN",
+    subjectTypes: ["Person"],
+    objectTypes: ["Event", "Conversation"],
+    meaning: "a person took part in an event or conversation",
+    useWhen: "Use for attendance, calls, meetings, trips, classes, and other event participation.",
+  },
+  OCCURRED_AT: {
+    predicate: "OCCURRED_AT",
+    subjectTypes: EVENT_TYPES,
+    objectTypes: ["Location"],
+    meaning: "an event happened at a place",
+    useWhen: "Use only for event location, not for where a person lives or where an object belongs.",
+  },
+  OCCURRED_ON: {
+    predicate: "OCCURRED_ON",
+    subjectTypes: [...EVENT_TYPES, "Task", "Media", "Object"],
+    objectTypes: ["Temporal"],
+    meaning: "an event, content item, task, or time-anchored thing happened on a date",
+    useWhen: "Use for calendar dates. The object must be a Temporal node such as a day.",
+  },
+  RECORDED_ON: {
+    predicate: "RECORDED_ON",
+    subjectTypes: RECORDABLE_TYPES,
+    objectTypes: ["Temporal"],
+    meaning: "a node or source was recorded, ingested, observed, or created on a date",
+    useWhen:
+      "Use for graph bookkeeping dates. Do not use when the source text says an event happened; use OCCURRED_ON for real-world occurrence dates.",
+  },
+  INVOLVED_ITEM: {
+    predicate: "INVOLVED_ITEM",
+    subjectTypes: EVENT_TYPES,
+    objectTypes: ["Object", "Concept", "Media", "Location"],
+    meaning: "an event involved a notable non-person item",
+    useWhen: "Use for objects, media, tools, places, or concepts that mattered in an event.",
+  },
+  EXHIBITED_EMOTION: {
+    predicate: "EXHIBITED_EMOTION",
+    subjectTypes: ["Person"],
+    objectTypes: ["Emotion"],
+    meaning: "a person expressed or displayed an emotion",
+    useWhen: "Use only when the object is an Emotion node such as excitement, frustration, joy, or concern.",
+  },
+  TAGGED_WITH: {
+    predicate: "TAGGED_WITH",
+    subjectTypes: "any",
+    objectTypes: ["Concept"],
+    meaning: "a node has a reusable conceptual tag",
+    useWhen: "Use for durable labels or categories, not for arbitrary entities.",
+  },
+  ASSIGNED_TO: {
+    predicate: "ASSIGNED_TO",
+    subjectTypes: ["Task"],
+    objectTypes: ["Person"],
+    meaning: "a task is assigned to a responsible person",
+    useWhen:
+      "Use for commitments and tasks only. If source text says a person owns a task, model it as Task ASSIGNED_TO Person. Reassignment supersedes the prior assignee.",
+  },
+  DUE_ON: {
+    predicate: "DUE_ON",
+    subjectTypes: ["Task"],
+    objectTypes: ["Temporal"],
+    meaning: "a task is due on a date",
+    useWhen: "Use only for task deadlines. The object must be a Temporal date node.",
+  },
+  PRECEDES: {
+    predicate: "PRECEDES",
+    subjectTypes: SEQUENCE_TYPES,
+    objectTypes: SEQUENCE_TYPES,
+    meaning: "one event, task, or time node comes before another",
+    useWhen: "Use for explicit ordering or sequence claims.",
+  },
+  FOLLOWS: {
+    predicate: "FOLLOWS",
+    subjectTypes: SEQUENCE_TYPES,
+    objectTypes: SEQUENCE_TYPES,
+    meaning: "one event, task, or time node comes after another",
+    useWhen: "Use for explicit ordering or sequence claims.",
+  },
+  WORKS_AT: {
+    predicate: "WORKS_AT",
+    subjectTypes: ["Person"],
+    objectTypes: ["Organization"],
+    meaning: "a person works at an organization",
+    useWhen: "Use for employment. Model the employer as an Organization node.",
+  },
+  FOUNDED: {
+    predicate: "FOUNDED",
+    subjectTypes: ["Person"],
+    objectTypes: ["Organization", "Concept", "Object"],
+    meaning: "a person founded an organization, project, or product",
+    useWhen: "Use for founder relationships, not ordinary authorship or ownership.",
+  },
+  CREATED: {
+    predicate: "CREATED",
+    subjectTypes: ["Person", "Organization", "Concept", "Object"],
+    objectTypes: WORK_OR_PRODUCT_TYPES,
+    meaning: "an entity created a work, product, document, or artifact",
+    useWhen: "Use for authorship, building, producing, or making something.",
+  },
+  LOCATED_IN: {
+    predicate: "LOCATED_IN",
+    subjectTypes: ENTITY_TYPES,
+    objectTypes: ["Location"],
+    meaning: "an entity is located in a place",
+    useWhen: "Use only when the object is a Location node.",
+  },
+  PART_OF: {
+    predicate: "PART_OF",
+    subjectTypes: "any",
+    objectTypes: "any",
+    meaning: "one thing is a component, member, section, or period inside another",
+    useWhen: "Use for containment or composition, including time rollups such as day to week.",
+  },
+  USES: {
+    predicate: "USES",
+    subjectTypes: ENTITY_TYPES,
+    objectTypes: ["Object", "Concept", "Media"],
+    meaning: "an entity uses a tool, product, service, method, or medium",
+    useWhen: "Use for actual usage, not mere mention or viewing.",
+  },
+  OWNS: {
+    predicate: "OWNS",
+    subjectTypes: OWNER_TYPES,
+    objectTypes: OWNABLE_TYPES,
+    meaning: "an owner entity owns or possesses another thing",
+    useWhen: "Use owner-to-owned direction. Do not use for task assignment; use ASSIGNED_TO.",
+  },
+  AFFILIATED_WITH: {
+    predicate: "AFFILIATED_WITH",
+    subjectTypes: ["Person", "Organization", "Concept", "Object"],
+    objectTypes: ["Person", "Organization", "Concept", "Object"],
+    meaning: "a loose or former affiliation between entities",
+    useWhen: "Use when a more specific predicate such as WORKS_AT, FOUNDED, CREATED, or OWNS does not fit.",
+  },
+  RELATED_TO: {
+    predicate: "RELATED_TO",
+    subjectTypes: "any",
+    objectTypes: "any",
+    meaning: "a durable explicit association with no more specific predicate",
+    useWhen: "Use sparingly for meaningful associations that are not events, preferences, ownership, location, dates, employment, creation, usage, or task metadata.",
+  },
+};
+
+export class InvalidRelationshipPredicateShapeError extends Error {
+  readonly predicate: RelationshipPredicate;
+  readonly subjectType: NodeType;
+  readonly objectType: NodeType;
+
+  constructor(input: {
+    predicate: RelationshipPredicate;
+    subjectType: NodeType;
+    objectType: NodeType;
+  }) {
+    const shape = RELATIONSHIP_PREDICATE_SHAPES[input.predicate];
+    super(
+      `Invalid ${input.predicate} relationship shape: ${input.subjectType} -> ${input.objectType}; expected ${formatConstraint(shape.subjectTypes)} -> ${formatConstraint(shape.objectTypes)}`,
+    );
+    this.name = "InvalidRelationshipPredicateShapeError";
+    this.predicate = input.predicate;
+    this.subjectType = input.subjectType;
+    this.objectType = input.objectType;
+  }
+}
+
+function formatConstraint(constraint: NodeTypeConstraint): string {
+  return constraint === "any" ? "any" : constraint.join(" | ");
+}
+
+function allowsNodeType(
+  constraint: NodeTypeConstraint,
+  nodeType: NodeType,
+): boolean {
+  return constraint === "any" || constraint.includes(nodeType);
+}
+
+export function isRelationshipPredicateShapeAllowed(input: {
+  predicate: RelationshipPredicate;
+  subjectType: NodeType;
+  objectType: NodeType;
+}): boolean {
+  const shape = RELATIONSHIP_PREDICATE_SHAPES[input.predicate];
+  return (
+    allowsNodeType(shape.subjectTypes, input.subjectType) &&
+    allowsNodeType(shape.objectTypes, input.objectType)
+  );
+}
+
+export function relationshipPredicateFrom(
+  predicate: Predicate,
+): RelationshipPredicate | null {
+  const parsed = RelationshipPredicateEnum.safeParse(predicate);
+  return parsed.success ? parsed.data : null;
+}
+
+export function isInvalidRelationshipPredicateClaimShape(input: {
+  predicate: Predicate;
+  subjectType: NodeType;
+  objectType: NodeType | null;
+}): boolean {
+  const predicate = relationshipPredicateFrom(input.predicate);
+  if (predicate === null) return false;
+  if (input.objectType === null) return true;
+  return !isRelationshipPredicateShapeAllowed({
+    predicate,
+    subjectType: input.subjectType,
+    objectType: input.objectType,
+  });
+}
+
+export function assertRelationshipPredicateShape(input: {
+  predicate: RelationshipPredicate;
+  subjectType: NodeType;
+  objectType: NodeType;
+}): void {
+  if (!isRelationshipPredicateShapeAllowed(input)) {
+    throw new InvalidRelationshipPredicateShapeError(input);
+  }
+}
+
+export function formatRelationshipPredicateGuide(): string {
+  const rows = RelationshipPredicateEnum.options.map((predicate) => {
+    const shape = RELATIONSHIP_PREDICATE_SHAPES[predicate];
+    return `- ${predicate}: ${formatConstraint(shape.subjectTypes)} -> ${formatConstraint(shape.objectTypes)}. ${shape.meaning}. ${shape.useWhen}`;
+  });
+
+  return `Relationship predicate shape rules:
+${rows.join("\n")}
+
+Selection examples:
+- Bad: use DUE_ON for a person thanking another person. Good: create a concise Event for the interaction and connect participants with PARTICIPATED_IN, or omit the interaction if it is not durable.
+- Bad: use LOCATED_IN for a person liking an object. Good: use HAS_PREFERENCE with a scalar value describing the preference.
+- Bad: use EXHIBITED_EMOTION for viewing, reading, browsing, or messaging another account/person. Good: omit incidental activity, or create an Event when the activity is durable enough to remember.
+- Bad: use EXHIBITED_EMOTION for an article, document, or media item having a tone. Good: use HAS_ATTRIBUTE with a scalar tone value unless a person expressed the emotion.
+- Bad: use OCCURRED_ON to mean a person/object/concept node was created in the graph today. Good: use RECORDED_ON for bookkeeping dates, and OCCURRED_ON only for real-world events or content dates.
+- Bad: use Temporal "2026-07-01" OCCURRED_ON Event "product launch". Good: Event "product launch" OCCURRED_ON Temporal "2026-07-01".
+- Bad: Event "workshop" PARTICIPATED_IN Person "Alex". Good: Person "Alex" PARTICIPATED_IN Event "workshop".
+- Bad: Object "prototype" INVOLVED_ITEM Event "demo". Good: Event "demo" INVOLVED_ITEM Object "prototype".
+- Good: Task "send the invoice" ASSIGNED_TO Person "Alex"; Task "send the invoice" DUE_ON Temporal "2026-07-01".
+- Good: Person "Alex" OWNS Object "blue bicycle".
+- Good: Person "Alex" WORKS_AT Organization "Orchard Labs"; Organization "Orchard Labs" LOCATED_IN Location "Stockholm".
+- Good: Person "Alex" AFFILIATED_WITH Organization "Saturday Supper Club" when it is a named informal group.
+- Bad: model a company, school, client, club, or named friend group as Person, Concept, or Object. Good: use Organization.
+- Bad: model a product, app, project, document, event, or loose topic as Organization. Good: use Object, Concept, Document, Event, or Media unless the source clearly refers to the organization operating it.
+- Good RELATED_TO: an article explicitly references a comparable product, and no specific predicate above fits. Do not use RELATED_TO to avoid modeling an event, preference, ownership, date, location, or task assignment.`;
+}
+
+export function assertRelationshipPredicateShapeCoverage(): void {
+  const shapePredicates = new Set(Object.keys(RELATIONSHIP_PREDICATE_SHAPES));
+  for (const predicate of RelationshipPredicateEnum.options) {
+    if (!shapePredicates.has(predicate)) {
+      throw new Error(`Missing relationship predicate shape for ${predicate}`);
+    }
+  }
+  for (const nodeType of NodeTypeEnum.options) {
+    if (nodeType.length === 0) {
+      throw new Error("Unexpected empty node type");
+    }
+  }
+}

--- a/src/lib/claims/predicate-shapes.ts
+++ b/src/lib/claims/predicate-shapes.ts
@@ -95,27 +95,32 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     subjectTypes: ["Person"],
     objectTypes: ["Event", "Conversation"],
     meaning: "a person took part in an event or conversation",
-    useWhen: "Use for attendance, calls, meetings, trips, classes, and other event participation.",
+    useWhen:
+      "Use for attendance, calls, meetings, trips, classes, and other event participation.",
   },
   OCCURRED_AT: {
     predicate: "OCCURRED_AT",
     subjectTypes: EVENT_TYPES,
     objectTypes: ["Location"],
     meaning: "an event happened at a place",
-    useWhen: "Use only for event location, not for where a person lives or where an object belongs.",
+    useWhen:
+      "Use only for event location, not for where a person lives or where an object belongs.",
   },
   OCCURRED_ON: {
     predicate: "OCCURRED_ON",
     subjectTypes: [...EVENT_TYPES, "Task", "Media", "Object"],
     objectTypes: ["Temporal"],
-    meaning: "an event, content item, task, or time-anchored thing happened on a date",
-    useWhen: "Use for calendar dates. The object must be a Temporal node such as a day.",
+    meaning:
+      "an event, content item, task, or time-anchored thing happened on a date",
+    useWhen:
+      "Use for calendar dates. The object must be a Temporal node such as a day.",
   },
   RECORDED_ON: {
     predicate: "RECORDED_ON",
     subjectTypes: RECORDABLE_TYPES,
     objectTypes: ["Temporal"],
-    meaning: "a node or source was recorded, ingested, observed, or created on a date",
+    meaning:
+      "a node or source was recorded, ingested, observed, or created on a date",
     useWhen:
       "Use for graph bookkeeping dates. Do not use when the source text says an event happened; use OCCURRED_ON for real-world occurrence dates.",
   },
@@ -124,21 +129,24 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     subjectTypes: EVENT_TYPES,
     objectTypes: ["Object", "Concept", "Media", "Location"],
     meaning: "an event involved a notable non-person item",
-    useWhen: "Use for objects, media, tools, places, or concepts that mattered in an event.",
+    useWhen:
+      "Use for objects, media, tools, places, or concepts that mattered in an event.",
   },
   EXHIBITED_EMOTION: {
     predicate: "EXHIBITED_EMOTION",
     subjectTypes: ["Person"],
     objectTypes: ["Emotion"],
     meaning: "a person expressed or displayed an emotion",
-    useWhen: "Use only when the object is an Emotion node such as excitement, frustration, joy, or concern.",
+    useWhen:
+      "Use only when the object is an Emotion node such as excitement, frustration, joy, or concern.",
   },
   TAGGED_WITH: {
     predicate: "TAGGED_WITH",
     subjectTypes: "any",
     objectTypes: ["Concept"],
     meaning: "a node has a reusable conceptual tag",
-    useWhen: "Use for durable labels or categories, not for arbitrary entities.",
+    useWhen:
+      "Use for durable labels or categories, not for arbitrary entities.",
   },
   ASSIGNED_TO: {
     predicate: "ASSIGNED_TO",
@@ -153,7 +161,8 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     subjectTypes: ["Task"],
     objectTypes: ["Temporal"],
     meaning: "a task is due on a date",
-    useWhen: "Use only for task deadlines. The object must be a Temporal date node.",
+    useWhen:
+      "Use only for task deadlines. The object must be a Temporal date node.",
   },
   PRECEDES: {
     predicate: "PRECEDES",
@@ -181,7 +190,8 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     subjectTypes: ["Person"],
     objectTypes: ["Organization", "Concept", "Object"],
     meaning: "a person founded an organization, project, or product",
-    useWhen: "Use for founder relationships, not ordinary authorship or ownership.",
+    useWhen:
+      "Use for founder relationships, not ordinary authorship or ownership.",
   },
   CREATED: {
     predicate: "CREATED",
@@ -201,8 +211,10 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     predicate: "PART_OF",
     subjectTypes: "any",
     objectTypes: "any",
-    meaning: "one thing is a component, member, section, or period inside another",
-    useWhen: "Use for containment or composition, including time rollups such as day to week.",
+    meaning:
+      "one thing is a component, member, section, or period inside another",
+    useWhen:
+      "Use for containment or composition, including time rollups such as day to week.",
   },
   USES: {
     predicate: "USES",
@@ -216,21 +228,24 @@ export const RELATIONSHIP_PREDICATE_SHAPES: RelationshipPredicateShapeMap = {
     subjectTypes: OWNER_TYPES,
     objectTypes: OWNABLE_TYPES,
     meaning: "an owner entity owns or possesses another thing",
-    useWhen: "Use owner-to-owned direction. Do not use for task assignment; use ASSIGNED_TO.",
+    useWhen:
+      "Use owner-to-owned direction. Do not use for task assignment; use ASSIGNED_TO.",
   },
   AFFILIATED_WITH: {
     predicate: "AFFILIATED_WITH",
     subjectTypes: ["Person", "Organization", "Concept", "Object"],
     objectTypes: ["Person", "Organization", "Concept", "Object"],
     meaning: "a loose or former affiliation between entities",
-    useWhen: "Use when a more specific predicate such as WORKS_AT, FOUNDED, CREATED, or OWNS does not fit.",
+    useWhen:
+      "Use when a more specific predicate such as WORKS_AT, FOUNDED, CREATED, or OWNS does not fit.",
   },
   RELATED_TO: {
     predicate: "RELATED_TO",
     subjectTypes: "any",
     objectTypes: "any",
     meaning: "a durable explicit association with no more specific predicate",
-    useWhen: "Use sparingly for meaningful associations that are not events, preferences, ownership, location, dates, employment, creation, usage, or task metadata.",
+    useWhen:
+      "Use sparingly for meaningful associations that are not events, preferences, ownership, location, dates, employment, creation, usage, or task metadata.",
   },
 };
 

--- a/src/lib/commitment-curation.test.ts
+++ b/src/lib/commitment-curation.test.ts
@@ -193,7 +193,7 @@ describeIfServer("commitment curation", () => {
          ) VALUES
            ($1, $9, $5, NULL, 'pending', 'HAS_TASK_STATUS', 'Confirmed task is pending.', $8, 'personal', 'user', '2026-06-01T10:00:00Z', 'active'),
            ($2, $9, $6, NULL, 'pending', 'HAS_TASK_STATUS', 'Inferred task is pending.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:00:00Z', 'active'),
-           ($3, $9, $6, $7, NULL, 'OWNED_BY', 'Inferred task owned by Marcel.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:01:00Z', 'active'),
+           ($3, $9, $6, $7, NULL, 'ASSIGNED_TO', 'Inferred task owned by Marcel.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:01:00Z', 'active'),
            ($4, $9, $6, $10, NULL, 'DUE_ON', 'Inferred task due on 2026-08-01.', $8, 'personal', 'assistant_inferred', '2026-06-01T11:02:00Z', 'active')`,
         [
           newTypeId("claim"),
@@ -280,7 +280,7 @@ describeIfServer("commitment curation", () => {
            "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
          ) VALUES
            ($1, $6, $4, NULL, 'pending', 'HAS_TASK_STATUS', 'Inferred task is pending.', $5, 'personal', 'assistant_inferred', '2026-06-01T10:00:00Z', 'active'),
-           ($2, $6, $4, $7, NULL, 'OWNED_BY', 'Marcel owns inferred task.', $5, 'personal', 'user', '2026-06-02T10:00:00Z', 'active'),
+           ($2, $6, $4, $7, NULL, 'ASSIGNED_TO', 'Marcel owns inferred task.', $5, 'personal', 'user', '2026-06-02T10:00:00Z', 'active'),
            ($3, $6, $4, $8, NULL, 'DUE_ON', 'Inferred task due on 2026-09-09.', $5, 'personal', 'user', '2026-06-02T10:01:00Z', 'active')`,
         [
           newTypeId("claim"),

--- a/src/lib/commitments.test.ts
+++ b/src/lib/commitments.test.ts
@@ -571,7 +571,7 @@ describeIfServer("setCommitmentOwner", () => {
     await admin.end();
   });
 
-  it("assigns an owner and then reassigns, superseding the prior OWNED_BY", async () => {
+  it("assigns an owner and then reassigns, superseding the prior ASSIGNED_TO", async () => {
     const userId = "user_set_owner_reassign";
     const ownerANodeId = newTypeId("node");
     const ownerBNodeId = newTypeId("node");
@@ -633,7 +633,7 @@ describeIfServer("setCommitmentOwner", () => {
         expect(assignResult.claimId).toBeTruthy();
         const firstOwnerClaimId = assignResult.claimId!;
 
-        // Reassign to owner B — should supersede the previous OWNED_BY
+        // Reassign to owner B — should supersede the previous ASSIGNED_TO
         const reassignResult = await setCommitmentOwner(
           setCommitmentOwnerRequestSchema.parse({
             userId,
@@ -648,7 +648,7 @@ describeIfServer("setCommitmentOwner", () => {
         expect(reassignResult.claimId).toBeTruthy();
         expect(reassignResult.claimId).not.toBe(firstOwnerClaimId);
 
-        // Prior OWNED_BY claim must be superseded
+        // Prior ASSIGNED_TO claim must be superseded
         const { rows } = await client.query(
           `SELECT status FROM claims WHERE id = $1`,
           [firstOwnerClaimId],
@@ -664,7 +664,7 @@ describeIfServer("setCommitmentOwner", () => {
     }
   });
 
-  it("clears an owner (ownedBy: null) retracts active OWNED_BY and returns retractedClaimIds", async () => {
+  it("clears an owner (ownedBy: null) retracts active ASSIGNED_TO and returns retractedClaimIds", async () => {
     const userId = "user_set_owner_clear";
     const ownerNodeId = newTypeId("node");
 
@@ -720,7 +720,7 @@ describeIfServer("setCommitmentOwner", () => {
         expect(clearResult.claimId).toBeNull();
         expect(clearResult.retractedClaimIds).toContain(ownerClaimId);
 
-        // The OWNED_BY claim must now be retracted
+        // The ASSIGNED_TO claim must now be retracted
         const { rows } = await client.query(
           `SELECT status FROM claims WHERE id = $1`,
           [ownerClaimId],

--- a/src/lib/commitments.ts
+++ b/src/lib/commitments.ts
@@ -195,7 +195,7 @@ export async function setCommitmentDue(
  * `initialClaims`: a mandatory `HAS_TASK_STATUS` (so the task is never
  * observable without a status), plus an optional `DUE_ON` — resolving the
  * canonical Temporal node via {@link ensureDayNode} — and an optional
- * `OWNED_BY`. Because `createNode` rolls the node back if any claim fails, a
+ * `ASSIGNED_TO`. Because `createNode` rolls the node back if any claim fails, a
  * bad `ownedBy` leaves nothing behind.
  *
  * Always creates a new Task; callers wanting to advance an existing task's
@@ -217,7 +217,7 @@ export async function createCommitment(
   } = input;
   const db = await useDatabase();
 
-  // Resolve the owner up-front: it yields a natural-language OWNED_BY statement
+  // Resolve the owner up-front: it yields a natural-language ASSIGNED_TO statement
   // and lets the response echo the same `{ nodeId, label }` shape as the
   // open-commitments view. Existence is enforced here (createClaim re-checks)
   // so a bad owner fails before any node is written.
@@ -233,7 +233,7 @@ export async function createCommitment(
     ownerLabel = ownerRow.label ?? null;
   }
 
-  // HAS_TASK_STATUS first so its claim id is index 0; DUE_ON and OWNED_BY are
+  // HAS_TASK_STATUS first so its claim id is index 0; DUE_ON and ASSIGNED_TO are
   // appended only when supplied, and their positions are captured so we can map
   // createNode's ordered `initialClaimIds` back onto the response.
   const initialClaims: CreateNodeInitialClaimInput[] = [
@@ -270,10 +270,10 @@ export async function createCommitment(
   if (ownedBy !== undefined) {
     ownerIndex =
       initialClaims.push({
-        predicate: "OWNED_BY",
+        predicate: "ASSIGNED_TO",
         statement: ownerLabel
-          ? `${label} is owned by ${ownerLabel}.`
-          : `${label} is owned by a referenced entity.`,
+          ? `${label} is assigned to ${ownerLabel}.`
+          : `${label} is assigned to a referenced entity.`,
         objectNodeId: ownedBy,
         assertedByKind,
       }) - 1;
@@ -471,9 +471,9 @@ export async function setCommitmentStatus(
  *
  * - `ownedBy: TypeId<"node">` → resolve the owner node's label (throwing
  *   {@link NodesNotFoundError} if missing/cross-user) and assert a new
- *   `OWNED_BY` claim. The predicate-policy override for `Task` subjects
- *   supersedes any prior active `OWNED_BY` claim automatically.
- * - `ownedBy: null` → retract every active `OWNED_BY` claim on the task. No new
+ *   `ASSIGNED_TO` claim. The predicate policy supersedes any prior active
+ *   `ASSIGNED_TO` claim automatically.
+ * - `ownedBy: null` → retract every active `ASSIGNED_TO` claim on the task. No new
  *   claim is asserted.
  *
  * Throws {@link TaskNotFoundError} if the subject isn't a Task owned by the
@@ -495,7 +495,7 @@ export async function setCommitmentOwner(
         and(
           eq(claims.userId, userId),
           eq(claims.subjectNodeId, taskId),
-          eq(claims.predicate, "OWNED_BY"),
+          eq(claims.predicate, "ASSIGNED_TO"),
           eq(claims.status, "active"),
         ),
       );
@@ -525,10 +525,10 @@ export async function setCommitmentOwner(
   const created = await createClaim({
     userId,
     subjectNodeId: taskId,
-    predicate: "OWNED_BY",
+    predicate: "ASSIGNED_TO",
     statement: ownerLabel
-      ? `Task is owned by ${ownerLabel}.`
-      : `Task is owned by a referenced entity.`,
+      ? `Task is assigned to ${ownerLabel}.`
+      : `Task is assigned to a referenced entity.`,
     objectNodeId: ownedBy,
     description: note,
     assertedByKind,

--- a/src/lib/context/cache.ts
+++ b/src/lib/context/cache.ts
@@ -9,26 +9,72 @@
  * Mirrors `deep-research-cache.ts` ergonomics. Common aliases: bootstrap
  * cache, context bundle cache, read-model cache.
  */
-import { redisConnection } from "../queues";
 import { contextBundleSchema, type ContextBundle } from "./types";
+import { shouldSkipJobEnqueue } from "~/utils/test-overrides";
 
 const CONTEXT_BUNDLE_PREFIX = "context-bundle:";
 const TTL_SECONDS = 6 * 60 * 60;
 
+interface ContextCacheClient {
+  get(key: string): Promise<string | null>;
+  set(
+    key: string,
+    value: string,
+    expiryMode: "EX",
+    ttlSeconds: number,
+  ): Promise<unknown>;
+  del(key: string): Promise<unknown>;
+}
+
+const inMemoryCache = new Map<string, { value: string; expiresAt: number }>();
+
+const inMemoryCacheClient: ContextCacheClient = {
+  async get(key) {
+    const entry = inMemoryCache.get(key);
+    if (entry === undefined) return null;
+    if (entry.expiresAt <= Date.now()) {
+      inMemoryCache.delete(key);
+      return null;
+    }
+    return entry.value;
+  },
+  async set(key, value, _expiryMode, ttlSeconds) {
+    inMemoryCache.set(key, {
+      value,
+      expiresAt: Date.now() + ttlSeconds * 1000,
+    });
+  },
+  async del(key) {
+    inMemoryCache.delete(key);
+  },
+};
+
 function buildKey(userId: string): string {
   return `${CONTEXT_BUNDLE_PREFIX}${userId}`;
+}
+
+async function getCacheClient(): Promise<ContextCacheClient> {
+  if (shouldSkipJobEnqueue()) return inMemoryCacheClient;
+  const { redisConnection } = await import("../queues");
+  return {
+    get: (key) => redisConnection.get(key),
+    set: (key, value, expiryMode, ttlSeconds) =>
+      redisConnection.set(key, value, expiryMode, ttlSeconds),
+    del: (key) => redisConnection.del(key),
+  };
 }
 
 export async function getCachedBundle(
   userId: string,
 ): Promise<ContextBundle | null> {
   try {
-    const data = await redisConnection.get(buildKey(userId));
+    const client = await getCacheClient();
+    const data = await client.get(buildKey(userId));
     if (!data) return null;
     const parsed = contextBundleSchema.safeParse(JSON.parse(data));
     if (!parsed.success) {
       // Stale payload shape — drop it so the next call rebuilds cleanly.
-      await redisConnection.del(buildKey(userId));
+      await client.del(buildKey(userId));
       return null;
     }
     return parsed.data;
@@ -43,7 +89,8 @@ export async function setCachedBundle(
   bundle: ContextBundle,
 ): Promise<void> {
   try {
-    await redisConnection.set(
+    const client = await getCacheClient();
+    await client.set(
       buildKey(userId),
       JSON.stringify(bundle),
       "EX",
@@ -56,7 +103,8 @@ export async function setCachedBundle(
 
 export async function invalidateCachedBundle(userId: string): Promise<void> {
   try {
-    await redisConnection.del(buildKey(userId));
+    const client = await getCacheClient();
+    await client.del(buildKey(userId));
   } catch (error) {
     console.error("Failed to invalidate cached context bundle:", error);
   }

--- a/src/lib/context/node-card-types.ts
+++ b/src/lib/context/node-card-types.ts
@@ -23,7 +23,7 @@ import { typeIdSchema } from "~/types/typeid.js";
 /**
  * Active `single_current_value` attribute claim about the node, plus any
  * relationship claim whose policy resolves to single_current_value for the
- * subject's type (e.g. OWNED_BY on a Task). Either an `objectValue` (attribute)
+ * subject's type (e.g. ASSIGNED_TO on a Task). Either an `objectValue` (attribute)
  * or an `objectNodeId` + resolved `objectLabel` (relationship) is set; the
  * other column is null. The `(predicate, subjectType)` policy gate happens in
  * `node-card.ts`.

--- a/src/lib/context/node-card.test.ts
+++ b/src/lib/context/node-card.test.ts
@@ -314,28 +314,28 @@ describeIfServer("getNodeCard", () => {
         statedAt: new Date("2026-04-22T10:00:00Z"),
         status: "active",
       },
-      // OWNED_BY relationship: project owned by Marcel (multi_value on Concept).
+      // OWNS relationship: Marcel owns the project.
       {
         id: newTypeId("claim"),
         userId,
-        subjectNodeId: projectId,
-        objectNodeId: personId,
-        predicate: "OWNED_BY",
-        statement: "Memory Layer is owned by Marcel.",
+        subjectNodeId: personId,
+        objectNodeId: projectId,
+        predicate: "OWNS",
+        statement: "Marcel owns Memory Layer.",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
         statedAt: new Date("2026-04-15T10:00:00Z"),
         status: "active",
       },
-      // Open commitment: Task owned by Marcel, status pending.
+      // Open commitment: Task assigned to Marcel, status pending.
       {
         id: newTypeId("claim"),
         userId,
         subjectNodeId: taskId,
         objectNodeId: personId,
-        predicate: "OWNED_BY",
-        statement: "Task is owned by Marcel.",
+        predicate: "ASSIGNED_TO",
+        statement: "Task is assigned to Marcel.",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
@@ -447,7 +447,7 @@ describeIfServer("getNodeCard", () => {
     expect(card.openCommitments).toBeUndefined();
   });
 
-  it("Non-Person node: openCommitments stays undefined even with related OWNED_BY commitments", async () => {
+  it("Non-Person node: openCommitments stays undefined even with related ASSIGNED_TO commitments", async () => {
     await freshSchema();
     const userId = "user_concept_card";
     const conceptId = newTypeId("node");
@@ -459,14 +459,14 @@ describeIfServer("getNodeCard", () => {
     await insertNode(taskId, userId, "Task", "Subtask");
 
     await database.insert(schema.claims).values([
-      // Task's owner is the Concept (unusual but exercises the filter).
+      // Task's assignee is the Concept (unusual but exercises the filter).
       {
         id: newTypeId("claim"),
         userId,
         subjectNodeId: taskId,
         objectNodeId: conceptId,
-        predicate: "OWNED_BY",
-        statement: "Subtask owned by Big Project.",
+        predicate: "ASSIGNED_TO",
+        statement: "Subtask assigned to Big Project.",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
@@ -495,13 +495,15 @@ describeIfServer("getNodeCard", () => {
     expect(card.openCommitments).toBeUndefined();
   });
 
-  it("Subject-type cardinality routing: OWNED_BY is multi_value on Concept, single on Task", async () => {
+  it("Predicate routing: OWNS is multi_value and ASSIGNED_TO is single-current", async () => {
     await freshSchema();
     const userId = "user_routing";
     const conceptId = newTypeId("node");
     const taskId = newTypeId("node");
     const owner1 = newTypeId("node");
     const owner2 = newTypeId("node");
+    const owned1 = newTypeId("node");
+    const owned2 = newTypeId("node");
     const sourceId = newTypeId("source");
     await insertUser(userId);
     await insertPersonalSource(sourceId, userId, "msg_routing");
@@ -510,16 +512,18 @@ describeIfServer("getNodeCard", () => {
     await insertNode(taskId, userId, "Task", "Single-owner Task");
     await insertNode(owner1, userId, "Person", "Alice");
     await insertNode(owner2, userId, "Person", "Bob");
+    await insertNode(owned1, userId, "Object", "Laptop");
+    await insertNode(owned2, userId, "Object", "Notebook");
 
     await database.insert(schema.claims).values([
-      // Concept has TWO active OWNED_BY (multi_value) — both stay active.
+      // Concept has TWO active OWNS claims (multi_value) — both stay active.
       {
         id: newTypeId("claim"),
         userId,
         subjectNodeId: conceptId,
-        objectNodeId: owner1,
-        predicate: "OWNED_BY",
-        statement: "Shared Initiative owned by Alice.",
+        objectNodeId: owned1,
+        predicate: "OWNS",
+        statement: "Shared Initiative owns Laptop.",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
@@ -530,24 +534,24 @@ describeIfServer("getNodeCard", () => {
         id: newTypeId("claim"),
         userId,
         subjectNodeId: conceptId,
-        objectNodeId: owner2,
-        predicate: "OWNED_BY",
-        statement: "Shared Initiative owned by Bob.",
+        objectNodeId: owned2,
+        predicate: "OWNS",
+        statement: "Shared Initiative owns Notebook.",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
         statedAt: new Date("2026-04-12T10:00:00Z"),
         status: "active",
       },
-      // Task has TWO OWNED_BY: lifecycle would have superseded the older one.
+      // Task has TWO ASSIGNED_TO claims: lifecycle would have superseded the older one.
       // We emulate the post-lifecycle state directly.
       {
         id: newTypeId("claim"),
         userId,
         subjectNodeId: taskId,
         objectNodeId: owner1,
-        predicate: "OWNED_BY",
-        statement: "Task owned by Alice (older).",
+        predicate: "ASSIGNED_TO",
+        statement: "Task assigned to Alice (older).",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
@@ -559,8 +563,8 @@ describeIfServer("getNodeCard", () => {
         userId,
         subjectNodeId: taskId,
         objectNodeId: owner2,
-        predicate: "OWNED_BY",
-        statement: "Task owned by Bob (latest).",
+        predicate: "ASSIGNED_TO",
+        statement: "Task assigned to Bob (latest).",
         sourceId,
         scope: "personal",
         assertedByKind: "user",
@@ -571,25 +575,25 @@ describeIfServer("getNodeCard", () => {
 
     const { getNodeCard } = await import("./node-card");
 
-    // Concept card: both OWNED_BY claims are active and surface in recentEvidence.
+    // Concept card: both OWNS claims are active and surface in recentEvidence.
     const conceptCard = await getNodeCard({ userId, nodeId: conceptId });
     expect(conceptCard).not.toBeNull();
     if (!conceptCard) throw new Error("expected concept card");
-    // Multi_value OWNED_BY → not in currentFacts.
+    // Multi_value OWNS → not in currentFacts.
     expect(conceptCard.currentFacts).toEqual([]);
-    // Both OWNED_BY claims appear in recentEvidence.
+    // Both OWNS claims appear in recentEvidence.
     const conceptStatements = conceptCard.recentEvidence.map(
       (e) => e.statement,
     );
-    expect(conceptStatements).toContain("Shared Initiative owned by Alice.");
-    expect(conceptStatements).toContain("Shared Initiative owned by Bob.");
+    expect(conceptStatements).toContain("Shared Initiative owns Laptop.");
+    expect(conceptStatements).toContain("Shared Initiative owns Notebook.");
 
     // Task card: single-current-value override → currentFacts has exactly one (latest).
     const taskCard = await getNodeCard({ userId, nodeId: taskId });
     expect(taskCard).not.toBeNull();
     if (!taskCard) throw new Error("expected task card");
     expect(taskCard.currentFacts.length).toBe(1);
-    expect(taskCard.currentFacts[0]?.predicate).toBe("OWNED_BY");
+    expect(taskCard.currentFacts[0]?.predicate).toBe("ASSIGNED_TO");
     expect(taskCard.currentFacts[0]?.objectNodeId).toBe(owner2);
     expect(taskCard.currentFacts[0]?.objectLabel).toBe("Bob");
   });

--- a/src/lib/context/node-card.ts
+++ b/src/lib/context/node-card.ts
@@ -574,7 +574,7 @@ export async function getNodeCards(
 
 /**
  * Per-Person open-commitments fetch. `getOpenCommitments` already queries the
- * subset of claims under HAS_TASK_STATUS / OWNED_BY / DUE_ON; running it in
+ * subset of claims under HAS_TASK_STATUS / ASSIGNED_TO / DUE_ON; running it in
  * parallel for the small subset of Person ids in a card batch is the simplest
  * shape until the read-model pipeline lands a true batch query.
  */

--- a/src/lib/extract-graph.test.ts
+++ b/src/lib/extract-graph.test.ts
@@ -209,7 +209,7 @@ describeIfServer("extractGraph claim-native insertion", () => {
                           {
                             subjectId: "existing_person_1",
                             objectId: "project_1",
-                            predicate: "TAGGED_WITH",
+                            predicate: "RELATED_TO",
                             statement: "Alice discussed Project Falcon.",
                             sourceRef: "msg_1",
                             assertionKind: "user",
@@ -353,6 +353,15 @@ describeIfServer("extractGraph claim-native insertion", () => {
       expect(prompt).toContain(
         "- sourceRef: msg_1; statedAt: 2026-04-25T10:00:00.000Z",
       );
+      expect(prompt).toContain("Relationship predicate shape rules:");
+      expect(prompt).toContain("- ASSIGNED_TO:");
+      expect(prompt).toContain("- OWNS:");
+      expect(prompt).toContain("- RECORDED_ON:");
+      expect(prompt).toContain("Organization");
+      expect(prompt).toContain("named informal groups");
+      expect(prompt).toContain("Do not emit RECORDED_ON");
+      expect(prompt).not.toContain("LIVES_IN");
+      expect(prompt).not.toContain("OWNED_BY");
       expect(prompt).not.toContain("- msg_1 (2026-04-25T10:00:00.000Z)");
       expect(warnings).toContain(
         "Skipping claim with invalid sourceRef: missing_msg",

--- a/src/lib/extract-graph.ts
+++ b/src/lib/extract-graph.ts
@@ -6,6 +6,10 @@ import {
   defaultTaskStatusStatement,
 } from "./claims/default-task-status";
 import { applyClaimLifecycle, fetchClaimsByIds } from "./claims/lifecycle";
+import {
+  assertRelationshipPredicateShape,
+  formatRelationshipPredicateGuide,
+} from "./claims/predicate-shapes";
 import { coerceTaskStatus } from "./claims/task-status";
 import {
   generateCommitmentPresentation,
@@ -261,6 +265,7 @@ export async function extractGraph({
   const client = await createCompletionClient(userId, {
     task: "graph_extraction",
   });
+  const relationshipPredicateGuide = formatRelationshipPredicateGuide();
 
   // Static instruction block. Depends only on `sourceType` (and whether a
   // speaker map is present), so it is byte-identical across every ingest of
@@ -319,11 +324,11 @@ ${
 - "Orchard is based in Stockholm and uses a billing system built on the Stripe API." → (Orchard Labs, LOCATED_IN, Stockholm) and (Orchard Labs, USES, Stripe API).
 - "The Starter tier costs €49/month." → do NOT create a "€49" node; if the figure matters use (Starter tier, HAS_ATTRIBUTE, "€49/month"). Use RELATED_TO only when no specific predicate fits.`
     : speakerMap && speakerMap.size > 0
-      ? `- Speaker "Alice" (user-self) says "I live in Lisbon." → create the (LIVES_IN, Lisbon) claim with subjectId set to Alice's nodeId from "Speakers in this transcript" (do NOT mint a new "Alice" node), assertionKind: "user", assertedBySpeakerLabel: "Alice".
+      ? `- Speaker "Alice" (user-self) says "I live in Lisbon." → create the (Alice, LOCATED_IN, Lisbon) claim with subjectId set to Alice's nodeId from "Speakers in this transcript" (do NOT mint a new "Alice" node), assertionKind: "user", assertedBySpeakerLabel: "Alice".
 - Speaker "Bob" (non user-self) says "I'll send the PR tomorrow." → assertionKind: "participant", assertedBySpeakerLabel: "Bob".
-- Speaker "Bob" says "You're moving to Paris next month." Speaker "Alice" (user-self) replies "Yeah." → for the (Alice, LIVES_IN, Paris) claim use assertionKind: "user_confirmed", assertedBySpeakerLabel: "Alice".`
+- Speaker "Bob" says "You're moving to Paris next month." Speaker "Alice" (user-self) replies "Yeah." → for the (Alice, LOCATED_IN, Paris) claim use assertionKind: "user_confirmed", assertedBySpeakerLabel: "Alice".`
       : `- User says "I started working at Acme last week." → assertionKind: "user".
-- Assistant: "So you live in Paris now?" User: "Yes." → assertionKind: "user_confirmed" for the (user, LIVES_IN, Paris) claim (if extracted).
+- Assistant: "So you live in Paris now?" User: "Yes." → assertionKind: "user_confirmed" for the (user, LOCATED_IN, Paris) claim (if extracted).
 - Assistant: "It sounds like you might be a software engineer." User does not respond. → do NOT extract. If you must, assertionKind: "assistant_inferred".`
 }
 
@@ -332,24 +337,26 @@ ${
     ? `Extract, for example, the following elements:
 1. People mentioned in the text (real or fictional)
 2. Locations the text discusses or references
-3. Events the text describes or analyzes
-4. Objects, products, services, or items the text references
-5. Concepts, theories, frameworks, or ideas the text explores
-6. Other media the text cites (books, articles, studies, podcasts, etc.)
-7. Temporal references the text provides (dates, periods, deadlines)
-8. Recommendations, decisions, best practices, and warnings the text states
-9. Facts the text states about people, organizations, or other entities`
+3. Organizations the text mentions, including companies, institutions, clients, schools, nonprofits, teams, clubs, communities, and named informal groups
+4. Events the text describes or analyzes
+5. Objects, products, services, or items the text references
+6. Concepts, theories, frameworks, or ideas the text explores
+7. Other media the text cites (books, articles, studies, podcasts, etc.)
+8. Temporal references the text provides (dates, periods, deadlines)
+9. Recommendations, decisions, best practices, and warnings the text states
+10. Facts the text states about people, organizations, or other entities`
     : `Extract, for example, the following elements:
 1. People mentioned by the user (real or fictional)
-2. Locations the user discussed or mentioned
-3. Events that the user stated occurred or experienced
-4. Objects or items the user mentioned as significant
-5. Emotions the user expressed or discussed
-6. Concepts or ideas the user explored or mentioned
-7. Media the user mentioned (books, movies, articles, etc.)
-8. Temporal references the user provided (dates, times, periods)
-9. The user's preferences, goals, projects, and plans
-10. Facts the user stated about other people or entities`
+2. Organizations the user mentioned, including companies, institutions, clients, schools, nonprofits, teams, clubs, communities, and named informal groups
+3. Locations the user discussed or mentioned
+4. Events that the user stated occurred or experienced
+5. Objects or items the user mentioned as significant
+6. Emotions the user expressed or discussed
+7. Concepts or ideas the user explored or mentioned
+8. Media the user mentioned (books, movies, articles, etc.)
+9. Temporal references the user provided (dates, times, periods)
+10. The user's preferences, goals, projects, and plans
+11. Facts the user stated about other people or entities`
 }
 
 For each element, create a node with:
@@ -362,7 +369,9 @@ For each element, create a node with:
 	- Claims represent sourced facts about nodes. For example, if you have a Person node and an Event node, create a claim from the Person node to the Event node with predicate PARTICIPATED_IN.
 	- Relationship claims use objectId and a relationship predicate.
 	- Attribute claims use objectValue and an attribute predicate, such as HAS_STATUS, HAS_PREFERENCE, HAS_GOAL, MADE_DECISION, or HAS_ATTRIBUTE (a generic property whose value goes in objectValue).
-	- Use the MOST SPECIFIC predicate that fits; RELATED_TO is a fallback ONLY when no other predicate applies. For world/document facts use, e.g., WORKS_AT (person→organization), FOUNDED (founder→organization), CREATED (creator→work or product), LOCATED_IN (entity→place), PART_OF (component→larger whole), USES (entity→tool/product/service), AFFILIATED_WITH (looser or former affiliation, e.g. a previous employer or investor), OWNED_BY, or PARTICIPATED_IN.
+	- Use the MOST SPECIFIC predicate that fits; RELATED_TO is a fallback ONLY when no other predicate applies.
+	- The relationship predicate table below is mandatory. Do not emit a relationship claim unless its subject and object node types match the table.
+	- Do not emit RECORDED_ON for ordinary source content. Ingestion attaches bookkeeping dates automatically; use OCCURRED_ON only when the text says a real event/content/task happened on a date.
 	- For a notable scalar property of an entity, prefer a HAS_ATTRIBUTE attribute claim (value in objectValue) over creating a node for the value.
 	- ONLY create claims for facts explicitly stated by the ${sourceType === "document" ? "document text" : "user"}, not your own interpretations or assumptions.
 	- In the claim statement, write one concise sentence that can stand alone as the sourced assertion.
@@ -386,12 +395,16 @@ Rules of the graph:
 - If multiple people could share a name, use the most specific distinguishing label available (e.g. a full name) and NEVER merge or conflate two different people who share a first name.
 - Omit unnecessary details in node names, eg. "John Doe" instead of "John Doe (person)"
 - Nodes are independent of context and represent a *single* thing. Bad example: "John - the person taking a walk". Good example: "John" (Person node, no description) linked to [PARTICIPATED_IN] "John's walk on 2025-05-18" (Event node), linked to [OCCURRED_ON] "2025-05-18" (Temporal node).
+- Use Organization for companies, employers, clients, schools, nonprofits, teams, clubs, communities, and named informal groups. Do not model those as Person, Concept, or Object.
+- Products, apps, projects, documents, events, and loose topics are usually Object, Concept, Document, Event, or Media, not Organization, unless the source clearly refers to the organization operating them.
 - Don't create nodes for things that should be represented by edges.
 - NEVER create a node for a scalar value, quantity, duration, money amount, percentage, count, or date range (e.g. "47 days", "€49", "38 employees", "six months"). Put it in the claim statement, or in a HAS_ATTRIBUTE attribute claim's objectValue when the value is worth keeping. Nodes are only for entities you can refer to again: people, organizations, places, products/works, events, media, and genuine concepts.
 - Temporal nodes are ONLY for specific calendar points (a day or date the content anchors to), never durations or periods ("six months", "two weeks").
 - Avoid redundant or duplicate information - if a fact is already represented, don't create another node or edge for it
 
 	Then create relationshipClaims and attributeClaims to represent the facts using the appropriate predicates.
+
+${relationshipPredicateGuide}
 
 ${
   sourceType === "document"
@@ -805,7 +818,7 @@ function _formatOpenCommitmentsSection(
   const header = `CURRENT OPEN TASKS:
 These are the user's currently open Task nodes. Each line lists the task's existing nodeId, label, current status, owner, and due date. RULES:
 - If the source mentions completing, abandoning, or progressing one of these tasks, emit an attribute claim with predicate \`HAS_TASK_STATUS\` (objectValue one of "pending", "in_progress", "done", "abandoned") whose subjectId is the task's existingNodeId shown below. DO NOT create a new Task node for it.
-- Only emit \`HAS_TASK_STATUS\`, \`OWNED_BY\`, or \`DUE_ON\` claims for these existing tasks if their status, owner, or due date has actually changed in the source. Tasks whose state is unchanged should NOT be re-emitted.
+- Only emit \`HAS_TASK_STATUS\`, \`ASSIGNED_TO\`, or \`DUE_ON\` claims for these existing tasks if their status, owner, or due date has actually changed in the source. Tasks whose state is unchanged should NOT be re-emitted.
 - A "task" is a concrete, actionable item a specific person still has to DO. Only create one when the source establishes a real action item with a clear owner.
 - DO NOT manufacture tasks from any of the following:
   - assistant suggestions, proposals, offers, or recommendations the user did not take up (e.g. "you could try…", "maybe set up a…", "we should…", "want me to…");
@@ -813,7 +826,7 @@ These are the user's currently open Task nodes. Each line lists the task's exist
   - general planning, brainstorming, venting, or discussion the user did not commit to acting on;
   - the existence of the conversation itself — NEVER create a "check-in", "weekly planning", "review", or similar meta task that merely restates that this conversation took place.
 - A Task node's label must be a short imperative action (e.g. "Book Zouk social tickets"), NOT a topic, a date, or a description of the conversation. NEVER put a multi-point summary, recap, or transcript of the conversation into a Task node's label or description.
-- For a genuine brand-new task not in this list, create a new Task node with a temporary id (e.g. "temp_task_1") and emit \`HAS_TASK_STATUS=pending\` (and \`OWNED_BY\` / \`DUE_ON\` as applicable). Every newly created task is recorded as TENTATIVE (unconfirmed) and surfaced to the user to confirm — ingestion never creates a firm commitment, and the \`assertionKind\` you put on a new task's status claim does not change that. Do NOT lower the bar above just because the task will be tentative: still only create one when the source establishes a real action item.`;
+- For a genuine brand-new task not in this list, create a new Task node with a temporary id (e.g. "temp_task_1") and emit \`HAS_TASK_STATUS=pending\` (and \`ASSIGNED_TO\` / \`DUE_ON\` as applicable). Every newly created task is recorded as TENTATIVE (unconfirmed) and surfaced to the user to confirm — ingestion never creates a firm commitment, and the \`assertionKind\` you put on a new task's status claim does not change that. Do NOT lower the bar above just because the task will be tentative: still only create one when the source establishes a real action item.`;
 
   if (openCommitments.length === 0) {
     return `${header}
@@ -914,6 +927,22 @@ async function _fetchSourceScope(
   // Source must exist by the time extraction runs; default defensively to
   // personal so we never silently widen scope on a misconfigured source.
   return row?.scope ?? "personal";
+}
+
+async function _fetchNodeTypeMap(
+  db: DrizzleDB,
+  userId: string,
+  nodeIds: TypeId<"node">[],
+): Promise<Map<TypeId<"node">, NodeType>> {
+  const uniqueNodeIds = [...new Set(nodeIds)];
+  if (uniqueNodeIds.length === 0) return new Map();
+
+  const nodeRows = await db
+    .select({ id: nodes.id, nodeType: nodes.nodeType })
+    .from(nodes)
+    .where(and(eq(nodes.userId, userId), inArray(nodes.id, uniqueNodeIds)));
+
+  return new Map(nodeRows.map((node) => [node.id, node.nodeType]));
 }
 
 async function _processAndInsertNewNodes(
@@ -1030,6 +1059,16 @@ async function _processAndInsertLlmClaims(
     userId,
     [...sourceRefMap.values()].map((sourceRef) => sourceRef.sourceId),
   );
+  const relationshipNodeIds = new Set<TypeId<"node">>();
+  for (const llmClaim of uniqueParsedLlmClaims) {
+    const subjectNodeId = idMap.get(llmClaim.subjectId);
+    const objectNodeId = idMap.get(llmClaim.objectId);
+    if (subjectNodeId) relationshipNodeIds.add(subjectNodeId);
+    if (objectNodeId) relationshipNodeIds.add(objectNodeId);
+  }
+  const nodeTypes = await _fetchNodeTypeMap(db, userId, [
+    ...relationshipNodeIds,
+  ]);
 
   for (const llmClaim of uniqueParsedLlmClaims) {
     const subjectNodeId = idMap.get(llmClaim.subjectId);
@@ -1065,6 +1104,27 @@ async function _processAndInsertLlmClaims(
 
     const provenance = _resolveAssertedByKind(llmClaim, sourceType, speakerMap);
     if (provenance === null) continue;
+
+    const subjectType = nodeTypes.get(subjectNodeId);
+    const objectType = nodeTypes.get(objectNodeId);
+    if (!subjectType || !objectType) {
+      console.warn(
+        `Skipping relationship claim with unresolved node types: ${llmClaim.subjectId} -> ${llmClaim.objectId}`,
+      );
+      continue;
+    }
+
+    try {
+      assertRelationshipPredicateShape({
+        predicate: llmClaim.predicate,
+        subjectType,
+        objectType,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Skipping invalid relationship claim shape: ${message}`);
+      continue;
+    }
 
     claimInserts.push({
       userId,

--- a/src/lib/graph.test.ts
+++ b/src/lib/graph.test.ts
@@ -203,7 +203,7 @@ describeIfServer("graph claim operations", () => {
             "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status"
           )
           VALUES
-            ($1, $11, $6, $7, NULL, 'OWNED_BY', 'Alice owns a MacBook Pro.', $10, 'personal', 'user', now(), 'active'),
+            ($1, $11, $6, $7, NULL, 'OWNS', 'Alice owns a MacBook Pro.', $10, 'personal', 'user', now(), 'active'),
             ($2, $11, $6, $8, NULL, 'TAGGED_WITH', 'Alice was tagged with Hidden Item.', $10, 'personal', 'user', now(), 'retracted'),
             ($3, $11, $6, NULL, 'busy', 'HAS_STATUS', 'Alice is busy.', $10, 'personal', 'user', now(), 'active'),
             ($4, $11, $6, $9, NULL, 'RELATED_TO', 'Alice is related to a reference item.', $12, 'reference', 'document_author', now(), 'active'),
@@ -233,7 +233,7 @@ describeIfServer("graph claim operations", () => {
       expect(oneHopNodes[0]).toMatchObject({
         id: laptopNodeId,
         label: "MacBook Pro",
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Alice owns a MacBook Pro.",
         claimSubjectId: aliceNodeId,
         claimObjectId: laptopNodeId,
@@ -411,7 +411,7 @@ describeIfServer("graph claim operations", () => {
             "asserted_by_kind", "stated_at", "status"
           )
           VALUES
-            ($1, $8, $4, $5, 'OWNED_BY', 'Alice owns a MacBook Pro.', $6, 'personal', 'user', now(), 'active'),
+            ($1, $8, $4, $5, 'OWNS', 'Alice owns a MacBook Pro.', $6, 'personal', 'user', now(), 'active'),
             ($2, $8, $4, $5, 'RELATED_TO', 'Alice is related to reference content.', $7, 'reference', 'document_author', now(), 'active'),
             ($3, $8, $4, $5, 'TAGGED_WITH', 'Assistant inferred this relation.', $6, 'personal', 'assistant_inferred', now(), 'active')
         `,

--- a/src/lib/identity-resolution.test.ts
+++ b/src/lib/identity-resolution.test.ts
@@ -509,7 +509,7 @@ describeIfServer("resolveIdentity", () => {
           decoyNodeId,
         ],
       );
-      // matchNode has user-asserted profile: HAS_GOAL=ship-q4, OWNED_BY→colleague.
+      // matchNode has user-asserted profile: HAS_GOAL=ship-q4, OWNS→colleague.
       // decoyNode has the same shape, but only as `assistant_inferred`, so it
       // must NOT contribute to profile compatibility.
       const matchClaim1 = newTypeId("claim");
@@ -522,9 +522,9 @@ describeIfServer("resolveIdentity", () => {
             "predicate","statement","source_id","scope","asserted_by_kind","stated_at","status")
            VALUES
              ($1,$5,$6,NULL,'ship-q4','HAS_GOAL','match goal',$7,'personal','user',now(),'active'),
-             ($2,$5,$6,$8,NULL,'OWNED_BY','match owns colleague',$7,'personal','user',now(),'active'),
+             ($2,$5,$6,$8,NULL,'OWNS','match owns colleague',$7,'personal','user',now(),'active'),
              ($3,$5,$9,NULL,'ship-q4','HAS_GOAL','decoy goal',$7,'personal','assistant_inferred',now(),'active'),
-             ($4,$5,$9,$8,NULL,'OWNED_BY','decoy owns colleague',$7,'personal','assistant_inferred',now(),'active')`,
+             ($4,$5,$9,$8,NULL,'OWNS','decoy owns colleague',$7,'personal','assistant_inferred',now(),'active')`,
         [
           matchClaim1,
           matchClaim2,
@@ -555,7 +555,7 @@ describeIfServer("resolveIdentity", () => {
               assertedByKind: "user",
             },
             {
-              predicate: "OWNED_BY",
+              predicate: "OWNS",
               objectNodeId: colleagueNodeId,
               assertedByKind: "user",
             },

--- a/src/lib/ingestion/ensure-source-node.test.ts
+++ b/src/lib/ingestion/ensure-source-node.test.ts
@@ -1,0 +1,184 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as schema from "~/db/schema";
+import { newTypeId } from "~/types/typeid";
+
+const TEST_DB_HOST = process.env["TEST_PG_HOST"] ?? "localhost";
+const TEST_DB_PORT = Number(process.env["TEST_PG_PORT"] ?? 5431);
+const TEST_DB_USER = process.env["TEST_PG_USER"] ?? "postgres";
+const TEST_DB_PASSWORD = process.env["TEST_PG_PASSWORD"] ?? "postgres";
+const TEST_DB_ADMIN_DB = process.env["TEST_PG_ADMIN_DB"] ?? "postgres";
+
+const adminDsn = () =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${TEST_DB_ADMIN_DB}`;
+
+const dsnFor = (dbName: string) =>
+  `postgres://${TEST_DB_USER}:${TEST_DB_PASSWORD}@${TEST_DB_HOST}:${TEST_DB_PORT}/${dbName}`;
+
+async function isServerReachable(): Promise<boolean> {
+  const client = new Client({ connectionString: adminDsn() });
+  try {
+    await client.connect();
+    await client.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SERVER_AVAILABLE = await isServerReachable();
+const describeIfServer = SERVER_AVAILABLE ? describe : describe.skip;
+
+describeIfServer("ensureSourceNode", () => {
+  const dbName = `memory_source_node_test_${Date.now()}_${Math.floor(
+    Math.random() * 1e6,
+  )}`;
+
+  beforeAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+    await admin.end();
+  });
+
+  afterAll(async () => {
+    const admin = new Client({ connectionString: adminDsn() });
+    await admin.connect();
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [dbName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await admin.end();
+  });
+
+  it("links source bookkeeping dates with RECORDED_ON", async () => {
+    const userId = "user_source_recorded_on";
+    const sourceId = newTypeId("source");
+    const timestamp = new Date("2026-06-19T08:00:00.000Z");
+
+    const client = new Client({ connectionString: dsnFor(dbName) });
+    await client.connect();
+    const db = drizzle(client, { schema, casing: "snake_case" });
+
+    vi.resetModules();
+    vi.doMock("~/lib/embeddings", () => ({
+      generateEmbeddings: async () => ({
+        data: [{ embedding: Array.from({ length: 1024 }, () => 0) }],
+        usage: { total_tokens: 0 },
+      }),
+    }));
+    const { resetTestOverrides, setSkipEmbeddingPersistence } = await import(
+      "~/utils/test-overrides"
+    );
+    setSkipEmbeddingPersistence(true);
+
+    try {
+      await client.query(`
+        CREATE TABLE "users" ("id" text PRIMARY KEY NOT NULL);
+        CREATE TABLE "nodes" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "node_type" varchar(50) NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "node_metadata" (
+          "id" text PRIMARY KEY NOT NULL,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "label" text,
+          "canonical_label" text,
+          "description" text,
+          "additional_data" jsonb,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "sources" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "type" varchar(50) NOT NULL,
+          "external_id" text NOT NULL,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "status" varchar(20) DEFAULT 'completed',
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "source_links" (
+          "id" text PRIMARY KEY NOT NULL,
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "specific_location" text,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL
+        );
+        CREATE TABLE "claims" (
+          "id" text PRIMARY KEY NOT NULL,
+          "user_id" text NOT NULL REFERENCES "users"("id"),
+          "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+          "object_value" text,
+          "predicate" varchar(80) NOT NULL,
+          "statement" text NOT NULL,
+          "description" text,
+          "metadata" jsonb,
+          "object_instant" timestamp with time zone,
+          "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+          "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+          "asserted_by_kind" varchar(24) NOT NULL,
+          "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+          "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+          "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+          "stated_at" timestamp with time zone NOT NULL,
+          "valid_from" timestamp with time zone,
+          "valid_to" timestamp with time zone,
+          "status" varchar(30) DEFAULT 'active' NOT NULL,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "claims_object_shape_xor_ck"
+            CHECK (num_nonnulls("object_node_id", "object_value") = 1)
+        );
+      `);
+      await client.query(`INSERT INTO "users" ("id") VALUES ($1)`, [userId]);
+      await client.query(
+        `INSERT INTO "sources" ("id", "user_id", "type", "external_id", "status")
+           VALUES ($1, $2, 'document', 'doc:source-recorded-on', 'completed')`,
+        [sourceId, userId],
+      );
+
+      const { ensureSourceNode } = await import("./ensure-source-node");
+      const nodeId = await ensureSourceNode({
+        db,
+        userId,
+        sourceId,
+        timestamp,
+        nodeType: "Document",
+      });
+
+      const rows = await client.query<{
+        predicate: string;
+        subject_node_id: string;
+        object_type: string;
+        object_label: string;
+      }>(
+        `SELECT c."predicate", c."subject_node_id", n."node_type" AS "object_type", m."label" AS "object_label"
+         FROM "claims" c
+         INNER JOIN "nodes" n ON n."id" = c."object_node_id"
+         INNER JOIN "node_metadata" m ON m."node_id" = n."id"
+         WHERE c."user_id" = $1 AND c."subject_node_id" = $2`,
+        [userId, nodeId],
+      );
+
+      expect(rows.rows).toEqual([
+        {
+          predicate: "RECORDED_ON",
+          subject_node_id: nodeId,
+          object_type: "Temporal",
+          object_label: "2026-06-19",
+        },
+      ]);
+    } finally {
+      resetTestOverrides();
+      vi.doUnmock("~/lib/embeddings");
+      vi.resetModules();
+      await client.end();
+    }
+  });
+});

--- a/src/lib/ingestion/ensure-source-node.ts
+++ b/src/lib/ingestion/ensure-source-node.ts
@@ -79,14 +79,14 @@ export async function ensureSourceNode({
       );
     }
 
-    // Link to day node with a sourced relationship claim.
+    // Link to day node with a sourced bookkeeping relationship claim.
     const dayNodeId = await ensureDayNode(db, userId, timestamp);
     await db.insert(claims).values({
       userId,
-      predicate: "OCCURRED_ON",
+      predicate: "RECORDED_ON",
       subjectNodeId: newNode.id,
       objectNodeId: dayNodeId,
-      statement: `${nodeType} source occurred on ${timestamp.toISOString().slice(0, 10)}`,
+      statement: `${nodeType} source recorded on ${timestamp.toISOString().slice(0, 10)}`,
       sourceId,
       scope: "personal",
       assertedByKind: "system",

--- a/src/lib/ingestion/insert-new-sources.ts
+++ b/src/lib/ingestion/insert-new-sources.ts
@@ -3,7 +3,10 @@ import { sources } from "~/db/schema";
 import { sourceService, type SourceCreateInput } from "~/lib/sources";
 import { Scope, SourceType } from "~/types/graph";
 import { TypeId } from "~/types/typeid";
-import { getSourceServiceOverride } from "~/utils/test-overrides";
+import {
+  getSourceServiceOverride,
+  shouldSkipJobEnqueue,
+} from "~/utils/test-overrides";
 
 export interface SourceInput {
   externalId: string;
@@ -101,19 +104,21 @@ export async function insertNewSources(params: {
   }));
 
   // Best-effort, fire-and-forget container titling. Guarded inside the job, so
-  // enqueuing unconditionally is safe and idempotent. Dynamic import avoids a
-  // queues ⇄ ingestion import cycle.
-  const { batchQueue } = await import("../queues");
-  await batchQueue.add(
-    "generate-source-title",
-    { userId, sourceId: parentSource.id },
-    {
-      attempts: 2,
-      backoff: { type: "exponential", delay: 1_000 },
-      removeOnComplete: true,
-      removeOnFail: 20,
-    },
-  );
+  // enqueuing is safe and idempotent. Eval/probe runs set skipJobEnqueue so
+  // they do not import queues or let title generation consume LLM stubs.
+  if (!shouldSkipJobEnqueue()) {
+    const { batchQueue } = await import("../queues");
+    await batchQueue.add(
+      "generate-source-title",
+      { userId, sourceId: parentSource.id },
+      {
+        attempts: 2,
+        backoff: { type: "exponential", delay: 1_000 },
+        removeOnComplete: true,
+        removeOnFail: 20,
+      },
+    );
+  }
 
   return { sourceId: parentSource.id, newSourceSourceIds, sourceRefs };
 }

--- a/src/lib/jobs/cleanup-graph.test.ts
+++ b/src/lib/jobs/cleanup-graph.test.ts
@@ -46,8 +46,8 @@ function makeTempSubgraph(): TempSubgraph {
       {
         id: newTypeId("node"),
         tempId: "temp_node_1",
-        label: "Marcel",
-        description: "User",
+        label: "Ada",
+        description: "Example person",
         type: "Person",
         evidenceClaimCount: 2,
         sourceLinkCount: 1,
@@ -72,22 +72,24 @@ function makeTempSubgraph(): TempSubgraph {
         subjectTemp: "temp_node_1",
         objectTemp: "temp_node_2",
         predicate: "RELATED_TO",
-        statement: "Marcel lives in Antwerp.",
+        statement: "Ada lives in Antwerp.",
         scope: "personal",
         assertedByKind: "user",
         retractAllowed: false,
         contradictionCitationAllowed: true,
+        invalidRelationshipShape: false,
       },
       {
         id: claimAssistantInferred,
         subjectTemp: "temp_node_1",
         objectTemp: "temp_node_2",
         predicate: "OCCURRED_AT",
-        statement: "Marcel visited Antwerp last weekend.",
+        statement: "Ada visited Antwerp last weekend.",
         scope: "personal",
         assertedByKind: "assistant_inferred",
         retractAllowed: true,
         contradictionCitationAllowed: false,
+        invalidRelationshipShape: true,
       },
     ],
   };
@@ -119,6 +121,7 @@ describe("buildCleanupPrompt", () => {
     expect(prompt).toContain(`provenance="[assistant_inferred, personal]"`);
     expect(prompt).toContain(`provenance="[user, personal]"`);
     expect(prompt).toContain(`retractAllowed="true"`);
+    expect(prompt).toContain(`invalidRelationshipShape="true"`);
     expect(prompt).toContain(`contradictionCitationAllowed="true"`);
     expect(prompt).toContain(`id="${inferred.id}"`);
     expect(prompt).toContain(`id="${userClaim.id}"`);
@@ -135,6 +138,8 @@ describe("buildCleanupPrompt", () => {
     expect(prompt).toContain("<eligible_delete_nodes>");
     expect(prompt).toContain("(none)");
     expect(prompt).toContain("<eligible_retract_claims>");
+    expect(prompt).toContain(`- ${inferred.id}`);
+    expect(prompt).toContain("<invalid_relationship_claims>");
     expect(prompt).toContain(`- ${inferred.id}`);
     expect(prompt).toContain("<eligible_contradiction_citations>");
     expect(prompt).toContain(`- ${userClaim.id}`);
@@ -167,6 +172,7 @@ describe("buildCleanupPrompt", () => {
     expect(prompt).toContain("Return at most 10 operations");
     expect(prompt).toContain("Absence from the bundle is NEVER sufficient");
     expect(prompt).toContain("ACTIVE, same-scope, source-backed claim");
+    expect(prompt).toContain("relationship shape is impossible");
   });
 
   it("emits provider-compatible JSON Schema for the cleanup operations", () => {
@@ -190,7 +196,7 @@ describe("buildCleanupPrompt", () => {
 
     expect(prompt).toContain("<subgraph>");
     expect(prompt).toContain('<node tempId="temp_node_1"');
-    expect(prompt).toContain("Marcel lives in Antwerp.");
+    expect(prompt).toContain("Ada lives in Antwerp.");
   });
 
   it("omits the bundle wrapper when no sections are present", () => {

--- a/src/lib/jobs/cleanup-graph.ts
+++ b/src/lib/jobs/cleanup-graph.ts
@@ -11,6 +11,10 @@
  * cleanup pipeline, cleanup prompt builder.
  */
 import { createCompletionClient, parseStructuredCompletion } from "../ai";
+import {
+  formatRelationshipPredicateGuide,
+  isInvalidRelationshipPredicateClaimShape,
+} from "../claims/predicate-shapes";
 import { getConversationBootstrapContext } from "../context/assemble-bootstrap-context";
 import type { ContextBundle } from "../context/types";
 import { generateAndInsertNodeEmbeddings } from "../embeddings-util";
@@ -96,6 +100,7 @@ export interface GraphClaim {
   assertedByKind: AssertedByKind;
   retractAllowed: boolean;
   contradictionCitationAllowed: boolean;
+  invalidRelationshipShape: boolean;
 }
 export interface Subgraph {
   nodes: GraphNode[];
@@ -119,6 +124,7 @@ export interface TempClaim {
   assertedByKind: AssertedByKind;
   retractAllowed: boolean;
   contradictionCitationAllowed: boolean;
+  invalidRelationshipShape: boolean;
 }
 export interface TempSubgraph {
   nodes: TempNode[];
@@ -339,11 +345,14 @@ async function fetchNodeEvidenceCounts(
 async function fetchSubgraphClaims(
   db: DrizzleDB,
   userId: string,
-  nodeIds: readonly TypeId<"node">[],
+  graphNodes: readonly GraphNode[],
   limit: number,
 ): Promise<GraphClaim[]> {
-  const uniqueNodeIds = [...new Set(nodeIds)];
+  const uniqueNodeIds = [...new Set(graphNodes.map((node) => node.id))];
   if (uniqueNodeIds.length === 0) return [];
+  const nodeTypesById = new Map(
+    graphNodes.map((node) => [node.id, node.type]),
+  );
 
   const rows = await db
     .select({
@@ -371,15 +380,31 @@ async function fetchSubgraphClaims(
     .orderBy(desc(claims.createdAt), desc(claims.id))
     .limit(limit);
 
-  return rows.map((claim) => ({
-    ...claim,
-    retractAllowed: claim.assertedByKind === "assistant_inferred",
-    contradictionCitationAllowed:
-      claim.assertedByKind === "user" ||
-      claim.assertedByKind === "user_confirmed" ||
-      claim.assertedByKind === "participant" ||
-      claim.assertedByKind === "document_author",
-  }));
+  return rows.map((claim) => {
+    const subjectType = nodeTypesById.get(claim.subject);
+    const objectType =
+      claim.object === null ? null : (nodeTypesById.get(claim.object) ?? null);
+    const invalidRelationshipShape =
+      subjectType === undefined
+        ? false
+        : isInvalidRelationshipPredicateClaimShape({
+            predicate: claim.predicate,
+            subjectType,
+            objectType,
+          });
+    return {
+      ...claim,
+      retractAllowed:
+        claim.assertedByKind === "assistant_inferred" ||
+        invalidRelationshipShape,
+      contradictionCitationAllowed:
+        claim.assertedByKind === "user" ||
+        claim.assertedByKind === "user_confirmed" ||
+        claim.assertedByKind === "participant" ||
+        claim.assertedByKind === "document_author",
+      invalidRelationshipShape,
+    };
+  });
 }
 
 /**
@@ -481,7 +506,7 @@ async function buildSubgraph(
   const claimsArr = await fetchSubgraphClaims(
     db,
     userId,
-    nodesArr.map((node) => node.id),
+    nodesArr,
     maxClaims,
   );
   return { nodes: nodesArr, claims: claimsArr };
@@ -513,6 +538,7 @@ function toTempSubgraph(sub: Subgraph): {
       assertedByKind: claim.assertedByKind,
       retractAllowed: claim.retractAllowed,
       contradictionCitationAllowed: claim.contradictionCitationAllowed,
+      invalidRelationshipShape: claim.invalidRelationshipShape,
     };
     if (tgt) tempClaim.objectTemp = mapper.getId(tgt)!;
     if (claim.objectValue !== null) tempClaim.objectValue = claim.objectValue;
@@ -561,7 +587,7 @@ export function buildCleanupPrompt(
         claim.objectTemp !== undefined
           ? ` object="${claim.objectTemp}"`
           : ` objectValue="${claim.objectValue ?? ""}"`;
-      return `<claim id="${claim.id}" subject="${claim.subjectTemp}"${objectAttr} predicate="${claim.predicate}" provenance="[${claim.assertedByKind}, ${claim.scope}]" retractAllowed="${claim.retractAllowed.toString()}" contradictionCitationAllowed="${claim.contradictionCitationAllowed.toString()}">${claim.statement}</claim>`;
+      return `<claim id="${claim.id}" subject="${claim.subjectTemp}"${objectAttr} predicate="${claim.predicate}" provenance="[${claim.assertedByKind}, ${claim.scope}]" retractAllowed="${claim.retractAllowed.toString()}" contradictionCitationAllowed="${claim.contradictionCitationAllowed.toString()}" invalidRelationshipShape="${claim.invalidRelationshipShape.toString()}">${claim.statement}</claim>`;
     })
     .join("\n");
   const deleteTargets = temp.nodes
@@ -572,11 +598,16 @@ export function buildCleanupPrompt(
     .filter((claim) => claim.retractAllowed)
     .map((claim) => `- ${claim.id}`)
     .join("\n");
+  const invalidRelationshipTargets = temp.claims
+    .filter((claim) => claim.invalidRelationshipShape)
+    .map((claim) => `- ${claim.id}`)
+    .join("\n");
   const contradictionCitationTargets = temp.claims
     .filter((claim) => claim.contradictionCitationAllowed)
     .map((claim) => `- ${claim.id}`)
     .join("\n");
   const bundleText = renderBundleSections(bundle);
+  const relationshipPredicateGuide = formatRelationshipPredicateGuide();
 
   return `You are a graph cleaning assistant. Your task is to analyze this claim subgraph and propose cleanup operations to ensure accuracy, remove redundancies, and reconcile contradictions.
 
@@ -584,7 +615,7 @@ Output a single JSON object \`{ "operations": [...] }\` matching the cleanup ope
 
 - \`merge_nodes { keepTempId, removeTempIds }\` — collapse duplicates / aliases. Prefer this over \`delete_node\` whenever two nodes plausibly represent the same entity.
 - \`delete_node { tempId }\` — only for nodes explicitly listed under \`eligible_delete_nodes\` below. If that list is empty, do not emit \`delete_node\`.
-- \`retract_claim { claimId, reason }\` — only for claims explicitly listed under \`eligible_retract_claims\` below. If that list is empty, do not emit \`retract_claim\`.
+- \`retract_claim { claimId, reason }\` — only for claims explicitly listed under \`eligible_retract_claims\` below. This includes uncorroborated assistant-inferred claims and relationship claims whose predicate/type shape is impossible. If that list is empty, do not emit \`retract_claim\`.
 - \`contradict_claim { claimId, contradictedByClaimId, reason }\` — citation REQUIRED. Use only when another ACTIVE, same-scope, source-backed claim already in this subgraph contradicts the original. \`contradictedByClaimId\` must be listed under \`eligible_contradiction_citations\` below.
 - \`promote_assertion { claimId, corroboratingSourceId, reason }\` — when an \`assistant_inferred\` claim is corroborated by a user-attributed source visible in the bundle (i.e., bundle evidence cites a claim with the same fact, attributed to \`user\` or \`user_confirmed\`). The corroborating source id is the \`sourceId\` field on that bundle evidence row.
 - \`add_claim { subjectTempId, objectTempId, objectValue, predicate, statement, sourceClaimId }\` — system-authored. Provide exactly ONE of \`objectTempId\` / \`objectValue\` and set the other to null. Use SPARINGLY and only for facts directly inferrable from the subgraph (e.g., a transitive relation visible in two existing claims). When at all possible, set \`sourceClaimId\` to the real \`clm_*\` id from the subgraph so scope is inherited correctly (use null only when no claim applies). Never invent facts not grounded in the subgraph.
@@ -598,12 +629,16 @@ ID rules:
 Cleaning rules:
 1. **The bundle is not the full memory.** It is high-signal current context, not a complete evidence set. Absence from the bundle is NEVER sufficient reason to retract or contradict a sourced claim.
 2. **Reconcile against explicit contradictions.** Claims that directly contradict a specific claim visible in this subgraph should be \`contradict_claim\` with that cited claim id. Atlas / open_commitments / preferences guide cleanup, but they are not standalone citations.
-3. **Provenance gates retraction.** A claim with \`provenance=[assistant_inferred, …]\` and no corroboration in the bundle or in adjacent claims is the only valid \`retract_claim\` target. Do NOT retract claims with \`provenance=[user, …]\`, \`[user_confirmed, …]\`, \`[participant, …]\`, \`[document_author, …]\`, or \`[system, …]\`.
+3. **Provenance gates retraction.** A claim with \`provenance=[assistant_inferred, …]\` and no corroboration in the bundle or in adjacent claims is a valid \`retract_claim\` target. Claims listed under \`invalid_relationship_claims\` are the narrow exception: the relationship shape is impossible under the predicate table, so they may be retracted even when source-attributed. Do NOT retract any other claim with \`provenance=[user, …]\`, \`[user_confirmed, …]\`, \`[participant, …]\`, \`[document_author, …]\`, or \`[system, …]\`.
 4. **Promote, don't duplicate.** When the bundle's evidence shows a \`user\`/\`user_confirmed\` claim that says the same thing as an \`assistant_inferred\` subgraph claim, emit \`promote_assertion\` rather than \`add_claim\`.
 5. **Prefer \`merge_nodes\` over \`delete_node\`.** If two nodes plausibly refer to the same entity (similar labels, overlapping aliases, compatible types), merge. NEVER merge record / occurrence nodes — \`Task\`, \`Event\`, \`Idea\`, \`Document\`, \`Conversation\`, \`AssistantDream\`, \`Feedback\`, \`Atlas\` — even when their labels match exactly: these legitimately recur with the same name (e.g. a task created for each day, a weekly standup event) and represent distinct instances. Only merge nominal entities (\`Person\`, \`Location\`, \`Object\`, \`Emotion\`, \`Concept\`, \`Media\`, \`Temporal\`).
 6. **No fabricated facts.** Never \`add_claim\` something that isn't already inferrable from the subgraph + bundle. System-authored claims must cite a \`sourceClaimId\` whenever possible.
 7. **Idempotence.** Don't add a claim that duplicates an existing relationship visible in the subgraph.
 8. **Action flags are hard gates.** Do not emit an operation when its target is not in the matching eligible list below. These lists already account for hidden attribute claims, participant provenance, source links, and aliases that may not be otherwise obvious in the subgraph.
+9. **Predicate shapes are hard gates.** Any \`add_claim\` relationship must obey the predicate shape table below. If the available nodes do not match a specific predicate, either choose a valid predicate, create the missing Event node first, use an attribute claim with \`objectValue\`, or emit no operation.
+10. **Repair invalid relationships.** Prioritize claims listed under \`invalid_relationship_claims\`. When the statement supports a valid replacement, emit the valid replacement first, then \`retract_claim\` the invalid relationship. For brief interactions or moments, create a concise Event only when the event itself is durable enough to remember; otherwise retract the invalid relationship without inventing a replacement. Use \`RELATED_TO\` only when the statement expresses a durable association and no specific predicate fits.
+
+${relationshipPredicateGuide}
 
 <eligible_targets>
 <eligible_delete_nodes>
@@ -612,6 +647,9 @@ ${deleteTargets || "(none)"}
 <eligible_retract_claims>
 ${retractTargets || "(none)"}
 </eligible_retract_claims>
+<invalid_relationship_claims>
+${invalidRelationshipTargets || "(none)"}
+</invalid_relationship_claims>
 <eligible_contradiction_citations>
 ${contradictionCitationTargets || "(none)"}
 </eligible_contradiction_citations>

--- a/src/lib/jobs/cleanup-graph.ts
+++ b/src/lib/jobs/cleanup-graph.ts
@@ -350,9 +350,7 @@ async function fetchSubgraphClaims(
 ): Promise<GraphClaim[]> {
   const uniqueNodeIds = [...new Set(graphNodes.map((node) => node.id))];
   if (uniqueNodeIds.length === 0) return [];
-  const nodeTypesById = new Map(
-    graphNodes.map((node) => [node.id, node.type]),
-  );
+  const nodeTypesById = new Map(graphNodes.map((node) => [node.id, node.type]));
 
   const rows = await db
     .select({
@@ -503,12 +501,7 @@ async function buildSubgraph(
         counts.aliasCount === 0,
     };
   });
-  const claimsArr = await fetchSubgraphClaims(
-    db,
-    userId,
-    nodesArr,
-    maxClaims,
-  );
+  const claimsArr = await fetchSubgraphClaims(db, userId, nodesArr, maxClaims);
   return { nodes: nodesArr, claims: claimsArr };
 }
 

--- a/src/lib/jobs/cleanup-operations.test.ts
+++ b/src/lib/jobs/cleanup-operations.test.ts
@@ -389,10 +389,10 @@ describeIfServer("cleanup operation helpers", () => {
       id: claimId,
       userId,
       subjectNodeId: subjectId,
-      predicate: "RELATED_TO",
-      statement: "Legacy topic related to another migrated concept.",
+      predicate: "HAS_ATTRIBUTE",
+      statement: "Legacy topic came from imported memory.",
       sourceId,
-      objectValue: "another migrated concept",
+      objectValue: "imported memory",
       assertedByKind: "user",
     });
 
@@ -420,6 +420,144 @@ describeIfServer("cleanup operation helpers", () => {
       [claimId],
     );
     expect(after.rows[0]?.status).toBe("active");
+  });
+
+  it("retract_claim allows sourced relationship claims whose predicate shape is impossible", async () => {
+    const userId = "user_retract_invalid_shape";
+    const personId = newTypeId("node");
+    const objectId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    const claimId = newTypeId("claim");
+
+    await seedUserAndNodes(rootClient, userId, [
+      { id: personId, nodeType: "Person", label: "Ada" },
+      { id: objectId, nodeType: "Object", label: "desk lamp" },
+    ]);
+    await seedSource(rootClient, {
+      sourceId,
+      userId,
+      type: "conversation_message",
+      externalId: "msg:user_retract_invalid_shape",
+      scope: "personal",
+    });
+    await seedClaim(rootClient, {
+      id: claimId,
+      userId,
+      subjectNodeId: personId,
+      objectNodeId: objectId,
+      predicate: "LOCATED_IN",
+      statement: "Ada likes the desk lamp.",
+      sourceId,
+      assertedByKind: "user",
+    });
+
+    const { applyCleanupOperations } = await import("./cleanup-operations");
+    const result = await applyCleanupOperations(
+      database,
+      userId,
+      [
+        {
+          kind: "retract_claim",
+          claimId,
+          reason: "relationship shape is impossible: Person LOCATED_IN Object",
+        },
+      ],
+      buildMapper([]),
+    );
+
+    expect(result.applied).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const after = await rootClient.query<{ status: string }>(
+      `SELECT "status" FROM "claims" WHERE "id" = $1`,
+      [claimId],
+    );
+    expect(after.rows[0]?.status).toBe("retracted");
+  });
+
+  it("audits invalid relationship predicate shapes by count and example", async () => {
+    const userId = "user_audit_invalid_shapes";
+    const personId = newTypeId("node");
+    const objectId = newTypeId("node");
+    const taskId = newTypeId("node");
+    const temporalId = newTypeId("node");
+    const sourceId = newTypeId("source");
+    const invalidLocationClaimId = newTypeId("claim");
+    const invalidDueClaimId = newTypeId("claim");
+    const validDueClaimId = newTypeId("claim");
+
+    await seedUserAndNodes(rootClient, userId, [
+      { id: personId, nodeType: "Person", label: "Ada" },
+      { id: objectId, nodeType: "Object", label: "desk lamp" },
+      { id: taskId, nodeType: "Task", label: "Send the note" },
+      { id: temporalId, nodeType: "Temporal", label: "2026-07-01" },
+    ]);
+    await seedSource(rootClient, {
+      sourceId,
+      userId,
+      type: "conversation_message",
+      externalId: "msg:user_audit_invalid_shapes",
+      scope: "personal",
+    });
+    await seedClaim(rootClient, {
+      id: invalidLocationClaimId,
+      userId,
+      subjectNodeId: personId,
+      objectNodeId: objectId,
+      predicate: "LOCATED_IN",
+      statement: "Ada likes the desk lamp.",
+      sourceId,
+      assertedByKind: "user",
+    });
+    await seedClaim(rootClient, {
+      id: invalidDueClaimId,
+      userId,
+      subjectNodeId: personId,
+      objectNodeId: temporalId,
+      predicate: "DUE_ON",
+      statement: "Ada mentioned July 1.",
+      sourceId,
+      assertedByKind: "user",
+    });
+    await seedClaim(rootClient, {
+      id: validDueClaimId,
+      userId,
+      subjectNodeId: taskId,
+      objectNodeId: temporalId,
+      predicate: "DUE_ON",
+      statement: "Send the note is due on 2026-07-01.",
+      sourceId,
+      assertedByKind: "user",
+    });
+
+    const { auditInvalidRelationshipPredicateShapes } = await import(
+      "~/lib/claims/predicate-shape-audit"
+    );
+    const audit = await auditInvalidRelationshipPredicateShapes(
+      database,
+      userId,
+      { exampleLimit: 5 },
+    );
+
+    expect(audit.totalInvalid).toBe(2);
+    expect(audit.counts).toContainEqual({
+      predicate: "LOCATED_IN",
+      count: 1,
+    });
+    expect(audit.counts).toContainEqual({ predicate: "DUE_ON", count: 1 });
+    expect(audit.examples.map((example) => example.claimId)).toContain(
+      invalidLocationClaimId,
+    );
+    expect(audit.examples.map((example) => example.claimId)).toContain(
+      invalidDueClaimId,
+    );
+    expect(audit.examples.map((example) => example.claimId)).not.toContain(
+      validDueClaimId,
+    );
+    expect(audit.seedNodeIds).toContain(personId);
+    expect(audit.seedNodeIds).toContain(objectId);
+    expect(audit.seedNodeIds).toContain(temporalId);
+    expect(audit.seedNodeIds).not.toContain(taskId);
   });
 
   it("contradict_claim sets contradicted_by_claim_id and status", async () => {

--- a/src/lib/jobs/cleanup-operations.ts
+++ b/src/lib/jobs/cleanup-operations.ts
@@ -296,12 +296,7 @@ export async function retractClaim(
   const [updated] = await database
     .update(claims)
     .set({ status: "retracted", updatedAt: new Date() })
-    .where(
-      and(
-        eq(claims.id, op.claimId),
-        eq(claims.userId, userId),
-      ),
-    )
+    .where(and(eq(claims.id, op.claimId), eq(claims.userId, userId)))
     .returning();
 
   if (!updated) return null;

--- a/src/lib/jobs/cleanup-operations.ts
+++ b/src/lib/jobs/cleanup-operations.ts
@@ -26,6 +26,10 @@ import {
 import { createAlias, deleteAliasByText } from "~/lib/alias";
 import { createClaim, type ClaimSelect } from "~/lib/claim";
 import { applyClaimLifecycle } from "~/lib/claims/lifecycle";
+import {
+  isInvalidRelationshipPredicateClaimShape,
+  relationshipPredicateFrom,
+} from "~/lib/claims/predicate-shapes";
 import type { GraphNode } from "~/lib/jobs/cleanup-graph";
 import { normalizeLabel } from "~/lib/label";
 import { logEvent } from "~/lib/observability/log";
@@ -226,6 +230,35 @@ export class DeleteNodeNotAllowedError extends Error {
   }
 }
 
+async function isShapeInvalidRelationshipClaim(
+  database: DbOrTx,
+  userId: string,
+  claim: ClaimSelect,
+): Promise<boolean> {
+  const predicate = relationshipPredicateFrom(claim.predicate);
+  if (predicate === null) return false;
+  if (claim.objectNodeId === null) return true;
+
+  const rows = await database
+    .select({ id: nodes.id, nodeType: nodes.nodeType })
+    .from(nodes)
+    .where(
+      and(
+        eq(nodes.userId, userId),
+        inArray(nodes.id, [claim.subjectNodeId, claim.objectNodeId]),
+      ),
+    );
+  const subject = rows.find((row) => row.id === claim.subjectNodeId);
+  const object = rows.find((row) => row.id === claim.objectNodeId);
+  if (!subject || !object) return false;
+
+  return isInvalidRelationshipPredicateClaimShape({
+    predicate,
+    subjectType: subject.nodeType,
+    objectType: object.nodeType,
+  });
+}
+
 // =============================================================================
 // Per-op helpers
 // =============================================================================
@@ -251,7 +284,12 @@ export async function retractClaim(
     .limit(1);
 
   if (!claim) return null;
-  if (!RETRACTABLE_KINDS.has(claim.assertedByKind)) {
+  const shapeInvalid = await isShapeInvalidRelationshipClaim(
+    database,
+    userId,
+    claim,
+  );
+  if (!RETRACTABLE_KINDS.has(claim.assertedByKind) && !shapeInvalid) {
     throw new RetractionNotAllowedError(claim);
   }
 
@@ -262,7 +300,6 @@ export async function retractClaim(
       and(
         eq(claims.id, op.claimId),
         eq(claims.userId, userId),
-        eq(claims.assertedByKind, "assistant_inferred"),
       ),
     )
     .returning();

--- a/src/lib/jobs/ingest-transcript.test.ts
+++ b/src/lib/jobs/ingest-transcript.test.ts
@@ -265,7 +265,7 @@ describeIfServer("ingestTranscript", () => {
     }));
     // `ensureDayNode` (called from `ensureSourceNode`) embeds the day label
     // via Jina in production. Replace it with a minimal real-DB stub: insert
-    // a Temporal node and return its id. The OCCURRED_ON claim that
+    // a Temporal node and return its id. The RECORDED_ON claim that
     // `ensureSourceNode` writes then satisfies its FK to nodes(id).
     vi.doMock("../temporal", () => ({
       ensureDayNode: async (
@@ -599,6 +599,7 @@ describeIfServer("ingestTranscript", () => {
           userId,
           [
             "Person",
+            "Organization",
             "Location",
             "Event",
             "Object",
@@ -819,7 +820,7 @@ describeIfServer("ingestTranscript", () => {
                         {
                           subjectId: selfNodeIdForStub,
                           objectId: "loc_1",
-                          predicate: "LIVES_IN",
+                          predicate: "LOCATED_IN",
                           statement: "Marcel lives in Lisbon.",
                           sourceRef: `${transcriptId}:0`,
                           assertionKind: "user",
@@ -876,17 +877,17 @@ describeIfServer("ingestTranscript", () => {
         userSelfAliasesOverride: ["Marcel", "Marcel Samyn"],
       });
 
-      const livesIn = await client.query<{
+      const locatedIn = await client.query<{
         subject_node_id: string;
         asserted_by_kind: string;
       }>(
-        `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LIVES_IN'`,
+        `SELECT subject_node_id, asserted_by_kind FROM claims WHERE user_id = $1 AND predicate = 'LOCATED_IN'`,
         [userId],
       );
-      expect(livesIn.rows).toHaveLength(1);
-      expect(livesIn.rows[0]?.subject_node_id).toBe(selfNodeId);
-      expect(livesIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
-      expect(livesIn.rows[0]?.asserted_by_kind).toBe("user");
+      expect(locatedIn.rows).toHaveLength(1);
+      expect(locatedIn.rows[0]?.subject_node_id).toBe(selfNodeId);
+      expect(locatedIn.rows[0]?.subject_node_id).not.toBe(otherMarcelId);
+      expect(locatedIn.rows[0]?.asserted_by_kind).toBe("user");
     } finally {
       unmockCommon();
       await client.end();

--- a/src/lib/jobs/prune-orphan-nodes.ts
+++ b/src/lib/jobs/prune-orphan-nodes.ts
@@ -43,6 +43,7 @@ import { useDatabase } from "~/utils/db";
 
 const DEFAULT_PRUNABLE_NODE_TYPES = [
   "Person",
+  "Organization",
   "Location",
   "Event",
   "Object",

--- a/src/lib/jobs/prune-stale-nodes.ts
+++ b/src/lib/jobs/prune-stale-nodes.ts
@@ -41,6 +41,7 @@ import { useDatabase } from "~/utils/db";
 
 const DEFAULT_PRUNABLE_NODE_TYPES = [
   "Person",
+  "Organization",
   "Location",
   "Event",
   "Object",

--- a/src/lib/jobs/run-iterative-cleanup.ts
+++ b/src/lib/jobs/run-iterative-cleanup.ts
@@ -4,7 +4,9 @@ import type {
   CleanupGraphIterationParams,
   CleanupGraphResult,
 } from "./cleanup-graph";
-import { TypeId } from "~/types/typeid";
+import { auditInvalidRelationshipPredicateShapes } from "~/lib/claims/predicate-shape-audit";
+import type { TypeId } from "~/types/typeid";
+import { useDatabase } from "~/utils/db";
 
 /**
  * Params for iterative cleanup across multiple seed batches
@@ -58,11 +60,19 @@ export async function runIterativeCleanup(
     dynamicFollowups = true,
   } = params;
 
-  let seedPool = await fetchEntryNodes(
-    userId,
-    since,
-    seedsPerIteration * iterations,
-  );
+  const seedCount = seedsPerIteration * iterations;
+  const db = await useDatabase();
+  const [entrySeeds, invalidShapeAudit] = await Promise.all([
+    fetchEntryNodes(userId, since, seedCount),
+    auditInvalidRelationshipPredicateShapes(db, userId, { exampleLimit: 0 }),
+  ]);
+  const invalidShapeSeeds = invalidShapeAudit.seedNodeIds.slice(0, seedCount);
+  let seedPool = Array.from(new Set([...invalidShapeSeeds, ...entrySeeds]));
+  if (invalidShapeAudit.totalInvalid > 0) {
+    console.info(
+      `[cleanup-iter] Prioritizing ${invalidShapeSeeds.length} seed nodes from ${invalidShapeAudit.totalInvalid} invalid relationship-shape claims`,
+    );
+  }
   const processed = new Set<TypeId<"node">>();
   let successCount = 0;
   let attempt = 0;

--- a/src/lib/node.test.ts
+++ b/src/lib/node.test.ts
@@ -220,7 +220,7 @@ describeIfServer("node operations", () => {
             "predicate", "statement", "source_id", "asserted_by_kind", "stated_at", "status"
           )
           VALUES
-            ($1, $6, $3, $4, 'OWNED_BY', 'Alice owns a MacBook Pro.', $5, 'user', now(), 'active'),
+            ($1, $6, $3, $4, 'OWNS', 'Alice owns a MacBook Pro.', $5, 'user', now(), 'active'),
             ($2, $6, $3, $4, 'TAGGED_WITH', 'Alice was tagged with a MacBook Pro.', $5, 'user', now(), 'retracted')
         `,
         [
@@ -246,7 +246,7 @@ describeIfServer("node operations", () => {
       expect(nodeResult?.claims).toHaveLength(1);
       expect(nodeResult?.claims[0]).toMatchObject({
         id: activeClaimId,
-        predicate: "OWNED_BY",
+        predicate: "OWNS",
         statement: "Alice owns a MacBook Pro.",
       });
 
@@ -366,6 +366,78 @@ describeIfServer("node operations", () => {
         "created_at" timestamp with time zone DEFAULT now() NOT NULL,
         CONSTRAINT "node_redirects_user_id_from_node_id_pk"
           PRIMARY KEY ("user_id","from_node_id")
+      );
+    `);
+  }
+
+  async function ensureCreateNodeTables(client: Client): Promise<void> {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "users" ("id" text PRIMARY KEY NOT NULL);
+      CREATE TABLE IF NOT EXISTS "nodes" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "node_type" varchar(50) NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS "node_metadata" (
+        "id" text PRIMARY KEY NOT NULL,
+        "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "label" text,
+        "canonical_label" text,
+        "description" text,
+        "additional_data" jsonb,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "node_metadata_node_id_unique" UNIQUE ("node_id")
+      );
+      CREATE TABLE IF NOT EXISTS "sources" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "type" varchar(50) NOT NULL,
+        "external_id" text NOT NULL,
+        "parent_source" text,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "metadata" jsonb,
+        "last_ingested_at" timestamp with time zone,
+        "status" varchar(20) DEFAULT 'completed',
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "deleted_at" timestamp with time zone,
+        "content_type" varchar(100),
+        "content_length" integer,
+        CONSTRAINT "sources_user_type_external_unique" UNIQUE ("user_id", "type", "external_id")
+      );
+      CREATE TABLE IF NOT EXISTS "source_links" (
+        "id" text PRIMARY KEY NOT NULL,
+        "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+        "node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "specific_location" text,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "source_links_source_id_node_id_unique" UNIQUE ("source_id", "node_id")
+      );
+      CREATE TABLE IF NOT EXISTS "claims" (
+        "id" text PRIMARY KEY NOT NULL,
+        "user_id" text NOT NULL REFERENCES "users"("id"),
+        "subject_node_id" text NOT NULL REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "object_node_id" text REFERENCES "nodes"("id") ON DELETE CASCADE,
+        "object_value" text,
+        "predicate" varchar(80) NOT NULL,
+        "statement" text NOT NULL,
+        "description" text,
+        "metadata" jsonb,
+        "object_instant" timestamp with time zone,
+        "source_id" text NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+        "scope" varchar(16) DEFAULT 'personal' NOT NULL,
+        "asserted_by_kind" varchar(24) NOT NULL,
+        "asserted_by_node_id" text REFERENCES "nodes"("id") ON DELETE SET NULL,
+        "superseded_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+        "contradicted_by_claim_id" text REFERENCES "claims"("id") ON DELETE SET NULL,
+        "stated_at" timestamp with time zone NOT NULL,
+        "valid_from" timestamp with time zone,
+        "valid_to" timestamp with time zone,
+        "status" varchar(30) DEFAULT 'active' NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+        CONSTRAINT "claims_object_shape_xor_ck"
+          CHECK (num_nonnulls("object_node_id", "object_value") = 1)
       );
     `);
   }
@@ -677,7 +749,7 @@ describeIfServer("node operations", () => {
         [sourceId, userId],
       );
       // Three claims:
-      //  1. target as OBJECT (OWNED_BY) — must cascade-delete.
+      //  1. target as OBJECT (OWNS) — must cascade-delete.
       //  2. target as SUBJECT (HAS_PREFERENCE attribute) — must cascade-delete.
       //  3. target as ASSERTED_BY (participant) on a claim about a DIFFERENT
       //     subject/object — must SURVIVE with asserted_by_node_id NULL.
@@ -687,7 +759,7 @@ describeIfServer("node operations", () => {
            "predicate", "statement", "source_id", "scope", "asserted_by_kind",
            "asserted_by_node_id", "stated_at", "status"
          ) VALUES
-           ($1, $9, $4, $5, NULL, 'OWNED_BY', 'Task owned by Midday Marcel.',
+           ($1, $9, $4, $5, NULL, 'OWNS', 'Task owned by Midday Marcel.',
             $8, 'personal', 'user', NULL, now(), 'active'),
            ($2, $9, $5, NULL, 'tighter spec', 'HAS_PREFERENCE',
             'Midday Marcel prefers a tighter spec.', $8, 'personal', 'user',
@@ -819,7 +891,7 @@ describeIfServer("node operations", () => {
     }
   });
 
-  it("attaches a manually-created node to today's day node via OCCURRED_ON", async () => {
+  it("attaches a manually-created node to today's day node via RECORDED_ON", async () => {
     // Regression for the linkage gap: `/node/create` previously did not link
     // the new node to a Temporal day node, so `/query/node-type` (which
     // traverses one hop from the day node) returned empty for nodes created
@@ -839,9 +911,10 @@ describeIfServer("node operations", () => {
         data: [{ embedding: Array.from({ length: 1024 }, () => 0) }],
         usage: { total_tokens: 0 },
       }),
-    }));
+      }));
 
     try {
+      await ensureCreateNodeTables(client);
       await ensureMergeTables(client);
       // The inline `sources` table created by the first test in this file is
       // missing optional columns referenced by Drizzle's insert. Add them so
@@ -865,7 +938,7 @@ describeIfServer("node operations", () => {
         "A person created via /node/create",
       );
 
-      // OCCURRED_ON claim links the new node to a Temporal day node.
+      // RECORDED_ON claim links the new node to a Temporal day node.
       const claimRows = await client.query<{
         subject_node_id: string;
         object_node_id: string | null;
@@ -874,7 +947,7 @@ describeIfServer("node operations", () => {
       }>(
         `SELECT "subject_node_id", "object_node_id", "predicate", "asserted_by_kind"
          FROM "claims"
-         WHERE "user_id" = $1 AND "subject_node_id" = $2 AND "predicate" = 'OCCURRED_ON'`,
+         WHERE "user_id" = $1 AND "subject_node_id" = $2 AND "predicate" = 'RECORDED_ON'`,
         [userId, created.id],
       );
       expect(claimRows.rows).toHaveLength(1);
@@ -903,7 +976,7 @@ describeIfServer("node operations", () => {
         `SELECT s."type"
          FROM "claims" c
          INNER JOIN "sources" s ON s."id" = c."source_id"
-         WHERE c."subject_node_id" = $1 AND c."predicate" = 'OCCURRED_ON'`,
+         WHERE c."subject_node_id" = $1 AND c."predicate" = 'RECORDED_ON'`,
         [created.id],
       );
       expect(sourceRows.rows[0]?.type).toBe("manual");
@@ -1120,7 +1193,7 @@ describeIfServer("node operations", () => {
            "id", "user_id", "subject_node_id", "object_node_id", "object_value",
            "predicate", "statement", "source_id", "asserted_by_kind", "stated_at", "status"
          ) VALUES
-           ($1, $6, $4, $5, NULL, 'OWNED_BY', 'Alice owns a MacBook Pro.', $7, 'user', now(), 'active'),
+           ($1, $6, $4, $5, NULL, 'OWNS', 'Alice owns a MacBook Pro.', $7, 'user', now(), 'active'),
            ($2, $6, $4, NULL, 'tea', 'HAS_PREFERENCE', 'Alice prefers tea.', $7, 'user', now(), 'active'),
            ($3, $6, $4, $5, NULL, 'TAGGED_WITH', 'Alice was tagged with a MacBook Pro.', $7, 'user', now(), 'retracted')`,
         [

--- a/src/lib/node.test.ts
+++ b/src/lib/node.test.ts
@@ -911,7 +911,7 @@ describeIfServer("node operations", () => {
         data: [{ embedding: Array.from({ length: 1024 }, () => 0) }],
         usage: { total_tokens: 0 },
       }),
-      }));
+    }));
 
     try {
       await ensureCreateNodeTables(client);

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -539,14 +539,14 @@ export interface CreateNodeInitialClaimInput {
 
 /**
  * Create a new node with metadata and embedding, and attach it to the
- * Temporal day node for "today" via an `OCCURRED_ON` claim sourced from the
+ * Temporal day node for "today" via a `RECORDED_ON` claim sourced from the
  * per-user manual system source. Day-node attachment preserves the
  * temporal-graph invariant that ingestion paths uphold (see
  * `ensureSourceNode`), so date-scoped queries like `nodeType` can find
  * manually-created nodes the same way they find ingested ones.
  *
  * `initialClaims` lets callers bootstrap the node with required claims
- * (e.g. a `Task` with its `HAS_TASK_STATUS` and `OWNED_BY`) so it is never
+ * (e.g. a `Task` with its `HAS_TASK_STATUS` and `ASSIGNED_TO`) so it is never
  * observable in a half-bootstrapped state. Claims are written sequentially
  * after the node is created; if any one fails, the node is deleted and the
  * original error is re-thrown.
@@ -594,17 +594,17 @@ export async function createNode(
     .values({ sourceId, nodeId: inserted.id })
     .onConflictDoNothing();
 
-  // Link to today's day node via OCCURRED_ON, mirroring `ensureSourceNode`.
+  // Link to today's day node via RECORDED_ON, mirroring `ensureSourceNode`.
   // Skip for Temporal nodes themselves to avoid a self-link / cycle.
   if (nodeType !== "Temporal") {
     const now = new Date();
     const dayNodeId = await ensureDayNode(db, userId, now);
     await db.insert(claims).values({
       userId,
-      predicate: "OCCURRED_ON",
+      predicate: "RECORDED_ON",
       subjectNodeId: inserted.id,
       objectNodeId: dayNodeId,
-      statement: `${nodeType} node occurred on ${format(now, "yyyy-MM-dd")}`,
+      statement: `${nodeType} node recorded on ${format(now, "yyyy-MM-dd")}`,
       sourceId,
       scope: "personal",
       assertedByKind: "system",

--- a/src/lib/query/commitment-detail.test.ts
+++ b/src/lib/query/commitment-detail.test.ts
@@ -78,8 +78,8 @@ describeIfServer("getCommitment detail query", () => {
     const claimPendingId = newTypeId("claim"); // superseded
     const claimInProgressId = newTypeId("claim"); // superseded
     const claimDoneId = newTypeId("claim"); // active HAS_TASK_STATUS
-    const claimOwnerAliceId = newTypeId("claim"); // superseded OWNED_BY
-    const claimOwnerBobId = newTypeId("claim"); // active OWNED_BY
+    const claimOwnerAliceId = newTypeId("claim"); // superseded ASSIGNED_TO
+    const claimOwnerBobId = newTypeId("claim"); // active ASSIGNED_TO
     const claimDueOrigId = newTypeId("claim"); // superseded DUE_ON
     const claimDueNewId = newTypeId("claim"); // active DUE_ON
 
@@ -227,8 +227,8 @@ describeIfServer("getCommitment detail query", () => {
       await client.query(
         `INSERT INTO "claims" ("id","user_id","subject_node_id","object_node_id","predicate","statement","source_id","scope","asserted_by_kind","stated_at","status")
          VALUES
-           ($1,$3,$4,$5,'OWNED_BY','Task owned by Alice.',$7,'personal','user','2026-02-01T10:01:00Z','superseded'),
-           ($2,$3,$4,$6,'OWNED_BY','Task owned by Bob.',  $7,'personal','user','2026-02-15T10:01:00Z','active')`,
+           ($1,$3,$4,$5,'ASSIGNED_TO','Task owned by Alice.',$7,'personal','user','2026-02-01T10:01:00Z','superseded'),
+           ($2,$3,$4,$6,'ASSIGNED_TO','Task owned by Bob.',  $7,'personal','user','2026-02-15T10:01:00Z','active')`,
         [
           claimOwnerAliceId,
           claimOwnerBobId,

--- a/src/lib/query/commitment-detail.ts
+++ b/src/lib/query/commitment-detail.ts
@@ -19,7 +19,7 @@ import { useDatabase } from "~/utils/db";
 /** The three predicates that carry a Task's lifecycle. */
 const TASK_PREDICATES: readonly Predicate[] = [
   "HAS_TASK_STATUS",
-  "OWNED_BY",
+  "ASSIGNED_TO",
   "DUE_ON",
 ];
 
@@ -29,7 +29,7 @@ function isTaskLifecyclePredicate(
 ): predicate is TaskLifecycleEntry["predicate"] {
   return (
     predicate === "HAS_TASK_STATUS" ||
-    predicate === "OWNED_BY" ||
+    predicate === "ASSIGNED_TO" ||
     predicate === "DUE_ON"
   );
 }
@@ -80,7 +80,7 @@ export async function getCommitment(
     (claim) => claim.predicate === "HAS_TASK_STATUS" && isActive(claim.status),
   );
   const activeOwner = taskClaims.find(
-    (claim) => claim.predicate === "OWNED_BY" && isActive(claim.status),
+    (claim) => claim.predicate === "ASSIGNED_TO" && isActive(claim.status),
   );
   const activeDue = taskClaims.find(
     (claim) => claim.predicate === "DUE_ON" && isActive(claim.status),

--- a/src/lib/query/commitments-list.test.ts
+++ b/src/lib/query/commitments-list.test.ts
@@ -338,7 +338,7 @@ describeIfServer("listCommitments query", () => {
         );
       }
 
-      // OWNED_BY claims: Alice owns pending+inProgress, Bob owns done
+      // ASSIGNED_TO claims: Alice owns pending+inProgress, Bob owns done
       const ownerClaims = [
         [
           taskPendingId,
@@ -358,7 +358,7 @@ describeIfServer("listCommitments query", () => {
       for (const [taskId, ownerNodeId, stmt, statedAt] of ownerClaims) {
         await client.query(
           `INSERT INTO "claims" ("id", "user_id", "subject_node_id", "object_node_id", "predicate", "statement", "source_id", "scope", "asserted_by_kind", "stated_at", "status")
-           VALUES ($1, $2, $3, $4, 'OWNED_BY', $5, $6, 'personal', 'user', $7, 'active')`,
+           VALUES ($1, $2, $3, $4, 'ASSIGNED_TO', $5, $6, 'personal', 'user', $7, 'active')`,
           [
             newTypeId("claim"),
             userId,

--- a/src/lib/query/commitments-list.ts
+++ b/src/lib/query/commitments-list.ts
@@ -104,7 +104,7 @@ function statusProvenanceFilter(
 }
 
 /**
- * Provenance predicate for the OWNED_BY / DUE_ON sub-joins. The trusted band
+ * Provenance predicate for the ASSIGNED_TO / DUE_ON sub-joins. The trusted band
  * shows only trusted metadata; candidate/all apply no constraint so a trusted
  * owner/due on a not-yet-confirmed candidate still surfaces.
  */
@@ -273,7 +273,7 @@ export async function listCommitments(
       and(
         eq(ownerClaim.userId, userId),
         eq(ownerClaim.subjectNodeId, nodes.id),
-        eq(ownerClaim.predicate, "OWNED_BY"),
+        eq(ownerClaim.predicate, "ASSIGNED_TO"),
         eq(ownerClaim.status, "active"),
         eq(ownerClaim.scope, "personal"),
         subJoinProvenanceFilter(ownerClaim.assertedByKind, provenance),

--- a/src/lib/query/open-commitments.test.ts
+++ b/src/lib/query/open-commitments.test.ts
@@ -284,9 +284,9 @@ describeIfServer("open commitments query", () => {
             ($4, $25, $18, NULL, 'done', 'HAS_TASK_STATUS', 'Done task is complete.', $23, 'personal', 'user', '2026-04-04T10:00:00Z', 'active'),
             ($5, $25, $19, NULL, 'pending', 'HAS_TASK_STATUS', 'Reference task is pending.', $24, 'reference', 'document_author', '2026-04-05T10:00:00Z', 'active'),
             ($6, $25, $20, NULL, 'pending', 'HAS_TASK_STATUS', 'Inferred task is pending.', $23, 'personal', 'assistant_inferred', '2026-04-06T10:00:00Z', 'active'),
-            ($7, $25, $15, $13, NULL, 'OWNED_BY', 'Marcel owns Send spec.', $23, 'personal', 'user', '2026-04-01T10:01:00Z', 'active'),
-            ($8, $25, $16, $13, NULL, 'OWNED_BY', 'Marcel owns Review memo.', $23, 'personal', 'user', '2026-04-02T10:01:00Z', 'active'),
-            ($9, $25, $17, $14, NULL, 'OWNED_BY', 'Jane owns Prepare budget.', $23, 'personal', 'user', '2026-04-03T10:01:00Z', 'active'),
+            ($7, $25, $15, $13, NULL, 'ASSIGNED_TO', 'Marcel owns Send spec.', $23, 'personal', 'user', '2026-04-01T10:01:00Z', 'active'),
+            ($8, $25, $16, $13, NULL, 'ASSIGNED_TO', 'Marcel owns Review memo.', $23, 'personal', 'user', '2026-04-02T10:01:00Z', 'active'),
+            ($9, $25, $17, $14, NULL, 'ASSIGNED_TO', 'Jane owns Prepare budget.', $23, 'personal', 'user', '2026-04-03T10:01:00Z', 'active'),
             ($10, $25, $15, $21, NULL, 'DUE_ON', 'Send spec is due on 2026-04-27.', $23, 'personal', 'user', '2026-04-01T10:02:00Z', 'active'),
             ($11, $25, $16, $22, NULL, 'DUE_ON', 'Review memo is due on 2026-05-05.', $23, 'personal', 'user', '2026-04-02T10:02:00Z', 'active'),
             ($12, $25, $17, $21, NULL, 'DUE_ON', 'Prepare budget is due on 2026-04-27.', $23, 'personal', 'user', '2026-04-03T10:02:00Z', 'active')

--- a/src/lib/query/open-commitments.ts
+++ b/src/lib/query/open-commitments.ts
@@ -78,7 +78,7 @@ function provenanceFilter(
 }
 
 /**
- * Provenance predicate for the OWNED_BY / DUE_ON metadata sub-joins, which is
+ * Provenance predicate for the ASSIGNED_TO / DUE_ON metadata sub-joins, which is
  * NOT symmetric with the status filter. The trusted view shows only trusted
  * metadata (excludes inferred). The candidate view applies NO provenance
  * constraint, so a *trusted* owner/due set on a not-yet-confirmed candidate
@@ -153,7 +153,7 @@ async function queryCommitments(
       and(
         eq(ownerClaim.userId, userId),
         eq(ownerClaim.subjectNodeId, nodes.id),
-        eq(ownerClaim.predicate, "OWNED_BY"),
+        eq(ownerClaim.predicate, "ASSIGNED_TO"),
         eq(ownerClaim.status, "active"),
         eq(ownerClaim.scope, "personal"),
         subJoinProvenanceFilter(ownerClaim.assertedByKind, provenance),
@@ -195,7 +195,7 @@ async function queryCommitments(
       ),
     )
     // Belt-and-suspenders newest-wins dedupe across (taskId): supersession
-    // for OWNED_BY/DUE_ON on Tasks is now enforced at the lifecycle engine
+    // for ASSIGNED_TO/DUE_ON on Tasks is now enforced at the lifecycle engine
     // via `subjectTypeOverrides` in the predicate registry, so production
     // claims should already be single-active. We keep this dedupe so claims
     // written before the override landed (or any backfill gap) don't leak

--- a/src/lib/schemas/create-commitment.ts
+++ b/src/lib/schemas/create-commitment.ts
@@ -15,7 +15,7 @@ import { isValidTimeZone } from "~/lib/time-zone.js";
  * The server creates the `Task` node and bootstraps it with a `HAS_TASK_STATUS`
  * claim (so it is never observable in a half-bootstrapped, status-less state),
  * plus an optional `DUE_ON` claim — resolving the canonical Temporal node
- * internally — and an optional `OWNED_BY` claim to a referenced entity. A fresh
+ * internally — and an optional `ASSIGNED_TO` claim to a referenced entity. A fresh
  * commitment therefore deserialises identically to one returned by
  * `getOpenCommitments`.
  *
@@ -55,7 +55,7 @@ export const createCommitmentRequestSchema = z
       .nullish(),
     /**
      * Optional owner: the node id of the entity (typically a `Person`) that owns
-     * the commitment. Emits an `OWNED_BY` claim. Must be an existing node owned
+     * the commitment. Emits an `ASSIGNED_TO` claim. Must be an existing node owned
      * by `userId`, otherwise the call fails before any node is written.
      */
     ownedBy: typeIdSchema("node").optional(),
@@ -99,7 +99,7 @@ export const createCommitmentResponseSchema = z.object({
   statusClaimId: typeIdSchema("claim"),
   /** ID of the `DUE_ON` claim, or `null` when no due date was supplied. */
   dueClaimId: typeIdSchema("claim").nullable(),
-  /** ID of the `OWNED_BY` claim, or `null` when no owner was supplied. */
+  /** ID of the `ASSIGNED_TO` claim, or `null` when no owner was supplied. */
   ownerClaimId: typeIdSchema("claim").nullable(),
 });
 

--- a/src/lib/schemas/get-commitment.ts
+++ b/src/lib/schemas/get-commitment.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 /**
  * Detail read model for a single commitment: current state, lifecycle history,
  * and evidence sources. Reuses `getNodeById` for a one-query node + history
- * slice across the three task predicates (`HAS_TASK_STATUS`, `OWNED_BY`,
+ * slice across the three task predicates (`HAS_TASK_STATUS`, `ASSIGNED_TO`,
  * `DUE_ON`), then batch-resolves the distinct source ids.
  */
 export const getCommitmentRequestSchema = z.object({
@@ -24,7 +24,7 @@ export const getCommitmentRequestSchema = z.object({
 
 export const taskLifecycleEntrySchema = z.object({
   claimId: typeIdSchema("claim"),
-  predicate: z.enum(["HAS_TASK_STATUS", "OWNED_BY", "DUE_ON"]),
+  predicate: z.enum(["HAS_TASK_STATUS", "ASSIGNED_TO", "DUE_ON"]),
   /** `objectValue` (status) or `objectLabel` (owner / due) of the claim. */
   value: z.string().nullable(),
   objectNodeId: typeIdSchema("node").nullable(),

--- a/src/lib/schemas/list-commitments.ts
+++ b/src/lib/schemas/list-commitments.ts
@@ -49,7 +49,7 @@ export const listCommitmentsRequestSchema = z
     provenance: commitmentProvenanceEnum.default("trusted"),
     /** Only tasks owned by this node. Mutually exclusive with `unowned`. */
     ownedBy: typeIdSchema("node").optional(),
-    /** Only tasks with no active `OWNED_BY`. Mutually exclusive with `ownedBy`. */
+    /** Only tasks with no active `ASSIGNED_TO`. Mutually exclusive with `ownedBy`. */
     unowned: z.boolean().optional(),
     /** `YYYY-MM-DD`, inclusive upper bound on the due date. */
     dueBefore: z

--- a/src/lib/schemas/set-commitment-owner.ts
+++ b/src/lib/schemas/set-commitment-owner.ts
@@ -8,9 +8,9 @@ import { z } from "zod";
  * A structural twin of `setCommitmentDue`:
  *
  * - `ownedBy: typeIdSchema("node")` → resolve the owner node's label and assert
- *   a new `OWNED_BY` claim. The predicate-policy override for `Task` subjects
- *   supersedes any prior active `OWNED_BY` claim automatically.
- * - `ownedBy: null` → retract every active `OWNED_BY` claim on the task. No new
+ *   a new `ASSIGNED_TO` claim. The predicate policy supersedes any prior
+ *   active `ASSIGNED_TO` claim automatically.
+ * - `ownedBy: null` → retract every active `ASSIGNED_TO` claim on the task. No new
  *   claim is asserted.
  *
  * Verifies the subject is a `Task` owned by the user; cross-user / wrong-type
@@ -28,7 +28,7 @@ export const setCommitmentOwnerRequestSchema = z.object({
    */
   note: z.string().min(1).optional(),
   /**
-   * Provenance for the new `OWNED_BY` claim. Defaults to `"user"`. Has no
+   * Provenance for the new `ASSIGNED_TO` claim. Defaults to `"user"`. Has no
    * effect when `ownedBy` is `null`.
    */
   assertedByKind: AssertedByKindEnum.optional(),
@@ -43,12 +43,12 @@ export const setCommitmentOwnerResponseSchema = z.object({
     })
     .nullable(),
   /**
-   * ID of the newly asserted `OWNED_BY` claim. `null` when `ownedBy` was set
+   * ID of the newly asserted `ASSIGNED_TO` claim. `null` when `ownedBy` was set
    * to `null` (i.e. the operation only retracted prior claims).
    */
   claimId: typeIdSchema("claim").nullable(),
   /**
-   * IDs of any previously active `OWNED_BY` claims that this call retracted.
+   * IDs of any previously active `ASSIGNED_TO` claims that this call retracted.
    * When `ownedBy` is set, the lifecycle engine supersedes the prior claim
    * automatically and this stays empty; the field is only populated on the
    * explicit clear path (`ownedBy: null`).

--- a/src/sdk/memory-client.ts
+++ b/src/sdk/memory-client.ts
@@ -866,7 +866,7 @@ export class MemoryClient {
   /**
    * Open a new commitment as a Task: creates the node and bootstraps it with a
    * `HAS_TASK_STATUS` claim (pending or in_progress), plus an optional `DUE_ON`
-   * (server resolves the Temporal node) and `OWNED_BY` claim. Always creates a
+   * (server resolves the Temporal node) and `ASSIGNED_TO` claim. Always creates a
    * new Task — use `createClaim`/`setCommitmentDue` to advance an existing one.
    *
    * Optional time-of-day precision: pass `dueTime` (`HH:mm`, 24h) together
@@ -939,8 +939,8 @@ export class MemoryClient {
 
   /**
    * Assign, reassign, or clear a Task's owner. Pass a node id to assert a new
-   * `OWNED_BY` claim (superseding any prior active one automatically), or
-   * `ownedBy: null` to retract every active `OWNED_BY` claim without asserting
+   * `ASSIGNED_TO` claim (superseding any prior active one automatically), or
+   * `ownedBy: null` to retract every active `ASSIGNED_TO` claim without asserting
    * a new one. Throws if the owner node id is missing or cross-user.
    */
   async setCommitmentOwner(
@@ -993,7 +993,7 @@ export class MemoryClient {
   /**
    * Detail read model for a single commitment: current status, active owner and
    * due date, evidence source ids, and — when `includeHistory` is true — the
-   * full lifecycle history of `HAS_TASK_STATUS`, `OWNED_BY`, and `DUE_ON` claims
+   * full lifecycle history of `HAS_TASK_STATUS`, `ASSIGNED_TO`, and `DUE_ON` claims
    * sorted newest-first. Suited to detail views and undo flows.
    */
   async getCommitment(

--- a/src/types/graph.test.ts
+++ b/src/types/graph.test.ts
@@ -10,6 +10,7 @@ describe("isLabelMergeableNodeType", () => {
     for (const nodeType of LABEL_MERGEABLE_NODE_TYPES) {
       expect(isLabelMergeableNodeType(nodeType)).toBe(true);
     }
+    expect(isLabelMergeableNodeType("Organization")).toBe(true);
   });
 
   it("protects record/occurrence types from label-based merging", () => {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 export const NodeTypeEnum = z.enum([
   "Person",
+  "Organization",
   "Location",
   "Event",
   "Object",
@@ -33,6 +34,7 @@ export type NodeType = z.infer<typeof NodeTypeEnum>;
  */
 export const ExtractionNodeTypeEnum = z.enum([
   "Person",
+  "Organization",
   "Location",
   "Event",
   "Object",
@@ -65,6 +67,7 @@ export type ExtractionNodeType = z.infer<typeof ExtractionNodeTypeEnum>;
  */
 export const LABEL_MERGEABLE_NODE_TYPES = [
   "Person",
+  "Organization",
   "Location",
   "Object",
   "Emotion",
@@ -150,10 +153,11 @@ export const RelationshipPredicateEnum = z.enum([
   "PARTICIPATED_IN",
   "OCCURRED_AT",
   "OCCURRED_ON",
+  "RECORDED_ON",
   "INVOLVED_ITEM",
   "EXHIBITED_EMOTION",
   "TAGGED_WITH",
-  "OWNED_BY",
+  "ASSIGNED_TO",
   "DUE_ON",
   "PRECEDES",
   "FOLLOWS",
@@ -166,6 +170,7 @@ export const RelationshipPredicateEnum = z.enum([
   "LOCATED_IN",
   "PART_OF",
   "USES",
+  "OWNS",
   "AFFILIATED_WITH",
   // Catch-all — last resort only, when no specific predicate fits.
   "RELATED_TO",


### PR DESCRIPTION
## Summary

Graph extraction and cleanup now have hard relation-shape guardrails instead of relying on the model to infer valid edge direction and endpoint types. Invalid relationships are rejected during extraction, prioritized during iterative cleanup, and auditable through a dedicated predicate-health report.

This also makes organizations first-class graph nodes, replaces passive `OWNED_BY` with canonical `OWNS`/`ASSIGNED_TO`, and moves bookkeeping date facts from overloaded `OCCURRED_ON` edges to `RECORDED_ON`.

## Design Decisions

| Area | Decision |
| --- | --- |
| Predicate taxonomy | Add a central domain/range table for relationship predicates and include it in extraction + cleanup prompts. |
| Ownership direction | Migrate away from `OWNED_BY`; ownership is `owner OWNS owned`, task responsibility is `Task ASSIGNED_TO Person`. |
| Date semantics | Keep `OCCURRED_ON` for real-world occurrence dates and use `RECORDED_ON` for observed/ingested/bookkeeping dates. |
| Organization modeling | Add `Organization` for companies, institutions, named teams, communities, clubs, and informal named groups. |
| Cleanup targeting | Feed invalid relationship-shape nodes into the regular iterative cleanup seed pool before ordinary entry nodes. |

## Real-Data Dry Run

Ran the migrations in a rollback-only transaction against the imported graph:

| Metric | Before | Projected After |
| --- | ---: | ---: |
| Invalid relationship shapes | 470 | 445 |
| Deprecated `OWNED_BY` predicates | 46 | 0 |
| Active `OWNED_BY` claims | 45 | 0 |
| New `OWNS` claims | 0 | 24 |
| New `RECORDED_ON` claims | 0 | 272 |
| `Organization` nodes | 0 | 11 |

The remaining invalid-shape buckets are now regular cleanup targets rather than taxonomy-migration fallout.

## Test Plan

- `pnpm exec vitest run src/db/migrations-claims.test.ts --pool=threads --poolOptions.threads.singleThread=true`
- `pnpm exec vitest run src/evals/memory/run-all.test.ts --pool=threads --poolOptions.threads.singleThread=true`
- `pnpm exec vitest run src/types/graph.test.ts src/lib/claims/predicate-shapes.test.ts src/lib/claims/predicate-shape-repair.test.ts src/lib/structured-output-schemas.test.ts src/lib/context/assemble-bootstrap-context.test.ts --pool=threads --poolOptions.threads.singleThread=true`
- `pnpm run build:check`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
